### PR TITLE
docs: add Ollama CORS troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,31 @@ Your Firestore security rules are blocking reads. Update them in Firebase Consol
 - Subsequent syncs are incremental and much faster
 - Use `code-insights sync --dry-run` to preview how many sessions will be synced
 
+### Ollama CORS errors on the dashboard
+
+If you're using Ollama as your LLM provider on the dashboard and seeing CORS errors, the macOS Ollama app doesn't read shell environment variables (`.zshrc`/`.bashrc`). Try one of these:
+
+**Option 1 — Run from terminal** (most reliable):
+Quit the Ollama menu bar app first, then:
+```bash
+OLLAMA_ORIGINS="https://code-insights.app" ollama serve
+```
+Keep the terminal open while using the dashboard.
+
+**Option 2 — launchctl** (persistent for macOS app):
+```bash
+launchctl setenv OLLAMA_ORIGINS "https://code-insights.app"
+```
+Then fully quit Ollama (menu bar icon → Quit Ollama) and reopen it.
+
+**Option 3 — Shell profile** (only works with `ollama serve`):
+```bash
+echo 'export OLLAMA_ORIGINS="https://code-insights.app"' >> ~/.zshrc
+source ~/.zshrc
+ollama serve
+```
+Note: This does NOT work with the macOS Ollama desktop app — only when running `ollama serve` from the terminal.
+
 ## Tech Stack
 
 - **CLI**: Node.js, TypeScript, Commander.js, Firebase Admin SDK


### PR DESCRIPTION
## Summary
- Adds a new troubleshooting entry explaining why the macOS Ollama desktop app doesn't pick up `OLLAMA_ORIGINS` from shell environment variables (`.zshrc`/`.bashrc`)
- Documents three workarounds: inline env var with `ollama serve`, `launchctl setenv` for persistent macOS app usage, and shell profile (terminal-only)
- Placed after existing troubleshooting entries, before the Tech Stack section

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the three options are accurate for macOS Ollama CORS configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)