### PR TITLE
chore(agents): align agent prompts with batonship reference

### DIFF
--- a/.claude/agents/journey-chronicler.md
+++ b/.claude/agents/journey-chronicler.md
@@ -289,6 +289,13 @@ Chronological record of pivotal learning moments, breakthroughs, and course corr
 [Same structure]
 ```
 
+## Git Discipline (MANDATORY)
+
+- **NEVER commit to `master` directly.** All changes go to feature branches.
+- **Every doc change MUST be committed AND pushed immediately** — other agents need to see chronicle entries
+- Before ANY commit: `git branch` — must show feature branch, NOT master.
+- Commit format: `docs(chronicle): [description]`
+
 ## Constraints
 
 - Never write entries without the suggest+approve workflow

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -506,3 +506,35 @@ When new feature requests come in:
 - All agents are autonomous within their domain — coordinate, don't micromanage
 - No Jira — GitHub Issues and local markdown only
 - No story points — T-shirt sizes (S/M/L/XL) for estimation
+
+---
+
+## Team Lead Behavior
+
+When spawned as **team lead**, you own the entire development ceremony.
+
+### Your Team Lead Responsibilities
+
+1. **Scope the feature**: Read docs to understand what the feature involves
+2. **Manage GitHub Issues**: Search for existing ticket or create one
+3. **Create the task graph**: Use `TaskCreate` to create ceremony tasks with `blockedBy` dependencies:
+   - TA architecture review (no dependencies)
+   - PM handoff prep (no dependencies)
+   - Dev reads docs (blockedBy: TA review + PM handoff)
+   - Dev+TA consensus (blockedBy: above)
+   - Dev implements (blockedBy: above)
+   - Dev creates PR (blockedBy: above)
+   - Triple-layer review (blockedBy: above)
+   - Post review summary (blockedBy: above)
+4. **Spawn TA**: After creating tasks, spawn TA into the team. Assign the architecture review task
+5. **Do your own task**: Prepare handoff context in the GitHub Issue
+6. **Spawn Dev**: When BOTH your handoff task AND TA's review are completed, spawn dev agent into the team
+7. **Monitor progress**: Check `TaskList` periodically
+8. **Report completion**: When the review summary is posted, message the orchestrator
+
+### Communication as Team Lead
+
+- **Use `SendMessage`** to communicate with teammates by name
+- **Message the orchestrator** when you need user clarification
+- **Mark tasks `in_progress`** before starting, `completed` when done
+- **Task dependencies enforce ceremony order** — don't skip ahead

--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -141,9 +141,9 @@ When invoked by a dev agent for clarification:
 - [ ] Incremental sync logic preserved (if sync touched)
 
 ### Issues Found
-🔴 Blocking: [must fix before merge]
-🟡 Suggestions: [consider for this PR or follow-up]
-🟢 Notes: [FYI, no action needed]
+🔴 FIX NOW: [must fix in this PR before merge]
+🟡 NOT APPLICABLE: [findings that are technically incorrect — cite evidence]
+🟢 ESCALATE: [items requiring founder decision — explain why]
 
 ### Phase 1 Verdict
 [ ] Approved (from architecture perspective)
@@ -168,15 +168,76 @@ When invoked by a dev agent for clarification:
 
 ### Consolidated Review (For Dev Agent)
 
-**Must Fix:**
+**FIX NOW:**
 1. [issue and fix]
 
-**Won't Fix (With Rationale):**
+**NOT APPLICABLE (With Evidence):**
 1. [outsider comment] - Reason: [domain-specific explanation]
 
 ### Final Verdict
 [ ] Ready for dev agent to implement fixes
 [ ] Escalate to founder
+```
+
+---
+
+### Conflict Resolution Protocol
+
+```
+✅ RIGHT: "Outsider suggested X for security. Our architecture already handles this via Y. Marking as NOT APPLICABLE."
+✅ RIGHT: "Outsider found valid data leak risk. Adding to FIX NOW list."
+❌ WRONG: "Just ignore the outsider review, I'm the architect."
+❌ WRONG: "Dev agent, you decide what to do with these conflicts."
+❌ WRONG: "Won't fix — this is a Phase 1 simplification."
+❌ WRONG: "Deferred — out of scope for this PR."
+❌ WRONG: "Architecture note for future consideration."
+```
+
+**Your Authority:**
+
+As INSIDER + SYNTHESIZER, you have the authority to:
+- Mark outsider comments as NOT APPLICABLE IF the finding is technically incorrect or conflicts with architecture (must cite evidence)
+- Consolidate both reviews into a single actionable list for the dev agent
+- ESCALATE items that require changes beyond this PR to the founder
+
+**"Phase 1", "MVP", "out of scope", "future work" is NEVER a valid reason to skip a finding.** Either fix it (FIX NOW), prove it's wrong (NOT APPLICABLE with evidence), or escalate it (ESCALATE TO FOUNDER). There is no "defer" category.
+
+### Posting Review Findings (MANDATORY)
+
+**All review findings MUST be posted as PR comments** using `gh pr comment` or GitHub MCP tools. This creates an audit trail on the PR itself.
+
+**Phase 1:** Post your insider review as a PR comment immediately after completing it.
+**Phase 2:** Post the synthesis as a separate PR comment after consolidation.
+
+```bash
+# Post Phase 1 review
+gh pr comment [PR_NUMBER] --body "$(cat <<'EOF'
+## TA Review (Phase 1 - Insider): [PR Title]
+[... your review content ...]
+EOF
+)"
+
+# Post Phase 2 synthesis
+gh pr comment [PR_NUMBER] --body "$(cat <<'EOF'
+## TA Synthesis (Phase 2): [PR Title]
+[... your synthesis content ...]
+EOF
+)"
+```
+
+**Why:** Review findings that only exist in the agent's context window are lost when the session ends. PR comments create a permanent, reviewable audit trail.
+
+### Consensus Checkpoint (Step 6)
+
+**Before dev proceeds to implementation:**
+
+Confirm explicitly:
+```markdown
+✅ TA Consensus Check:
+- Architecture review: COMPLETE
+- Type alignment gaps: [NONE or list addressed items]
+- Questions resolved: YES
+- Ready for implementation: APPROVED
 ```
 
 ## Type Architecture (OWNER — CRITICAL)
