### PR TITLE
feat: capture thinking content, tool results, and per-message usage

### DIFF
--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -28,9 +28,13 @@ export interface MessageContent {
   type: 'text' | 'thinking' | 'tool_use' | 'tool_result';
   text?: string;
   thinking?: string;
+  // tool_use fields
+  id?: string;                       // tool_use_id
   name?: string;
   input?: Record<string, unknown>;
-  content?: string;
+  // tool_result fields
+  tool_use_id?: string;              // references tool_use_id
+  content?: string | Array<{ type: string; text: string }>;  // can be string or array
 }
 
 export interface SessionSummary {
@@ -79,7 +83,10 @@ export interface ParsedMessage {
   sessionId: string;
   type: 'user' | 'assistant' | 'system';
   content: string;
+  thinking: string | null;           // extracted thinking content
   toolCalls: ToolCall[];
+  toolResults: ToolResult[];         // extracted tool results
+  usage: MessageUsage | null;        // per-message usage (assistant only)
   timestamp: Date;
   parentId: string | null;
 }
@@ -126,8 +133,23 @@ export interface ParsedInsightContent {
 }
 
 export interface ToolCall {
+  id: string;                        // tool_use_id from JSONL
   name: string;
   input: Record<string, unknown>;
+}
+
+export interface ToolResult {
+  toolUseId: string;                 // References ToolCall.id
+  output: string;                    // Truncated tool output
+}
+
+export interface MessageUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  model: string;
+  estimatedCostUsd: number;
 }
 
 export type InsightType = 'summary' | 'decision' | 'learning' | 'technique' | 'prompt_quality';


### PR DESCRIPTION
## Summary
- **Issue #12**: Extract thinking content from assistant messages into a separate `thinking` field
- **Issue #13**: Extract tool results from user messages into `toolResults[]` array with `toolUseId` matching
- **Issue #14**: Capture per-message token usage (`MessageUsage`) on assistant messages with cost calculation

## Changes

### types.ts
- Add `id` to `ToolCall` (captures `tool_use_id` from JSONL)
- Add `ToolResult` interface (`toolUseId`, `output`)
- Add `MessageUsage` interface (`inputTokens`, `outputTokens`, `cacheCreationTokens`, `cacheReadTokens`, `model`, `estimatedCostUsd`)
- Update `ParsedMessage` with `thinking`, `toolResults`, `usage` fields
- Update `MessageContent` with `id`, `tool_use_id`, polymorphic `content` field

### parser/jsonl.ts
- Add `extractThinkingContent()` — joins multiple thinking parts with newline
- Add `extractToolResults()` — handles both string and array content formats
- Modify `extractToolCalls()` to capture `id`
- Modify `parseMessage()` to populate all 3 new fields and compute per-message cost via `calculateCost()`

### firebase/client.ts
- Modify `uploadMessages()` to write `thinking` (5k truncation), `toolResults` (2k per output), and `usage` object to Firestore

## Test plan
- [ ] `pnpm build` passes (verified)
- [ ] Re-sync with `code-insights sync --force` after deploying
- [ ] Verify messages in Firestore contain new fields
- [ ] Verify web dashboard displays thinking, tool results, and per-message usage

Closes #12, #13, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)