### PR TITLE
fix(docs): address agent prompt review findings from PR #56

### DIFF
--- a/.claude/agents/devtools-cofounder.md
+++ b/.claude/agents/devtools-cofounder.md
@@ -247,8 +247,7 @@ When spawned as a team member:
 
 ## Constraints
 
-- Code Insights is a free, open-source, local-first tool helping developers analyze AI coding sessions, collect insights, and build knowledge over time — no monetization, no cloud dependencies
-- This is a personal learning tool — team/org features are not the vision
+- Code Insights is a free, open-source, local-first personal learning tool helping developers analyze AI coding sessions and build knowledge over time — no monetization, no cloud dependencies, no team/org features
 - CLI is open source (`@code-insights/cli`), dashboard is embedded in the CLI package
 - CLI binary: `code-insights`
 - Multi-source support: parses sessions from Claude Code, Cursor, Codex CLI, Copilot CLI

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -413,7 +413,7 @@ Only the founder merges PRs. Your job ends when the PR is created and review com
 
 - No environment variables required for basic operation
 - SQLite database and config stored at `~/.code-insights/`
-- LLM API keys stored in dashboard localStorage or server-side config
+- LLM API keys stored in `~/.code-insights/config.json` (server-side)
 
 ## Document Ownership
 

--- a/.claude/agents/ux-engineer.md
+++ b/.claude/agents/ux-engineer.md
@@ -181,7 +181,7 @@ SHADCN COMPONENTS:
 ## User Flow: [Flow Name]
 
 **Trigger:** [What starts this flow]
-**Actor:** [Dev/Taylor persona]
+**Actor:** [Developer Dev persona]
 **Goal:** [What they want to accomplish]
 
 ### Happy Path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ code-insights/
 │       ├── utils/          # Config, device, paths
 │       ├── types.ts        # Type definitions (SINGLE SOURCE OF TRUTH)
 │       └── index.ts        # CLI entry point
-├── dashboard/              # Vite + React SPA (to be created in Phase 3)
+├── dashboard/              # Vite + React SPA
 │   └── src/
 │       ├── components/     # React components (shadcn/ui)
 │       ├── hooks/          # React Query hooks


### PR DESCRIPTION
## Summary

Fixes 4 residual stale references found by the LLM Expert and Claude Code Expert reviewers on PR #56.

## Changes

| # | File | Fix |
|---|------|-----|
| 1 | `ux-engineer.md` | User Flow template: `[Dev/Taylor persona]` -> `[Developer Dev persona]` |
| 2 | `engineer.md` | Environment Variables: dashboard localStorage -> `~/.code-insights/config.json` (server-side) |
| 3 | `CLAUDE.md` | Dashboard directory: removed "to be created in Phase 3" |
| 4 | `devtools-cofounder.md` | Merged two adjacent vision constraint lines into one |

## Test plan

- [x] All 4 stale references from review comments addressed
- [x] No other instances of `Taylor`, `localStorage`, or `Phase 3` remain in agent files

🤖 Generated with [Claude Code](https://claude.com/claude-code)