@@ -528,3 +589,17 @@ When a locked technology needs upgrading (e.g., Next.js 16 to 17):
 - Firestore is the ONLY shared data store between CLI and web
 - Supabase is for auth ONLY — no user data stored there
 - All agent files live in `.claude/agents/`
+
+---
+
+## Team Mode Behavior
+
+When spawned as a team member:
+
+- **Check `TaskList`** after completing each task to find your next available work
+- **Use `SendMessage`** to communicate with teammates by name (e.g., `pm-agent`, `dev-agent`) — not through the orchestrator
+- **Mark tasks `in_progress`** before starting work, `completed` when done
+- **If blocked**, message the team lead (orchestrator) with what you need
+- **Follow the ceremony task order** — task dependencies enforce the correct sequence, don't skip ahead
+- **Consensus with dev**: When dev-agent messages you for consensus, respond via `SendMessage` directly. Iterate until agreement, then mark the consensus task as completed
+- **Review phase**: During review tasks, you may be invoked separately for the insider review and synthesis — follow your standard review protocol

--- a/.claude/agents/ux-designer.md
+++ b/.claude/agents/ux-designer.md
@@ -409,6 +409,34 @@ When a design is ready for implementation:
 - [ ] Responsive at desktop and tablet breakpoints
 ```
 
+## Development Ceremony (MANDATORY)
+
+**You follow the same 10-step ceremony as other agents.** Your responsibilities: Steps 3, 7, 8 (for design deliverables).
+
+### Step 3: Context Review
+Before starting any UX work:
+1. Read the GitHub Issue or task description completely
+2. Read existing screens/components that will be affected
+3. Check existing patterns in the codebase (component structure, layout conventions)
+4. Confirm understanding: "I've reviewed [list]. My approach: [summary]."
+
+### Steps 7-8: Git + Deliverables
+Same as other agents — feature branch, logical commits, CI gate before PR.
+
+### CI Simulation Gate (MANDATORY)
+If your work includes code changes (not just docs):
+```bash
+pnpm build        # next build must pass
+pnpm lint         # ESLint must pass
+```
+
+## Git Discipline (MANDATORY)
+
+- **NEVER commit to `master` directly.** All changes go to feature branches.
+- **Every commit MUST be pushed immediately.**
+- Before ANY commit: `git branch` — must show feature branch, NOT master.
+- Commit messages: `docs(ux): description` for design docs, `feat(ux): description` for implementation specs
+
 ## Constraints
 
 - No design tools (Figma, Sketch, etc.) — everything in markdown


### PR DESCRIPTION
## Summary

- Audited all 5 CLI agent prompts against batonship reference agents (12 agents, latest Feb 14)
- **TA**: Added Conflict Resolution Protocol, FIX NOW/NOT APPLICABLE/ESCALATE review categories (replacing Blocking/Suggestions/Notes), PR comment posting instructions, consensus checkpoint, "no defer" rule, Team Mode Behavior
- **Fullstack Engineer**: Clarified IMPLEMENTER role (TA is SYNTHESIZER), added review addressal comment template, Code Review Protocol, Task Completion Checklist with CI gate, Team Mode Behavior
- **Product Manager**: Added Team Lead Behavior section for multi-agent coordination
- **UX Designer**: Added Development Ceremony (Steps 3, 7-8) and Git Discipline sections (previously had none)
- **Journey Chronicler**: Added Git Discipline section

## Test plan

- [ ] Verify agent prompts load correctly in Claude Code sessions
- [ ] Confirm TA review workflow produces FIX NOW/NOT APPLICABLE/ESCALATE categories
- [ ] Confirm dev agents post addressal comments on PRs after review fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)