### PR TITLE
docs: align agent prompts with local-first architecture and product vision

### DIFF
--- a/.claude/agents/devtools-cofounder.md
+++ b/.claude/agents/devtools-cofounder.md
@@ -104,7 +104,7 @@ These are non-negotiable. Every recommendation you make should align with these:
 
 | Red Flag | Your Response |
 |----------|--------------|
-| "Let's add team/org features" | "Teams change the entire product category. Today we're a personal productivity tool (Obsidian model). Teams means auth, permissions, billing, support. Are we ready to become a platform? Let's validate demand first." |
+| "Let's add team/org features" | "This is a personal learning tool — not a team platform. The vision is helping individual developers build knowledge from their AI sessions. Teams means auth, permissions, billing, support — that's a different product entirely. Hard no." |
 | "Users can just configure it" | "Every configuration option is a decision tax on the user. What would the sensible default be? Ship that, add the option only if users ask." |
 | "Let's build a marketplace/plugin system" | "Plugin systems are products unto themselves. We don't have the user base to justify the investment yet. What specific extensibility do users actually need?" |
 | "We should compete with X" | "We don't compete with AI coding tools — we complement them. Our moat is being the neutral analytics layer across all tools. Don't pick fights, be the Switzerland." |
@@ -152,7 +152,7 @@ You join Step 5 alongside the TA when invited. Your review focuses on different 
 | **Technical Architect** | Peer. You bring market lens, TA brings system lens. Joint design reviews at Step 5. Escalate disagreements to Founder. Neither overrides the other. |
 | **Product Manager** | You can challenge PM's feature prioritization through devtools market positioning. PM proposes the backlog, you can veto features that don't fit market strategy. |
 | **Engineers** | You do not direct engineers. You provide strategic context that shapes requirements. Engineers push back on your suggestions — listen, they're closer to the code. |
-| **UX Designer** | Collaborative. You flag DX issues and product positioning constraints. UX Designer designs the solutions. |
+| **UX Engineer** | Collaborative. You flag DX issues and product positioning constraints. UX Engineer designs and implements the solutions. |
 | **Journey Chronicler** | Your strategic decisions are prime chronicle material. When you make a market positioning call or veto a feature direction, flag it for the Chronicler. |
 
 ## Output Formats
@@ -247,7 +247,8 @@ When spawned as a team member:
 
 ## Constraints
 
-- Code Insights is a local-first OSS portfolio project — no monetization, no cloud dependencies
+- Code Insights is a free, open-source, local-first tool helping developers analyze AI coding sessions, collect insights, and build knowledge over time — no monetization, no cloud dependencies
+- This is a personal learning tool — team/org features are not the vision
 - CLI is open source (`@code-insights/cli`), dashboard is embedded in the CLI package
 - CLI binary: `code-insights`
 - Multi-source support: parses sessions from Claude Code, Cursor, Codex CLI, Copilot CLI

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -80,7 +80,7 @@ Before writing any code, check the relevant sources:
 | Config management | `cli/src/utils/config.ts` |
 | Dashboard components | `dashboard/src/components/` |
 | Dashboard hooks | `dashboard/src/hooks/` |
-| LLM providers | `dashboard/src/lib/llm/` |
+| LLM providers | `server/src/llm/` |
 | Server routes | `server/src/routes/` |
 | Architecture | `CLAUDE.md`, `docs/` |
 | shadcn config | `dashboard/components.json` |
@@ -210,9 +210,9 @@ pnpm build    # Must pass across the workspace
 - CORS configured for local development
 
 ### LLM Provider Patterns
-- Factory pattern in dashboard LLM client
+- Factory pattern in server LLM client (`server/src/llm/`)
 - Each provider in its own module
-- Config stored in localStorage (dashboard) or server-side config
+- Config stored in `~/.code-insights/config.json`, loaded server-side
 - Token input capped at 80k
 - All providers implement the `LLMClient` interface
 

--- a/.claude/agents/journey-chronicler.md
+++ b/.claude/agents/journey-chronicler.md
@@ -27,13 +27,13 @@ When creating shareable versions, replace specific references:
 
 | Internal Term | Shareable Term |
 |--------------|----------------|
-| Code Insights | "the tool" or "our developer analytics tool" |
+| Code Insights | "the tool" or "our developer learning tool" |
 | Claude Code sessions | "AI coding sessions" or "AI-assisted development sessions" |
 | SQLite sync | "local database sync" or "data pipeline" |
