### PR TITLE
docs: update auth references for Supabase migration

### DIFF
--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -56,7 +56,7 @@ Before making any decision, ground yourself in the current state:
 | Config management | `cli/src/utils/config.ts` | N/A |
 | Firestore hooks | N/A | `code-insights-web/src/lib/hooks/useFirestore.ts` |
 | LLM providers | N/A | `code-insights-web/src/lib/llm/` |
-| Auth config | N/A | `code-insights-web/src/lib/auth.ts` |
+| Auth config | N/A | `code-insights-web/src/lib/supabase/` |
 | UI components | N/A | `code-insights-web/src/components/` |
 | Architecture docs | `CLAUDE.md`, `docs/` | `code-insights-web/CLAUDE.md` |
 
@@ -481,7 +481,7 @@ These technology choices are LOCKED. Do not introduce alternatives without an AD
 | Database | Firestore (user-owned) | Supabase, PlanetScale, custom backend |
 | Web Framework | Next.js 16 (App Router) | Remix, SvelteKit, Astro |
 | UI Library | shadcn/ui + Tailwind | Material UI, Chakra, Ant Design |
-| Auth | NextAuth v5 + Prisma | Clerk, Auth0, Firebase Auth |
+| Auth | Supabase Auth (@supabase/ssr) | Clerk, Auth0, NextAuth, Firebase Auth |
 | Package Manager | pnpm | npm, yarn, bun |
 | Language | TypeScript (strict mode) | JavaScript, Go, Rust |
 | Icons | Lucide React | Heroicons, FontAwesome, custom SVGs |
@@ -526,5 +526,5 @@ When a locked technology needs upgrading (e.g., Next.js 16 to 17):
 - pnpm is the package manager for both repos
 - ES Modules everywhere — no CommonJS `require()`
 - Firestore is the ONLY shared data store between CLI and web
-- Postgres (via Prisma) is for auth ONLY — no user data
+- Supabase is for auth ONLY — no user data stored there
 - All agent files live in `.claude/agents/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,7 @@ codeInsights/
 │   └── .claude/agents/     # Agent definitions (TA, fullstack-engineer, ux-designer, PM, chronicler)
 │
 └── code-insights-web/      # SEPARATE REPO — Closed-source web dashboard
-    ├── src/                # Next.js 16 app
-    ├── prisma/             # Auth schema (Vercel Postgres)
-    └── generated/          # Prisma client output
+    └── src/                # Next.js 16 app (Supabase Auth, Firebase data)
 ```
 
 ## Commands


### PR DESCRIPTION
## What
Update CLAUDE.md, fullstack-engineer agent, and technical-architect agent to reflect the auth migration from NextAuth/Prisma to Supabase Auth in the web dashboard.

## Why
The web repo migrated from NextAuth v5 + Prisma to Supabase Auth. These doc/agent references need to stay current so agents have accurate context when working on auth-related code.

## How
- **CLAUDE.md**: Updated repo structure (removed prisma/generated dirs)
- **fullstack-engineer.md**: Updated tech stack, context sources, auth patterns, env vars, pushback examples
- **technical-architect.md**: Updated context sources, technology guardrails (Auth locked choice), constraints

## Cross-Repo Impact
- [x] Types changed: No
- [x] Firestore schema changed: No
- [x] Backward compatible: Yes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)