### PR TITLE
docs: update VISION.md, PRODUCT.md, ROADMAP.md to reflect local-first architecture

### DIFF
--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -2,45 +2,53 @@
 
 ## What It Is
 
-Code Insights transforms your Claude Code session history into structured, searchable insights. It extracts patterns from your conversations—what you built, decisions you made, lessons learned—and presents them in a visual dashboard.
+Code Insights transforms your AI coding session history into structured, searchable insights. It extracts patterns from your conversations—what you built, decisions you made, lessons learned—and presents them in a local visual dashboard.
 
 ## The Problem
 
-Claude Code stores every conversation as JSONL files in `~/.claude/projects/`. This is valuable data:
+AI coding tools store every conversation as files on your machine. Claude Code uses JSONL in `~/.claude/projects/`. Cursor stores state in SQLite. Codex CLI and Copilot CLI write their own session formats. This is valuable data:
 - What features did you work on last week?
 - Why did you choose that architecture?
 - What mistakes did you make (and fix)?
 - How much time went into different parts of the codebase?
 
-But it's trapped in raw JSON. You can't search it, visualize it, or learn from it.
+But it's trapped in raw files. You can't search it, visualize it, or learn from it.
 
 ## The Solution
 
 Code Insights provides:
 
-1. **Automated extraction** - Parses JSONL files and structures the data
-2. **Smart session titles** - Auto-generates meaningful titles from session content
-3. **Session classification** - Categorizes sessions (deep focus, bug hunt, feature build, etc.)
-4. **LLM-powered analysis** - Multi-provider insight generation (OpenAI, Anthropic, Gemini, Ollama) with your own API key
-5. **Visual dashboard** - Web interface with charts, timelines, and filters
-6. **Markdown export** - Download insights as Obsidian, plain MD, or Notion format
+1. **Automated extraction** — Parses session files from multiple AI coding tools and structures the data
+2. **Smart session titles** — Auto-generates meaningful titles from session content
+3. **Session classification** — Categorizes sessions (deep focus, bug hunt, feature build, etc.)
+4. **LLM-powered analysis** — Multi-provider insight generation (OpenAI, Anthropic, Gemini, Ollama) with your own API key
+5. **Visual dashboard** — Local web interface with charts, timelines, and filters at `http://localhost:7890`
+6. **CLI analytics** — Terminal stats via `code-insights stats` and subcommands
 
 ## Who It's For
 
-- **Claude Code developers** who want to track their AI-assisted work
-- **Learners** who want to review and reinforce what they've built with Claude
-- **Privacy-conscious users** who want insights without giving up their data
+- **Developers using multiple AI coding tools** who want to understand their AI-assisted work patterns across Claude Code, Cursor, Codex CLI, and Copilot CLI
+- **Learners** who want to review and reinforce what they've built with AI assistants
+- **Privacy-conscious developers** who want insights without giving up their data to a cloud service
 
 ## Privacy Model
 
-**Bring Your Own Firebase (BYOF)**
+**Fully local. No cloud. No accounts.**
 
-Code Insights stores all user session data in the user's own Firebase Firestore. The hosted dashboard:
-- Requires Google/GitHub login for access control
-- Collects anonymous aggregate analytics via Vercel Analytics
-- **Does NOT store or access your Claude Code data** — that stays in your Firebase
+Code Insights stores all session data in a SQLite database at `~/.code-insights/data.db` on your own machine. There is no central server, no sign-up, and no data sent anywhere. The dashboard runs locally at `http://localhost:7890` — served by a Hono API process on your own machine.
+
+LLM analysis uses your own API key, stored in `~/.code-insights/config.json` (mode 0o600). API calls go directly from the local server to your chosen LLM provider — not through any Code Insights infrastructure.
 
 ## Core Features
+
+### Multi-Source Support
+
+| Source Tool | What's Captured |
+|-------------|-----------------|
+| **Claude Code** | JSONL sessions from `~/.claude/projects/` |
+| **Cursor** | Sessions from Cursor's local SQLite state |
+| **Codex CLI** | Rollout files from `~/.codex/sessions/` |
+| **Copilot CLI** | Event files from `~/.copilot/session-state/` |
 
 ### Insight Categories
 
