### PR TITLE
docs: update docs-site to reflect multi-source support

### DIFF
--- a/docs-site/src/content/docs/getting-started/installation.md
+++ b/docs-site/src/content/docs/getting-started/installation.md
@@ -6,7 +6,11 @@ description: Install the Code Insights CLI and verify it works.
 ## Prerequisites
 
 - **Node.js** 18 or later
-- **Claude Code** installed with existing session history in `~/.claude/projects/`
+- At least one supported AI coding tool with existing session history:
+  - **Claude Code** — `~/.claude/projects/`
+  - **Cursor** — Workspace storage (macOS, Linux, Windows)
+  - **OpenAI Codex CLI** — `~/.codex/sessions/`
+  - **GitHub Copilot CLI** — `~/.copilot/session-state/`
 - A **Google account** (for Firebase — see [Firebase Setup](/guides/firebase-setup/))
 
 ## Install

--- a/docs-site/src/content/docs/getting-started/introduction.md
+++ b/docs-site/src/content/docs/getting-started/introduction.md
@@ -3,11 +3,11 @@ title: Introduction
 description: What Code Insights is, why it exists, and how it works.
 ---
 
-Code Insights parses your Claude Code session history — the JSONL files stored in `~/.claude/projects/` — and syncs them to your own Firebase database. From there, a web dashboard lets you browse sessions, generate LLM-powered insights, and track patterns in how you work with AI.
+Code Insights parses session data from multiple AI coding tools — Claude Code, Cursor, Codex CLI, and Copilot CLI — and syncs them to your own Firebase database. From there, a web dashboard lets you browse sessions, generate LLM-powered insights, and track patterns in how you work with AI.
 
 ## Why?
 
-Claude Code stores every conversation as JSONL. That's valuable data: what you built, why you made certain choices, what went wrong and how you fixed it. But raw JSON isn't searchable or browsable. Code Insights makes it useful.
+AI coding tools store every conversation as structured data. That's valuable: what you built, why you made certain choices, what went wrong and how you fixed it. But raw session files aren't searchable or browsable. Code Insights makes them useful.
 
 ## Privacy: Bring Your Own Firebase
 
@@ -24,11 +24,12 @@ You create a Firebase project, point the CLI at it, and your data stays there. T
 ## How It Works
 
 ```
-~/.claude/projects/**/*.jsonl
+Session files from supported tools
+(Claude Code, Cursor, Codex CLI, Copilot CLI)
            |
            v
     +--------------+
-    |   CLI         |  Parse JSONL, extract metadata
+    |   CLI         |  Parse sessions, extract metadata
     |  (Node.js)    |  Upload to YOUR Firestore
     +--------------+
            |
@@ -48,7 +49,7 @@ You create a Firebase project, point the CLI at it, and your data stays there. T
 
 The system has two parts:
 
-- **CLI** (this repo, open source) — Parses JSONL files, generates session titles, classifies session types, and syncs everything to Firestore.
+- **CLI** (this repo, open source) — Discovers and parses sessions from supported tools, generates session titles, classifies session types, and syncs everything to Firestore.
 - **Web Dashboard** (closed source, hosted at Vercel) — Visualizes sessions, runs LLM analysis, and exports data to Markdown.
 
 ## What You Get

--- a/docs-site/src/content/docs/getting-started/quick-start.md
+++ b/docs-site/src/content/docs/getting-started/quick-start.md
@@ -27,10 +27,10 @@ You can also run `code-insights init` without flags for an interactive setup wiz
 code-insights sync
 ```
 
-This parses all Claude Code JSONL files in `~/.claude/projects/` and uploads them to your Firestore. The first sync may take a moment depending on how many sessions you have.
+This discovers sessions from all supported tools (Claude Code, Cursor, Codex CLI, Copilot CLI) and uploads them to your Firestore. The first sync may take a moment depending on how many sessions you have.
 
 :::note
-If you have months of Claude Code history, the initial sync may exceed Firebase's free tier write limits. Consider temporarily upgrading to the [Blaze plan](https://firebase.google.com/pricing) (pay-as-you-go) for the initial sync. The cost is negligible. Subsequent syncs are incremental and stay well within the free tier.
+If you have months of session history, the initial sync may exceed Firebase's free tier write limits. Consider temporarily upgrading to the [Blaze plan](https://firebase.google.com/pricing) (pay-as-you-go) for the initial sync. The cost is negligible. Subsequent syncs are incremental and stay well within the free tier.
 :::
 
 ## 3. Open the Dashboard

--- a/docs-site/src/content/docs/guides/syncing-sessions.md
+++ b/docs-site/src/content/docs/guides/syncing-sessions.md
@@ -3,14 +3,25 @@ title: Syncing Sessions
 description: How session sync works — incremental updates, filtering, and auto-sync.
 ---
 
-The `sync` command reads Claude Code JSONL files from `~/.claude/projects/` and uploads them to your Firestore.
+The `sync` command discovers sessions from all supported AI coding tools and uploads them to your Firestore.
+
+## Supported Sources
+
+The CLI automatically detects and syncs sessions from:
+
+| Tool | Session location |
+|------|-----------------|
+| **Claude Code** | `~/.claude/projects/` |
+| **Cursor** | Workspace storage (macOS, Linux, Windows) |
+| **OpenAI Codex CLI** | `~/.codex/sessions/` |
+| **GitHub Copilot CLI** | `~/.copilot/session-state/` |
 
 ## How It Works
 
