### PR TITLE
fix: update install-hook to use new Claude Code hooks format

### DIFF
--- a/cli/src/commands/install-hook.ts
+++ b/cli/src/commands/install-hook.ts
@@ -18,7 +18,7 @@ interface ClaudeSettings {
 
 interface HookConfig {
   matcher?: string;
-  hooks: Array<{ type: string; command: string; timeout?: number }>;
+  hooks: Array<string | { type: string; command: string; timeout?: number }>;
 }
 
 /** Extract command string from both old (string) and new ({type, command}) hook formats */


### PR DESCRIPTION
## Summary

- **Fix hooks format**: Update `install-hook` command to generate the new Claude Code hooks schema — objects with `{type, command}` instead of plain strings
- **Remove unnecessary matcher**: Stop hooks don't support matchers per Claude Code docs, removed `matcher: ".*"`  
- **Migration safety**: Add `getHookCommand()` type guard to handle both old string-format and new object-format hooks during install/uninstall, preventing `TypeError` for users upgrading from older CLI versions

## Context

Claude Code changed the hooks configuration format. The old format used plain strings in the `hooks` array:
```json
{"hooks": {"Stop": [{"matcher": ".*", "hooks": ["node /path/to/cli sync -q"]}]}}
```

The new format requires objects:
```json
{"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "node /path/to/cli sync -q"}]}]}}
```

Users who had the old hook installed would see a settings validation error on Claude Code startup, preventing the session from loading hooks.

## Test plan

- [ ] Run `code-insights install-hook` — verify settings.json gets the new object format
- [ ] Run `code-insights uninstall-hook` — verify it removes the hook cleanly
- [ ] Manually write old-format hook to settings.json, then run `uninstall-hook` — verify no crash
- [ ] Run `code-insights install-hook` twice — verify duplicate detection works
- [ ] Start a Claude Code session after install — verify no settings validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)