### PR TITLE
chore: add Vercel deployment config for docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ Note: This does NOT work with the macOS Ollama desktop app — only when running
 - **Analytics**: Vercel Analytics
 - **LLM**: OpenAI, Anthropic, Gemini, Ollama
 
+## Documentation
+
+Full documentation is available at [docs.code-insights.app](https://docs.code-insights.app). Source files are in the [`docs-site/`](docs-site/) directory.
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, code style, and PR guidelines.

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,8 @@
 
 Command-line tool that parses Claude Code session history and syncs it to your own Firebase Firestore.
 
+Full documentation: [docs.code-insights.app](https://docs.code-insights.app)
+
 ## Prerequisites
 
 - **Node.js** 18 or later

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "astro",
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install"
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` to `docs-site/` for Vercel deployment
- Add docs link to root README and cli/README

## Deployment steps (manual, after merge)
1. Import repo in Vercel → set root directory to `docs-site/`
2. Add custom domain `docs.code-insights.app`
3. Add DNS CNAME: `docs` → `cname.vercel-dns.com`

## Test plan
- [ ] `pnpm build` passes in docs-site/
- [ ] vercel.json is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)