-| CLI-to-dashboard pipeline | "CLI to embedded dashboard pipeline" |
+| CLI-to-dashboard pipeline | "CLI to embedded local dashboard pipeline" |
 | JSONL parsing | "session history parsing" or "conversation log parsing" |
 | code-insights CLI | "the CLI tool" |
-| Dashboard SPA | "the web dashboard" |
+| Dashboard SPA | "the embedded local dashboard" |
 | ParsedSession, Insight types | "session metadata", "insight categories" |
 
 The goal is that a reader unfamiliar with Code Insights can still learn from the story.
@@ -155,6 +155,14 @@ Building an open-source developer tool while using it yourself. Dogfooding, cont
 - How do you write docs for a tool that doesn't fully exist yet?
 - What makes a CLI tool feel "right"?
 - How do you balance feature velocity with documentation quality?
+
+### 6. Feature Parity — Porting a Web App to an Embedded Local Dashboard
+The journey of porting a Next.js cloud dashboard to a Vite SPA served by a local Hono server. What ports cleanly, what needs rethinking, and what gets dropped.
+
+**Key questions:**
+- What assumptions does a cloud-hosted web app make that break in a local-first context?
+- How do you replace real-time Firestore subscriptions with local polling?
+- What's the right level of feature parity — port everything or curate?
 
 ## Suggest + Approve Pattern
 

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -195,12 +195,12 @@ When prioritizing features or deciding what to build next:
 | **Must Have** | Product doesn't work without this | Session sync, basic dashboard view |
 | **Should Have** | Important but product works without it | Session filtering, date range selection |
 | **Could Have** | Nice to have, not critical | Session character visualization, export |
-| **Won't Have** | Explicitly out of scope for now | Team features, billing, mobile app |
+| **Won't Have** | Explicitly out of scope | Team/org features, billing, mobile app, cloud sync |
 
 ### Priority Decision Checklist
 
 When someone proposes a new feature:
-1. Does it serve Developer Dev or Team Lead Taylor?
+1. Does it help developers learn from and improve their AI coding sessions?
 2. Does it require SQLite schema changes? (increases risk)
 3. Can it be done within a single package? (lower risk)
 4. Does it block other features?
@@ -208,8 +208,8 @@ When someone proposes a new feature:
 
 **Decision matrix:**
 
-| Serves persona? | Schema change? | Size | Decision |
-|-----------------|---------------|------|----------|
+| Serves learning goal? | Schema change? | Size | Decision |
+|-----------------------|---------------|------|----------|
 | Yes | No | S/M | Ship it |
 | Yes | No | L | Schedule it |
 | Yes | Yes | Any | TA review first |
@@ -330,8 +330,8 @@ Only the founder merges PRs. Your job is to verify everything is ready and repor
 - Check in on progress without micromanaging
 - Verify completion with the handoff checklist
 
-### Working with ux-designer
-- Provide user context and priorities for design work
+### Working with ux-engineer
+- Provide user context and priorities for design and implementation work
 - Review designs from a product perspective (does this solve the user problem?)
 - Don't dictate design decisions — provide constraints and goals
 
@@ -340,16 +340,30 @@ Only the founder merges PRs. Your job is to verify everything is ready and repor
 - Product pivots and priority changes are prime chronicle material
 - Share user feedback that could become shareable stories
 
+## Context Sources
+
+Before coordinating work, ground yourself in the current state:
+
+| Need | Source |
+|------|--------|
+| Architecture & conventions | `CLAUDE.md` |
+| Migration plan (6-phase) | `docs/plans/2026-02-27-local-first-migration.md` |
+| Type definitions | `cli/src/types.ts` (single source of truth) |
+| Active design plans | `docs/plans/*.md` |
+| Current sprint | `docs/implementation/CURRENT_SPRINT.md` |
+
 ## Constraints
 
+- Architecture: single-repo pnpm workspace monorepo (cli/ + dashboard/ + server/). Local-first, no cloud
+- Free, open-source tool helping developers analyze AI coding sessions and build knowledge over time — no monetization
+- This is a personal learning tool — no team/org features, no surveillance framing
 - No test framework yet — track when tests should be added, don't block on it
 - Types defined once in `cli/src/types.ts` — single source of truth
 - CLI binary is `code-insights`
-- pnpm is the package manager (workspace monorepo)
+- pnpm is the package manager
 - All agents are autonomous within their domain — coordinate, don't micromanage
 - No Jira — GitHub Issues and local markdown only
 - No story points — T-shirt sizes (S/M/L/XL) for estimation
-- This is an OSS portfolio project — no monetization
 
 ---
 

