### PR TITLE
chore: remove unused --no-qr flag from connect command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -53,9 +53,6 @@ Generate a URL to connect the web dashboard to your Firebase.
 code-insights connect
 ```
 
-**Flags:**
-- `--no-qr` — Skip QR code output (prints URL only)
-
 The URL includes your Firebase web config base64-encoded as a query parameter. Open it in a browser to connect the dashboard to your Firestore — no manual configuration needed.
 
 ### `code-insights sync`

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -3,14 +3,10 @@ import { isConfigured, loadWebConfig, hasWebConfig } from '../utils/config.js';
 import { generateDashboardUrl, validateWebConfig } from '../utils/firebase-json.js';
 import type { FirebaseWebConfig } from '../types.js';
 
-export interface ConnectOptions {
-  qr?: boolean;
-}
-
 /**
  * Generate and display the dashboard connection URL
  */
-export async function connectCommand(options: ConnectOptions): Promise<void> {
+export async function connectCommand(): Promise<void> {
   if (!isConfigured()) {
     console.log(chalk.red('\n❌ Code Insights is not configured.'));
     console.log(chalk.gray('Run "code-insights init" first.\n'));

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -50,7 +50,6 @@ program
 program
   .command('connect')
   .description('Generate a URL to connect the web dashboard to your Firebase')
-  .option('--no-qr', 'Skip QR code output')
   .action(connectCommand);
 
 program.addCommand(resetCommand);

--- a/docs-site/src/content/docs/reference/commands.md
+++ b/docs-site/src/content/docs/reference/commands.md
@@ -91,20 +91,12 @@ No flags.
 Generate a URL to connect the web dashboard to your Firebase.
 
 ```bash
-# Print URL and QR code
 code-insights connect
-
-# URL only, no QR code
-code-insights connect --no-qr
 ```
 
-**Flags:**
-
-| Flag | Description |
-|------|-------------|
-| `--no-qr` | Skip QR code output (print URL only) |
-
 The URL includes your Firebase web config base64-encoded as a query parameter. Open it in a browser to connect the dashboard to your Firestore automatically.
+
+No flags.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `qr?: boolean` from `ConnectOptions` interface in connect.ts
- Remove `--no-qr` CLI option registration from index.ts
- Remove `--no-qr` documentation from README.md and docs-site commands reference

The QR code feature was planned but never implemented — no library was installed, no generation code exists. The `--no-qr` flag was a no-op. This cleans up the dead references.

## Test plan
- [ ] Verify `code-insights connect` still works (prints URL)
- [ ] Verify `code-insights --help` no longer shows `--no-qr`
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)