### PR TITLE
feat(cli): set live Supabase telemetry endpoint URL

### DIFF
--- a/cli/src/utils/telemetry.ts
+++ b/cli/src/utils/telemetry.ts
@@ -5,10 +5,7 @@ import * as crypto from 'crypto';
 import { createRequire } from 'module';
 import { loadConfig, getConfigDir, getClaudeDir } from './config.js';
 
-// Placeholder endpoint — will be replaced with real Supabase Edge Function URL
-// when the function is deployed. Intentionally left as a placeholder to avoid
-// accidentally sending data to a wrong endpoint during development.
-const TELEMETRY_ENDPOINT = 'https://PLACEHOLDER.supabase.co/functions/v1/cli-telemetry';
+const TELEMETRY_ENDPOINT = 'https://xrbkoqjfolxiyfxubiom.supabase.co/functions/v1/cli-telemetry';
 
 // Touch file path that tracks whether the one-time disclosure has been shown
 const NOTICE_FILE = path.join(getConfigDir(), '.telemetry-notice-shown');


### PR DESCRIPTION
## Summary
- Updates the telemetry endpoint URL in `cli/src/utils/telemetry.ts` from placeholder to the live Supabase Edge Function URL
- Companion to melagiri/code-insights-web#66 which adds the Supabase backend (migration + Edge Function)

## Change
Single line change in `cli/src/utils/telemetry.ts`:
```typescript
const TELEMETRY_ENDPOINT = 'https://xrbkoqjfolxiyfxubiom.supabase.co/functions/v1/cli-telemetry';
```

## Test plan
- [x] Edge Function is deployed and accepting events (verified via curl + real CLI invocation)
- [x] CLI `stats --no-sync` successfully sends telemetry event to the endpoint
- [x] Event appears in Supabase `cli_telemetry` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)