### PR TITLE
feat: add sourceTool field to session uploads

### DIFF
--- a/cli/src/firebase/client.ts
+++ b/cli/src/firebase/client.ts
@@ -101,6 +101,7 @@ export async function uploadSession(session: ParsedSession, isForceSync = false)
     toolCallCount: session.toolCallCount,
     gitBranch: session.gitBranch,
     claudeVersion: session.claudeVersion,
+    sourceTool: 'claude-code',
     // Device info for multi-device tracking
     deviceId: deviceInfo.deviceId,
     deviceHostname: deviceInfo.hostname,

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -74,6 +74,7 @@ export interface ParsedSession {
   customTitle?: string;
   gitBranch: string | null;
   claudeVersion: string | null;
+  sourceTool?: string;
   usage?: SessionUsage;
   messages: ParsedMessage[];
 }


### PR DESCRIPTION
## Summary
- Add optional `sourceTool?: string` field to `ParsedSession` interface in `cli/src/types.ts`
- Set `sourceTool: 'claude-code'` in Firestore session document during upload in `cli/src/firebase/client.ts`

Paired with web PR melagiri/code-insights-web#49 which adds the field to the web Session type.

## Why
Every session synced to Firestore now explicitly identifies its source tool. This prepares for multi-tool support — when parsers for Cursor, Copilot, Codex, etc. are added, each will set its own `sourceTool` value, enabling filtering and categorization in the web dashboard.

## Test plan
- [ ] Verify CLI build passes (`pnpm build` in cli/)
- [ ] Verify `code-insights sync` still works
- [ ] Verify new sessions in Firestore include `sourceTool: 'claude-code'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)