### PR TITLE
feat(telemetry): add dashboard_started, analysis_run, and export_run events

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,8 @@
     "./types": "./dist/types.js",
     "./utils/config": "./dist/utils/config.js",
     "./utils/browser": "./dist/utils/browser.js",
-    "./constants/llm-providers": "./dist/constants/llm-providers.js"
+    "./constants/llm-providers": "./dist/constants/llm-providers.js",
+    "./utils/telemetry": "./dist/utils/telemetry.js"
   },
   "bin": {
     "code-insights": "./dist/index.js"

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs';
 import chalk from 'chalk';
 import ora from 'ora';
 import net from 'net';
+import { trackEvent } from '../utils/telemetry.js';
 
 interface DashboardOptions {
   port: string;
@@ -87,6 +88,7 @@ export async function dashboardCommand(options: DashboardOptions): Promise<void>
 
     spinner.stop();
 
+    trackEvent('dashboard', true, 'started');
     await startServer({ port, staticDir, openBrowser: options.open });
   } catch (err) {
     spinner.fail('Failed to start dashboard server.');

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getDb } from '@code-insights/cli/db/client';
+import { trackEvent } from '@code-insights/cli/utils/telemetry';
 import { parseIntParam } from '../utils.js';
 import { analyzeSession, analyzePromptQuality, findRecurringInsights } from '../llm/analysis.js';
 import { isLLMConfigured } from '../llm/client.js';
@@ -40,6 +41,7 @@ app.post('/session', async (c) => {
   `).all(body.sessionId) as SQLiteMessageRow[];
 
   const result = await analyzeSession(session, messages);
+  if (result.success) trackEvent('analysis', true, 'session');
   return c.json(result, result.success ? 200 : 422);
 });
 
@@ -76,6 +78,7 @@ app.post('/prompt-quality', async (c) => {
   `).all(body.sessionId) as SQLiteMessageRow[];
 
   const result = await analyzePromptQuality(session, messages);
+  if (result.success) trackEvent('analysis', true, 'prompt-quality');
   return c.json(result, result.success ? 200 : 422);
 });
 
@@ -120,6 +123,7 @@ app.post('/recurring', async (c) => {
   }>;
 
   const result = await findRecurringInsights(insights);
+  if (result.success) trackEvent('analysis', true, 'recurring');
   return c.json(result, result.success ? 200 : 422);
 });
 

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getDb } from '@code-insights/cli/db/client';
+import { trackEvent } from '@code-insights/cli/utils/telemetry';
 
 const app = new Hono();
 
@@ -53,6 +54,7 @@ app.post('/markdown', async (c) => {
   }
 
   const markdown = lines.join('\n');
+  trackEvent('export', true, 'markdown');
   c.header('Content-Type', 'text/markdown');
   return c.body(markdown);
 });


### PR DESCRIPTION
## What

Adds 3 new telemetry events to track key user actions: `dashboard_started`, `analysis_run`, and `export_run`.

## Why

GitHub Issue #64 — Phase 5 telemetry. These events fill gaps in understanding how users interact with the dashboard and its LLM analysis/export features. The existing telemetry system only covered CLI sync commands.

## How

- **`dashboard_started`** (`cli/src/commands/dashboard.ts`): Fires after the server module loads and the spinner stops, before `startServer()` is awaited. Signals a user is actively running the dashboard (not just syncing).

- **`analysis_run`** (`server/src/routes/analysis.ts`): Fires on the success path of each analysis endpoint (`/session`, `/prompt-quality`, `/recurring`). Uses the subcommand field to distinguish types. Only fires when `result.success === true` — failed LLM calls are not counted.

- **`export_run`** (`server/src/routes/export.ts`): Fires after markdown content is assembled on the success path.

- **Export path added** (`cli/package.json`): Added `./utils/telemetry` export so server routes can import `trackEvent` from `@code-insights/cli/utils/telemetry` without duplicating the implementation.

All events use the existing `trackEvent(command, success, subcommand?)` signature which already handles `isTelemetryEnabled()` gating and is fire-and-forget (never awaited).

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes

## Testing

- `pnpm build` passes across the full workspace (CLI + server + dashboard)
- Events follow identical pattern to existing `trackEvent` calls in the codebase
- Server routes import from `@code-insights/cli/utils/telemetry` (workspace dep already present in server/package.json)

Closes #64