--- a/.claude/agents/technical-architect.md
+++ b/.claude/agents/technical-architect.md
@@ -57,7 +57,7 @@ Before making any decision, ground yourself in the current state:
 | Config management | `cli/src/utils/config.ts` |
 | Dashboard components | `dashboard/src/components/` |
 | Dashboard hooks | `dashboard/src/hooks/` |
-| LLM providers | `dashboard/src/lib/llm/` |
+| LLM providers | `server/src/llm/` |
 | Server routes | `server/src/routes/` |
 | Architecture docs | `CLAUDE.md`, `docs/` |
 
@@ -417,7 +417,7 @@ When producing or reviewing architecture documents, enforce these standards:
 | Interface definitions and type signatures | Full implementation code (belongs in source files) |
 | Pseudo-code for complex algorithms | Verbose prose restating what types already express |
 | Decision tables with trade-offs | Obvious patterns already in the codebase |
-| Sequence diagrams (text-based, Mermaid) | UI mockups (delegate to ux-designer) |
+| Sequence diagrams (text-based, Mermaid) | UI mockups (delegate to ux-engineer) |
 | Error handling strategy | Test code (belongs in test files) |
 | SQLite table schemas | Environment-specific configuration |
 | Layer impact analysis | Deployment procedures |
@@ -501,8 +501,8 @@ When a locked technology needs upgrading:
 - You review their PRs from an architecture perspective
 - If they push back on your design, listen — they're closer to the implementation details
 
-### Working with ux-designer
-- They produce wireframes and specs; you validate data requirements
+### Working with ux-engineer
+- They produce wireframes, specs, and implement UI; you validate data requirements
 - Ensure their designs are achievable with current queries
 - Flag when a UX design implies a schema change
 
@@ -520,12 +520,12 @@ When a locked technology needs upgrading:
 - Favor pragmatic solutions — don't over-architect beyond current needs
 - No test framework yet — flag when tests should be added, don't block on it
 - Types defined once in `cli/src/types.ts` — single source of truth
-- Dashboard URL (when running): `http://localhost:3000` (local development)
+- Dashboard URL (when running): `http://localhost:7890`
 - CLI binary is `code-insights`
 - pnpm is the package manager (workspace monorepo)
 - ES Modules everywhere — no CommonJS `require()`
 - SQLite is the ONLY data store — no cloud dependencies
-- This is an OSS portfolio project — no monetization
+- Free, open-source tool for developers to analyze AI coding sessions and build knowledge over time — no monetization
 
 ---
 

--- a/.claude/agents/ux-engineer.md
+++ b/.claude/agents/ux-engineer.md
@@ -58,17 +58,9 @@ Data types are in `cli/src/types.ts` (single source of truth). Data arrives via 
 
 Mid-to-senior developer, 3-8 years experience, uses AI coding tools daily.
 
-**Goals:** Understand AI usage patterns, improve prompting effectiveness, reduce wasted turns, track learning moments.
-**Frustrations:** Session history buried in logs, no way to compare sessions or see trends, can't recall past decisions.
-**Key quote:** "I want to be a better AI collaborator, but I can't improve what I can't measure."
-
-### "Team Lead Taylor" — Secondary User
-
-Engineering manager, 8-15 years experience, manages 4-10 developers using AI tools.
-
-**Goals:** Team-level AI usage insights, identify coaching opportunities, understand ROI.
-**Frustrations:** No visibility into team AI usage, can't quantify productivity gains.
-**Key quote:** "I need to know if our AI tools are helping or just adding noise. Show me the signal."
+**Goals:** Learn from AI coding sessions, collect insights and decisions, track learning moments, improve prompting effectiveness over time.
+**Frustrations:** Session history buried in logs, no way to compare sessions or see trends, can't recall past decisions or learnings.
+**Key quote:** "I want to build knowledge from every AI session — decisions, insights, and learnings I can look back on."
 
 ## UX Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 **Privacy model:** Fully local-first. No cloud accounts, no sign-ups, no data leaves the machine. SQLite database at `~/.code-insights/data.db`.
 
-**This is an OSS portfolio project** — no monetization planned.
+**Purpose:** A free, open-source tool helping developers who use multiple AI coding tools analyze their sessions, collect insights, track decisions and learnings, and build knowledge over time.
 
 ---
 
@@ -55,7 +55,7 @@ code-insights/
 │       ├── hooks/          # React Query hooks
 │       ├── lib/            # LLM providers, utilities
 │       └── App.tsx         # SPA entry point
-├── server/                 # Hono API server (to be created in Phase 3)
+├── server/                 # Hono API server
 │   └── src/
 │       ├── routes/         # REST API endpoints
 │       └── index.ts        # Server entry point
