### PR TITLE
feat(cli): HMAC-SHA256 signing for telemetry endpoint v2

### DIFF
--- a/cli/src/utils/telemetry.ts
+++ b/cli/src/utils/telemetry.ts
@@ -5,7 +5,14 @@ import * as crypto from 'crypto';
 import { createRequire } from 'module';
 import { loadConfig, getConfigDir, getClaudeDir } from './config.js';
 
-const TELEMETRY_ENDPOINT = 'https://xrbkoqjfolxiyfxubiom.supabase.co/functions/v1/cli-telemetry';
+const TELEMETRY_ENDPOINT = 'https://xrbkoqjfolxiyfxubiom.supabase.co/functions/v1/cli-telemetry-v2';
+
+// HMAC signing key for request integrity.
+// This is a deterrent, NOT a security boundary — npm packages are public and this key
+// is extractable. The real security is enforced server-side in the Edge Function.
+// Rotation: bump the endpoint version (cli-telemetry-v3) to rotate the key.
+// The Edge Function accepts keys as a Supabase secret (HMAC_KEYS env var), not hardcoded.
+const HMAC_KEY = 'fb73eabc121b8fe0bde2eb6f8a2d09c21bf74708d2148d7a520bb00661f03b7f';
 
 // Touch file path that tracks whether the one-time disclosure has been shown
 const NOTICE_FILE = path.join(getConfigDir(), '.telemetry-notice-shown');
@@ -302,6 +309,19 @@ function detectHook(): boolean {
 }
 
 /**
+ * Sign the request body with HMAC-SHA256.
+ * Returns the hex digest prefixed with 'sha256=' for the X-Signature header.
+ *
+ * Note: the key is public (extractable from the npm package) — this is a deterrent
+ * against casual data poisoning, not a cryptographic secret. Security is enforced
+ * server-side in the Edge Function using constant-time comparison.
+ */
+function signPayload(body: string): string {
+  const digest = crypto.createHmac('sha256', HMAC_KEY).update(body).digest('hex');
+  return `sha256=${digest}`;
+}
+
+/**
  * Internal: Send the event to the telemetry endpoint.
  * AbortController ensures we don't hang longer than 2 seconds.
  * All errors are swallowed — telemetry failures must never propagate.
@@ -312,10 +332,17 @@ async function sendEvent(event: TelemetryEvent): Promise<void> {
   const timer = setTimeout(() => controller.abort(), 2000);
 
   try {
+    const body = JSON.stringify(event);
     await fetch(TELEMETRY_ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(event),
+      headers: {
+        'Content-Type': 'application/json',
+        // HMAC signature — lets the Edge Function verify the payload wasn't tampered.
+        // The v2 endpoint accepts but does not require this header initially, allowing
+        // older CLI versions (which don't send it) to continue working.
+        'X-Signature': signPayload(body),
+      },
+      body,
       signal: controller.signal,
     });
   } catch {


### PR DESCRIPTION
## What
Adds HMAC-SHA256 request signing to the CLI telemetry client and updates the endpoint from `cli-telemetry` (v1) to `cli-telemetry-v2`.

## Why
The current telemetry endpoint accepts unauthenticated POSTs from any caller with the URL. Anyone who discovers the endpoint can poison the analytics data with arbitrary payloads. This PR adds a deterrent-level HMAC signature that the new Edge Function can verify.

## How
- Embed a static HMAC key constant (`HMAC_KEY`) directly in `telemetry.ts` — this is a public deterrent (the npm package is public), not a cryptographic secret
- Add `signPayload(body)` using Node's built-in `crypto.createHmac('sha256', key)`
- Update `sendEvent()` to serialize the event body first, sign it, then POST with `X-Signature: sha256=<hex>` header
- Update `TELEMETRY_ENDPOINT` to `cli-telemetry-v2`

The v2 Edge Function accepts but does not require the signature header, maintaining backward compatibility with older CLI versions that don't send it.

## Schema Impact
- [ ] SQLite schema changed: **no**
- [ ] Types changed: **no** (`TelemetryEvent` is module-internal, unchanged)
- [ ] Server API changed: **no**
- [ ] Backward compatible: **yes** — v1 endpoint remains live; v2 accepts requests without signature

## Testing
- `pnpm build` passes across the full monorepo workspace
- The only changed file is `cli/src/utils/telemetry.ts`
- HMAC signing uses Node's built-in `crypto` module (already imported) — no new dependencies

## Companion PR
The server-side Edge Function is in the private web repo:
`melagiri/code-insights-web` — `feature/secure-supabase-telemetry`

That PR contains:
- `supabase/functions/cli-telemetry-v2/index.ts` — Edge Function with schema validation, HMAC verification, rate limiting
- `supabase/migrations/20260228000000_telemetry_rls_and_rate_limiting.sql` — RLS + ip_hash column + indexes
- `supabase/config.toml` — Supabase CLI project config

## Deployment Note
After this CLI PR merges and publishes as a new npm version, the Edge Function can be tightened to require the HMAC header. That tightening happens in the web repo, no CLI change needed.

**Secrets to set (never in source):**
```
supabase secrets set HMAC_KEYS='["fb73eabc121b8fe0bde2eb6f8a2d09c21bf74708d2148d7a520bb00661f03b7f"]'
supabase secrets set RATE_LIMIT_PER_IP_HOUR=60
supabase secrets set RATE_LIMIT_PER_MACHINE_DAY=200
```

Closes #72 (partial — companion web repo PR must also merge)