### PR TITLE
docs: clean up stale NextAuth/Prisma references

### DIFF
--- a/.claude/agents/fullstack-engineer.md
+++ b/.claude/agents/fullstack-engineer.md
@@ -146,7 +146,6 @@ git checkout -b feature/description
 2. Type definitions (if changed)
 3. Core implementation (library/hook changes)
 4. Command wiring (CLI) or page implementations (web)
-5. Prisma migrations (if any)
 
 **CI Simulation Gate (BEFORE PR):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Your Firestore security rules are blocking reads. Update them in Firebase Consol
 
 - **CLI**: Node.js, TypeScript, Commander.js, Firebase Admin SDK
 - **Web**: Next.js 16, React 19, Tailwind CSS 4, shadcn/ui
-- **Auth**: NextAuth.js (Google, GitHub)
-- **Database**: Vercel Postgres (auth only), Firebase Firestore (your data)
+- **Auth**: Supabase Auth (Google, GitHub OAuth)
+- **Database**: Firebase Firestore (your data) — auth handled by Supabase
 - **Analytics**: Vercel Analytics
 - **LLM**: OpenAI, Anthropic, Gemini, Ollama
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -67,10 +67,10 @@ Code Insights stores all user session data in the user's own Firebase Firestore.
 ## Tech Stack
 
 - **CLI**: Node.js CLI (runs standalone or as Claude Code hook)
-- **Database**: User's Firebase Firestore (session data), Vercel Postgres (auth only)
+- **Database**: User's Firebase Firestore (session data) — auth handled by Supabase
 - **AI**: Multi-provider — OpenAI, Anthropic, Gemini, Ollama (user's own API keys)
 - **Web**: Next.js 16 + Tailwind CSS 4 + shadcn/ui
-- **Auth**: NextAuth.js (Google, GitHub)
+- **Auth**: Supabase Auth (Google, GitHub OAuth)
 - **Hosting**: Vercel (dashboard), user's Firebase (data)
 
 ## Success Metrics

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -10,7 +10,7 @@ Code Insights is a tool that helps Claude Code users understand their AI-assiste
 
 ### 1. Privacy by Architecture
 
-There is no central Code Insights data server. Users connect the CLI tool to their own Firebase project. Session data never leaves their control. The hosted dashboard only reads from the user's Firestore — it stores authentication credentials in Vercel Postgres and collects anonymous aggregate analytics via Vercel Analytics, but never touches your Claude Code data.
+There is no central Code Insights data server. Users connect the CLI tool to their own Firebase project. Session data never leaves their control. The hosted dashboard only reads from the user's Firestore — authentication is handled by Supabase Auth, and the dashboard collects anonymous aggregate analytics via Vercel Analytics, but never touches your Claude Code data.
 
 ### 2. Developers Can Handle It
 

--- a/docs/plans/2026-02-14-agents-hooks-analysis-features-design.md
+++ b/docs/plans/2026-02-14-agents-hooks-analysis-features-design.md
@@ -84,7 +84,7 @@
   - Next.js 16 App Router, React 19, Tailwind CSS 4, shadcn/ui
   - Firebase client SDK (Firestore real-time subscriptions)
   - Multi-provider LLM integration (OpenAI, Anthropic, Gemini, Ollama)
-  - Auth: NextAuth v5 with Prisma adapter
+  - Auth: Supabase Auth (@supabase/ssr)
   - Charts: Recharts 3
   - Keep: code-first design workflow, component patterns
   - Ceremony steps 3, 4, 6, 7, 8 (same as fullstack-engineer)


### PR DESCRIPTION
## What
Remove remaining NextAuth/Prisma/Vercel Postgres references from README, docs, and agent definitions.

## Why
The web dashboard migrated to Supabase Auth (PR #5 updated CLAUDE.md + agents, but missed README.md, docs/VISION.md, docs/PRODUCT.md, design plan doc, and a stale line in fullstack-engineer.md).

## How
- **README.md**: Updated tech stack lines (Auth + Database)
- **docs/VISION.md**: Replaced "Vercel Postgres" auth reference
- **docs/PRODUCT.md**: Updated auth and database lines
- **fullstack-engineer.md**: Removed "Prisma migrations" from commit strategy
- **design plan doc**: Updated auth line to reflect current stack

## Cross-Repo Impact
- [x] Types changed: No
- [x] Firestore schema changed: No
- [x] Backward compatible: Yes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)