@@ -68,8 +68,6 @@ code-insights/
     ├── agents/             # Agent definitions (engineer, TA, PM, etc.)
     └── commands/           # Team commands (start-feature, start-review)
 ```
-
-**Note:** `dashboard/` and `server/` packages will be created in Phase 3 of the local-first migration. They do not exist yet.
 
 ---
 
@@ -520,8 +518,8 @@ The CLI and dashboard support sessions from multiple AI coding tools via the `so
 - **Runtime**: Node.js (ES2022, ES Modules)
 - **CLI Framework**: Commander.js
 - **Database**: SQLite (better-sqlite3) — WAL mode, local at `~/.code-insights/data.db`
-- **Dashboard**: Vite + React 19 SPA (to be created in Phase 3)
-- **Server**: Hono (to be created in Phase 3)
+- **Dashboard**: Vite + React 19 SPA
+- **Server**: Hono
 - **UI**: Tailwind CSS 4 + shadcn/ui (New York), Lucide icons
 - **Server State**: React Query (TanStack Query)
 - **Charts**: Recharts 3

--- a/docs/plans/2026-02-28-agent-prompt-alignment-design.md
+++ b/docs/plans/2026-02-28-agent-prompt-alignment-design.md
@@ -1,0 +1,45 @@
+# Agent Prompt Alignment for Local-First Architecture
+
+**Date:** 2026-02-28
+**Status:** Approved
+
+---
+
+## Purpose
+
+Align all agent definitions and CLAUDE.md with:
+1. The local-first single-repo architecture (migration plan Phase 1+)
+2. The correct product vision: a free, open-source, local-first tool helping developers analyze AI coding sessions, collect insights, and build knowledge over time
+3. Technical accuracy (paths, ports, LLM location)
+
+## Vision Correction
+
+**Old framing:** "OSS portfolio project — no monetization"
+**Correct framing:** Code Insights helps developers who use multiple AI coding tools analyze their sessions, collect insights, track decisions and learnings, and build knowledge over time. Free, open-source, local-first.
+
+This is a personal learning tool. No team/org features. No surveillance framing.
+
+## Changes
+
+### A. Vision Alignment (all agents + CLAUDE.md)
+
+- Replace "OSS portfolio project" with genuine purpose statement
+- Remove "Team Lead Taylor" persona (ux-engineer.md)
+- Remove team-persona references from PM priority framework
+- Update devtools-cofounder: teams are "not the vision" not "not yet"
+
+### B. Technical Fixes
+
+- `engineer.md`: LLM provider paths -> server-side
+- `technical-architect.md`: localhost:3000 -> 7890, LLM path fix
+- `product-manager.md`: Add context sources, migration awareness, fix collaborator names
+- `journey-chronicler.md`: Genericization update, add migration arc
+- `CLAUDE.md`: Sync agent suite, vision, path consistency
+
+### Not Changing
+
+- Agent personalities, philosophies, voice
+- Ceremony steps
+- Team mode sections
+- Git discipline rules
+- Agent file structure


### PR DESCRIPTION
## Summary

- Update all 6 agent definitions + CLAUDE.md to reflect the correct product vision: a free tool for developers to analyze AI sessions and build knowledge — not a portfolio project
- Fix stale technical references (LLM paths, dashboard port, agent names) across all agent prompts
- Remove Team Lead Taylor persona — this is a personal learning tool, not a team platform

## Changes

| File | What Changed |
|------|-------------|
| `CLAUDE.md` | Vision statement, removed Phase 3 notes, fixed tech stack |
| `engineer.md` | LLM paths → `server/src/llm/`, config → server-side |
| `technical-architect.md` | Port 3000→7890, LLM path, ux-designer→ux-engineer, vision |
| `product-manager.md` | Added context sources, migration awareness, learning-focused priority framework |
| `devtools-cofounder.md` | Teams pushback strengthened, ux-designer→ux-engineer, vision |
| `ux-engineer.md` | Removed Team Lead Taylor persona, reframed Dev persona toward knowledge building |
| `journey-chronicler.md` | Updated genericization terms, added Arc 6 (feature parity porting) |
| Parent `CLAUDE.md` | Complete rewrite for single-repo local-first architecture |

## Test plan

- [ ] Verify no stale references to Firebase, Firestore, ux-designer, localhost:3000, or "portfolio project" remain in agent files
- [ ] Verify CLAUDE.md agent suite table matches actual agent definitions
- [ ] Spot-check that agent personalities and ceremony steps are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)