-Each JSONL file represents a Claude Code session. The CLI:
+For each supported source, the CLI:
 
-1. Scans `~/.claude/projects/` for JSONL files
-2. Parses each file to extract messages, metadata, and tool calls
+1. Discovers session files from the tool's storage location
+2. Parses each session to extract messages, metadata, and tool calls
 3. Generates a title for each session (based on content)
 4. Classifies the session character (deep focus, bug hunt, feature build, etc.)
 5. Uploads projects, sessions, and messages to Firestore
@@ -33,7 +44,7 @@ Sync only a specific project:
 code-insights sync --project "my-project"
 ```
 
-The project name matches the directory name under `~/.claude/projects/`.
+The project name matches the directory name of the project being synced.
 
 ## Force Re-Sync
 

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Code Insights
-description: Transform your Claude Code session history into structured, searchable insights.
+description: Transform your AI coding session history into structured, searchable insights.
 template: splash
 hero:
   tagline: Your AI coding sessions, parsed, synced, and visualized — on your own Firebase.
@@ -20,8 +20,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 	<Card title="Your Data, Your Firebase" icon="setting">
 		Bring Your Own Firebase (BYOF). Session data never leaves your control — the CLI writes to your Firestore, and the dashboard reads from it. No central server, no data collection, full delete at any time.
 	</Card>
-	<Card title="Automatic Session Sync" icon="rocket">
-		Install a Claude Code hook and forget about it. Every session gets synced automatically when it ends — titles generated, characters classified, messages parsed.
+	<Card title="Multi-Source Support" icon="rocket">
+		Sync sessions from Claude Code, Cursor, Codex CLI, and Copilot CLI. Install a Claude Code hook and every session syncs automatically when it ends — titles generated, characters classified, messages parsed.
 	</Card>
 	<Card title="LLM-Powered Insights" icon="star">
 		Generate summaries, track architectural decisions, surface learnings, and identify reusable techniques. Score your prompt quality with anti-pattern detection and efficiency tips.

--- a/docs-site/src/content/docs/reference/commands.md
+++ b/docs-site/src/content/docs/reference/commands.md
@@ -32,7 +32,7 @@ Configuration is stored in `~/.code-insights/config.json`. Web config is stored 
 
 ## `code-insights sync`
 
-Sync Claude Code sessions to Firestore.
+Sync sessions from all supported tools (Claude Code, Cursor, Codex CLI, Copilot CLI) to Firestore.
 
 ```bash
 # Sync new/modified sessions
@@ -102,13 +102,13 @@ No flags.
 
 ## `code-insights install-hook`
 
-Install a Claude Code hook for automatic sync after each session.
+Install a Claude Code hook for automatic sync after each session ends.
 
 ```bash
 code-insights install-hook
 ```
 
-This adds a hook that runs `code-insights sync -q` whenever a Claude Code session ends. No flags.
+This adds a hook that runs `code-insights sync -q` whenever a Claude Code session ends, keeping your dashboard up to date automatically. No flags.
 
 ---
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -11,7 +11,7 @@ All `Timestamp` fields convert to JavaScript `Date` objects when read by the web
 
 ## `projects`
 
-Each project corresponds to a directory under `~/.claude/projects/`. Project IDs are derived from the git remote URL when available, making them stable across devices.
+Each project corresponds to a working directory discovered from a supported AI coding tool. Project IDs are derived from the git remote URL when available, making them stable across devices.
 
 ```typescript
 {
@@ -35,7 +35,7 @@ Each project corresponds to a directory under `~/.claude/projects/`. Project IDs
 
 ## `sessions`
 
-One document per Claude Code session. The session ID comes from the JSONL filename.
+One document per session from any supported tool. The session ID is derived from the source file identifier (e.g., the JSONL filename for Claude Code).
 
 ```typescript
 {
@@ -58,7 +58,7 @@ One document per Claude Code session. The session ID comes from the JSONL filena
   toolCallCount: number
   gitBranch: string | null
   claudeVersion: string | null
-  sourceTool?: string           // 'claude-code' (multi-tool identifier)
+  sourceTool?: string           // 'claude-code' | 'cursor' | 'codex-cli' | 'copilot-cli'
 
   // Device info
   deviceId: string


### PR DESCRIPTION
## Summary
- Updates 7 docs-site pages to reflect multi-source support (Claude Code, Cursor, Codex CLI, Copilot CLI)
- Replaces Claude Code-only references with tool-agnostic language matching the CLI README

## Files Changed

| File | Key Change |
|------|-----------|
| `introduction.md` | Multi-source description, updated architecture diagram |
| `installation.md` | Prerequisites list all 4 supported tools |
| `quick-start.md` | Sync description mentions all tools |
| `syncing-sessions.md` | Added "Supported Sources" table, tool-agnostic language |
| `commands.md` | `sync` command lists all 4 tools |
| `schema.md` | `sourceTool` shows all variants, removed Claude Code-only references |
| `index.mdx` | Hero tagline updated, "Automatic Session Sync" → "Multi-Source Support" |

## Test plan
- [ ] Verify docs-site builds: `cd docs-site && pnpm build`
- [ ] Spot-check pages for consistent multi-source language

🤖 Generated with [Claude Code](https://claude.com/claude-code)