@@ -53,28 +61,34 @@ Code Insights stores all user session data in the user's own Firebase Firestore.
 
 ### Dashboard Views
 
-- **Daily/Weekly digest** - Summary of recent sessions
-- **Project timeline** - Visual history of work per project
-- **Decision log** - Searchable archive of "why" decisions
-- **Analytics** - Charts showing effort distribution, patterns
-- **Session detail** - Full session with analyze button for LLM insights
+- **Daily/Weekly digest** — Summary of recent sessions
+- **Project timeline** — Visual history of work per project
+- **Decision log** — Searchable archive of "why" decisions
+- **Analytics** — Charts showing effort distribution, patterns
+- **Session detail** — Full session with analyze button for LLM insights
 
-### Export Options
+### CLI Stats Commands
 
-- Filter by: project, date range, session
-- Formats: Obsidian (with `[[links]]`), plain Markdown, Notion
+```bash
+code-insights stats              # Overview (last 7 days)
+code-insights stats cost         # Cost breakdown by project and model
+code-insights stats projects     # Per-project detail cards
+code-insights stats today        # Today's sessions with details
+code-insights stats models       # Model usage distribution
+```
 
 ## Tech Stack
 
-- **CLI**: Node.js CLI (runs standalone or as Claude Code hook)
-- **Database**: User's Firebase Firestore (session data) — auth handled by Supabase
-- **AI**: Multi-provider — OpenAI, Anthropic, Gemini, Ollama (user's own API keys)
-- **Web**: Next.js 16 + Tailwind CSS 4 + shadcn/ui
-- **Auth**: Supabase Auth (Google, GitHub OAuth)
-- **Hosting**: Vercel (dashboard), user's Firebase (data)
+- **CLI**: Node.js (ES2022, ES Modules), Commander.js
+- **Database**: SQLite (`better-sqlite3`) at `~/.code-insights/data.db` — WAL mode, local
+- **Server**: Hono — lightweight API server, serves dashboard SPA at `localhost:7890`
+- **Dashboard**: Vite + React 19 SPA, Tailwind CSS 4 + shadcn/ui
+- **AI**: Multi-provider — OpenAI, Anthropic, Gemini, Ollama (your own API keys, proxied server-side)
+- **Package manager**: pnpm (workspace monorepo: `cli/`, `dashboard/`, `server/`)
 
 ## Success Metrics
 
 - Time to first insight: < 5 minutes from install
 - User can answer "what did I work on this week?" in one click
 - Decisions are searchable and linkable
+- Zero cloud dependencies after install

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,29 +8,28 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 
 ## Phase 1: Foundation ✅
 
-**Goal:** Working end-to-end flow from JSONL to dashboard
+**Goal:** Working end-to-end flow from AI session files to local dashboard
 
 ### Milestones
 
 - [x] **1.1 Project Setup**
-  - Next.js project with Tailwind + shadcn/ui
-  - Firebase SDK integration (Admin for CLI, Client for web)
-  - Configuration system for user's Firebase credentials
-  - TypeScript strict mode, pnpm workspaces
+  - Single-repo pnpm workspace monorepo (`cli/`, `dashboard/`, `server/`)
+  - TypeScript strict mode, ES Modules
+  - Configuration system at `~/.code-insights/config.json`
 
-- [x] **1.2 JSONL Parser**
+- [x] **1.2 Claude Code Parser**
   - Parse Claude Code session files from `~/.claude/projects/`
   - Extract: sessions, messages, tool calls, timestamps
   - Smart session title generation (5-tier fallback)
   - Session character classification (7 types)
   - CLI command: `code-insights sync`
 
-- [x] **1.3 Firestore Schema & Sync**
-  - Document structure: projects, sessions, messages, insights
-  - Upload to user's Firestore via Admin SDK
-  - Incremental sync (tracks file modification times)
-  - Multi-device support (git remote-based project IDs)
-  - CLI command: `code-insights init` (Firebase setup wizard)
+- [x] **1.3 SQLite Schema & Sync**
+  - Local database at `~/.code-insights/data.db` (WAL mode)
+  - Tables: projects, sessions, messages, insights
+  - Incremental sync (tracks file modification times in `sync-state.json`)
+  - Stable project IDs derived from git remote URLs
+  - CLI command: `code-insights init`
 
 - [x] **1.4 Basic Dashboard**
   - Session list view with filters (project, date)
@@ -38,22 +37,15 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
   - Insights display by type
   - Analytics page with Recharts charts
 
-- [x] **1.5 Marketing Site & Documentation**
-  - Landing page at code-insights.app
-  - What it is, how it works, privacy model
-  - Docs site with guides, reference, and quick start
-  - Link to GitHub repo
-
 ### Deliverables
-- ✅ CLI tool that syncs sessions to Firestore
-- ✅ Web dashboard showing sessions and insights
-- ✅ Marketing site and docs at docs.code-insights.app
+- ✅ CLI tool that syncs sessions to local SQLite
+- ✅ Local web dashboard served by `code-insights dashboard`
 
 ---
 
 ## Phase 2: Integration ✅
 
-**Goal:** Seamless integration with Claude Code workflow
+**Goal:** Seamless integration with Claude Code workflow and terminal analytics
 
 ### Milestones
 
@@ -62,33 +54,21 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
   - Quiet mode for background processing (`sync -q`)
   - `code-insights install-hook` / `code-insights uninstall-hook`
 
-- [ ] **2.2 Slash Command**
-  - `/insights` - Quick summary of recent sessions
-  - `/insights today` - What you worked on today
-  - `/insights decisions` - Recent architectural decisions
-
-- [x] **2.3 Real-time Dashboard**
-  - Firestore real-time listeners via `onSnapshot`
-  - Live updates as sessions complete
-  - Custom React hooks: useProjects, useSessions, useInsights, useAnalytics
-
-- [x] **2.4 CLI Stats Command Suite**
+- [x] **2.2 CLI Stats Command Suite**
   - Terminal analytics: `stats`, `stats cost`, `stats projects`, `stats today`, `stats models`
-  - Dual data sources: local (zero-config) and Firestore
-  - Data source preference system (`config set-source local|firebase`)
+  - Powered by local SQLite — zero external dependencies
   - Unicode sparklines, bar charts, semantic colors, responsive layout
-  - Rich rendering with chalk, responsive to terminal width
+  - Shared flags: `--period`, `--project`, `--source`, `--no-sync`
 
-- [ ] **2.5 Enhanced Filtering**
+- [ ] **2.3 Enhanced Filtering**
   - Full-text search across sessions
-  - Filter by: project, git branch, date range, insight type
+  - Filter by: project, git branch, date range, insight type, source tool
   - Saved filters / bookmarks
 
 ### Deliverables
-- ✅ Auto-sync via Claude Code hooks
-- Slash commands (pending)
-- ✅ Real-time dashboard updates
-- ✅ CLI stats command suite with local-first analytics
+- ✅ Auto-sync via Claude Code hook
+- ✅ CLI stats command suite with local analytics
+- Enhanced filtering (pending)
 
 ---
 
@@ -104,7 +84,7 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
   - Anthropic (claude-sonnet, claude-haiku, claude-opus)
   - Google Gemini (gemini-2.0-flash, gemini-1.5-pro/flash)
   - Ollama for local models (llama3.2, mistral, codellama)
-  - User configures their own API key, stored in localStorage
+  - LLM calls proxied server-side via Hono API (no browser CORS)
   - Token input capped at 80k
 
 - [x] **3.2 Session Analysis**
@@ -131,58 +111,89 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 
 ---
 
-## Phase 4: Export & Sharing (Partially Complete)
+## Phase 4: Feature Parity ✅
 
-**Goal:** Get insights out of the dashboard into your workflow
+**Goal:** Port all dashboard features to the embedded local SPA and add multi-source support
 
 ### Milestones
 
-- [x] **4.1 Markdown Export**
+- [x] **4.1 Vite + React SPA Foundation**
+  - Vite SPA replacing Next.js (no SSR needed for localhost)
+  - Hono API server embedding the SPA
+  - React Query for server state, Tailwind CSS 4 + shadcn/ui
+
+- [x] **4.2 Multi-Source Provider Support**
+  - `SessionProvider` interface for source tool abstraction
+  - Providers: `claude-code`, `cursor`, `codex-cli`, `copilot-cli`
+  - `--source` filter flag in all stats and sync commands
+  - Source tool display in dashboard (colors, avatars, filters)
+
+- [x] **4.3 Dashboard Feature Parity**
+  - Sessions list with source, project, date, character filters
+  - Session detail with full message display and analyze button
+  - Analytics page with cost, models, projects breakdown
+  - Stats overview and project cards
+
+- [ ] **4.4 Markdown Export**
   - Export by: session, day, week, project
   - Formats: Plain Markdown, Obsidian (with wikilinks), Notion
   - Export page in dashboard
 
-- [ ] **4.2 Scheduled Reports**
-  - Weekly email digest (optional, user's email service)
-  - Export to file system on schedule
-  - Export reminder logic (partially implemented)
-
-- [ ] **4.3 API Access**
-  - REST API for programmatic access to insights
-  - Webhook support for external integrations
-
 ### Deliverables
-- ✅ Multi-format markdown export
-- Scheduled reports (partially implemented)
-- API for custom integrations (pending)
+- ✅ Embedded local dashboard via `code-insights dashboard`
+- ✅ Multi-source support (Claude Code, Cursor, Codex CLI, Copilot CLI)
+- ✅ Full feature parity with original hosted dashboard
+- Markdown export (in progress)
 
 ---
 
-## Phase 5: Community
+## Phase 5: Telemetry (In Progress)
 
-**Goal:** Enable community contributions and customization
+**Goal:** Anonymous, opt-in usage signals to improve the tool without compromising privacy
 
 ### Milestones
 
-- [ ] **5.1 Plugin Architecture**
+- [ ] **5.1 Anonymous Aggregate Signals**
+  - Opt-in only, disabled by default
+  - Local export only — no phone-home during normal usage
+  - Depth metrics: sessions analyzed, insights generated
+
+- [ ] **5.2 Slash Commands**
+  - `/insights` — Quick summary of recent sessions
+  - `/insights today` — What you worked on today
+  - `/insights decisions` — Recent architectural decisions
+
+### Deliverables
+- Anonymous telemetry (opt-in, pending)
+- Slash commands (pending)
+
+---
+
+## Phase 6: Polish & Distribution
+
+**Goal:** Production-ready distribution and community foundation
+
+### Milestones
+
+- [ ] **6.1 npm Distribution**
+  - Publish as `@code-insights/cli`
+  - Binary: `code-insights`
+  - Pre-built dashboard SPA bundled in the package
+
+- [ ] **6.2 Plugin Architecture**
   - Custom insight extractors
   - Dashboard widget API
   - Theme support
 
-- [ ] **5.2 Shared Templates**
+- [ ] **6.3 Community**
+  - Static landing page at `code-insights.app`
+  - Comprehensive setup guide and API documentation
   - Community-contributed export templates
-  - Insight pattern libraries
-  - Dashboard layouts
-
-- [ ] **5.3 Documentation**
-  - Comprehensive setup guide
-  - API documentation
-  - Contribution guidelines (done: CONTRIBUTING.md)
 
 ### Deliverables
-- Extensible plugin system
-- Community template library
-- Full documentation
+- Published npm package
+- Plugin architecture foundation
+- Community documentation
 
 ---
 
@@ -190,14 +201,14 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 
 | Version | Phase | Key Features | Status |
 |---------|-------|--------------|--------|
-| 0.1.0 | 1 | CLI sync, basic dashboard | ✅ Done |
-| 0.2.0 | 1 | Firestore integration, smart titles | ✅ Done |
-| 0.3.0 | 2 | Claude Code hook, real-time updates | ✅ Done |
+| 0.1.0 | 1 | CLI sync, SQLite schema, basic dashboard | ✅ Done |
+| 0.2.0 | 1 | Smart titles, session classification | ✅ Done |
+| 0.3.0 | 2 | Claude Code hook, CLI stats commands | ✅ Done |
 | 0.4.0 | 3 | Multi-LLM analysis, bulk analyze | ✅ Done |
-| 0.5.0 | 4 | Markdown export | ✅ Done |
-| 0.6.0 | 2 | CLI stats commands, data source preference | ✅ Done |
-| 0.7.0 | 4 | Scheduled reports, API access | Planned |
-| 1.0.0 | 5 | Plugin architecture, community features | Planned |
+| 0.5.0 | 4 | Vite SPA + Hono server, embedded dashboard | ✅ Done |
+| 0.6.0 | 4 | Multi-source support (Cursor, Codex, Copilot CLI) | ✅ Done |
+| 0.7.0 | 4-5 | Markdown export, slash commands | Planned |
+| 1.0.0 | 6 | npm publish, plugin architecture | Planned |
 
 ---
 
@@ -208,6 +219,6 @@ This is an open source project. Contributions welcome!
 - **Issues**: Bug reports, feature requests
 - **PRs**: Code contributions (please discuss first for large changes)
 - **Docs**: Improvements to documentation
-- **Templates**: Export templates, insight patterns
+- **Providers**: New source tool providers
 
 See CONTRIBUTING.md for guidelines.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -2,71 +2,86 @@
 
 ## Philosophy
 
-**Your data, your infrastructure, your insights.**
+**Your data, your machine, your insights.**
 
-Code Insights is a tool that helps Claude Code users understand their AI-assisted development patterns. It's built on a simple principle: developers should own their data completely.
+Code Insights is a free, open-source tool that helps developers who use multiple AI coding tools analyze their sessions, collect insights, track decisions and learnings, and build knowledge over time. It's built on a simple principle: your session data never leaves your machine.
 
 ## Core Beliefs
 
 ### 1. Privacy by Architecture
 
-There is no central Code Insights data server. Users connect the CLI tool to their own Firebase project. Session data never leaves their control. The hosted dashboard only reads from the user's Firestore — authentication is handled by Supabase Auth, and the dashboard collects anonymous aggregate analytics via Vercel Analytics, but never touches your Claude Code data.
+There is no central Code Insights server. No accounts, no sign-ups, no cloud. All session data lives in a local SQLite database at `~/.code-insights/data.db`. The dashboard runs locally at `http://localhost:7890` — it never phones home.
 
 ### 2. Developers Can Handle It
 
-Claude Code users are technical. They can:
-- Create a Firebase project
-- Copy configuration keys
-- Run a CLI command
+Developers using AI coding tools are technical. They can:
+- Run `code-insights init` and answer three questions
+- Install a post-session hook with one command
+- Open a local dashboard that just works
 
 We don't need to hide complexity behind a managed service. Clear documentation beats magic.
 
-### 3. Two-Repo Model
+### 3. Single-Repo, Local-First
 
-- **CLI** (open source, MIT) — The parser and sync engine. Community-driven, transparent.
-- **Web Dashboard** (closed source) — The visualization layer. Hosted on Vercel, free to use.
+Everything ships in one repository:
+- **CLI** (open source, MIT) — the parser, sync engine, and stats commands
+- **Dashboard** (embedded SPA) — served locally by a Hono server via `code-insights dashboard`
+- **Server** (local API) — Hono API on `localhost:7890`, proxies LLM calls server-side
+
+No hosted infrastructure. No Vercel. No Firebase. No Supabase. One install, zero cloud dependencies.
 
 ### 4. Tool, Not Platform
 
 Code Insights is a utility, not a product. It should:
-- Do one thing well (extract insights from Claude sessions)
+- Do one thing well (extract insights from AI coding sessions)
+- Support multiple source tools (Claude Code, Cursor, Codex CLI, Copilot CLI)
 - Be easy to install and configure
 - Stay out of the way once set up
 
 ## Long-Term Direction
 
 ### Phase 1: Foundation ✅
-- CLI tool that parses JSONL → Firestore
+- CLI tool that parses JSONL → SQLite
 - Web dashboard with session views, character classification, smart titles
-- Manual export to Markdown formats
+- Claude Code hook for automatic session sync
 
 ### Phase 2: Integration ✅
-- Claude Code hook for automatic session sync
-- Real-time dashboard updates via Firestore subscriptions
-- CLI `insights` command for quick terminal views
+- Auto-sync via Claude Code post-session hook
+- CLI stats command suite (`stats`, `stats cost`, `stats projects`, `stats today`, `stats models`)
+- Terminal analytics powered by local SQLite
 
 ### Phase 3: Intelligence ✅
 - Multi-provider LLM analysis (OpenAI, Anthropic, Gemini, Ollama)
 - On-demand and bulk session analysis
 - Cross-session insight types (summary, decision, learning, technique)
 
-### Phase 4: Community
-- Shareable insight templates
-- Plugin architecture for custom extractors
-- Community-contributed dashboard widgets
+### Phase 4: Feature Parity ✅
+- Vite + React SPA replacing the hosted web dashboard
+- Hono server embedding the SPA — served via `code-insights dashboard`
+- Multi-source support: Claude Code, Cursor, Codex CLI, Copilot CLI
+- Full feature parity between CLI stats and dashboard views
+
+### Phase 5: Telemetry (In Progress)
+- Anonymous aggregate usage signals (opt-in, local-only export)
+- Depth metrics: sessions analyzed, insights generated, knowledge retained
+
+### Phase 6: Polish & Distribution
+- npm publish as `@code-insights/cli`
+- Static landing page at `code-insights.app`
+- Contribution guidelines and plugin architecture foundation
 
 ## Non-Goals
 
-- **Not a business** - No monetization, no paywall, no premium tier
-- **Not a central platform** - No central database for user session data
-- **Not a dependency** - Users can stop using it anytime, data remains theirs
-- **Not comprehensive** - Focus on Claude Code, not every AI tool
+- **Not a business** — No monetization, no paywall, no premium tier
+- **Not a central platform** — No central database for user session data
+- **Not a dependency** — Users can stop using it anytime, data remains theirs
+- **Not a team tool** — This is a personal learning tool; no org/team features
 
 ## Success Looks Like
 
-A developer installs Code Insights, spends 10 minutes on Firebase setup, and from then on has a personal dashboard showing:
-- What they built with Claude this week
+A developer installs Code Insights, runs `code-insights init`, installs the hook, and from then on has a local dashboard showing:
+- What they built with AI coding tools this week
 - Key decisions and why they made them
-- Patterns in how they use AI assistance
+- Patterns in how they use AI assistance across tools
 
 They own all the data. They can export it. They can delete it. They can modify the CLI tool. Complete autonomy.


### PR DESCRIPTION
## What
Update three core product docs to remove all stale cloud-era references and align with the current local-first architecture. Closes #58.

## Why
VISION.md, PRODUCT.md, and ROADMAP.md still referenced Firebase, Firestore, Supabase, Vercel, Next.js, and a two-repo model — none of which exist in the current architecture. These docs were misleading for contributors and anyone reading the project.

## How
- Rewrote VISION.md: replaced BYOF/Firebase model with local-first description, updated phases to match actual delivered state, removed "Not comprehensive — Focus on Claude Code" non-goal (multi-source is shipped)
- Rewrote PRODUCT.md: corrected privacy model (SQLite, no cloud), updated tech stack (Hono, Vite+React, SQLite), expanded "Who It's For" to all AI coding tool users, added multi-source support table and CLI stats section
- Rewrote ROADMAP.md: replaced all Firestore/Firebase milestones with SQLite equivalents, renamed Phase 4 to "Feature Parity" (not "Export & Sharing"), added multi-source support milestones, updated version milestone table

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes (docs only)

## Testing
- Grepped all three files for Firebase/Firestore/Supabase/Vercel/Next.js/BYOF/localStorage — no stale references remain
- `pnpm build` passes across the workspace (CLI, server, dashboard)

## CI Gate
`pnpm build` — passing