### PR TITLE
Fix sync to update existing sessions

### DIFF
--- a/cli/src/commands/sync.test.ts
+++ b/cli/src/commands/sync.test.ts
@@ -20,16 +20,11 @@ vi.mock('../db/client.js', () => ({
   getDb: () => ({}),
 }));
 
-const sessionExists = vi.fn();
-vi.mock('../db/read.js', () => ({
-  sessionExists,
-}));
-
-const insertSessionWithProject = vi.fn();
+const insertSessionWithProjectAndReturnIsNew = vi.fn();
 const insertMessages = vi.fn();
 const recalculateUsageStats = vi.fn(() => ({ sessionsWithUsage: 0, totalTokens: 0, estimatedCostUsd: 0 }));
 vi.mock('../db/write.js', () => ({
-  insertSessionWithProject,
+  insertSessionWithProjectAndReturnIsNew,
   insertMessages,
   recalculateUsageStats,
 }));
@@ -57,8 +52,7 @@ describe('runSync', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-sync-'));
     syncState = { lastSync: '', files: {} };
     saveSyncState.mockClear();
-    sessionExists.mockReset();
-    insertSessionWithProject.mockReset();
+    insertSessionWithProjectAndReturnIsNew.mockReset();
     insertMessages.mockReset();
     recalculateUsageStats.mockClear();
     getAllProviders.mockReset();
@@ -96,12 +90,12 @@ describe('runSync', () => {
       },
     ]);
 
-    sessionExists.mockReturnValue(true);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
 
     await runSync({ quiet: true });
 
-    expect(insertSessionWithProject).toHaveBeenCalledTimes(1);
-    expect(insertSessionWithProject).toHaveBeenCalledWith(
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledTimes(1);
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-1' }),
       false,
     );
@@ -140,11 +134,11 @@ describe('runSync', () => {
       },
     ]);
 
-    sessionExists.mockReturnValue(true);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
 
     await runSync({ quiet: true });
 
-    expect(insertSessionWithProject).toHaveBeenCalledWith(
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'cursor:composer-1' }),
       false,
     );
@@ -173,11 +167,11 @@ describe('runSync', () => {
       },
     ]);
 
-    sessionExists.mockReturnValue(false);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(true);
 
     await runSync({ quiet: true });
 
-    expect(insertSessionWithProject).toHaveBeenCalledTimes(1);
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledTimes(1);
     expect(recalculateUsageStats).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -4,8 +4,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { loadSyncState, saveSyncState } from '../utils/config.js';
 import { trackEvent } from '../utils/telemetry.js';
-import { insertSessionWithProject, insertMessages, recalculateUsageStats } from '../db/write.js';
-import { sessionExists } from '../db/read.js';
+import { insertSessionWithProjectAndReturnIsNew, insertMessages, recalculateUsageStats } from '../db/write.js';
 import { getDb } from '../db/client.js';
 import { getAllProviders, getProvider } from '../providers/registry.js';
 import { setProviderVerbose } from '../providers/context.js';
@@ -27,6 +26,7 @@ export interface SyncResult {
   syncedCount: number;
   messageCount: number;
   errorCount: number;
+  updatedExistingCount: number;
 }
 
 /**
@@ -142,6 +142,7 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
 
       // Process files — accumulate per-provider counts, show one summary line after
       let providerSyncedCount = 0;
+      let providerUpdatedCount = 0;
       let providerSkippedCount = 0;
       let providerMessageCount = 0;
 
@@ -157,10 +158,8 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
             continue;
           }
 
-          const exists = sessionExists(session.id);
-
           // Write session and messages to SQLite
-          insertSessionWithProject(session, !!options.force);
+          const isNew = insertSessionWithProjectAndReturnIsNew(session, !!options.force);
           insertMessages(session);
 
           // Update and persist sync state after each file
@@ -168,7 +167,8 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
           updateSyncState(syncState, filePath, session.id);
           saveSyncState(syncState);
 
-          if (exists && !options.force) {
+          if (!isNew && !options.force) {
+            providerUpdatedCount++;
             totalUpdatedExisting++;
           }
 
@@ -188,9 +188,12 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
       // One summary line per provider instead of per-file noise
       spinner.stop();
       if (providerSyncedCount > 0 || providerSkippedCount > 0) {
-        const syncedPart = providerSyncedCount > 0
-          ? `${providerSyncedCount} synced (${providerMessageCount.toLocaleString()} messages)`
-          : `0 synced`;
+        const providerNewCount = providerSyncedCount - providerUpdatedCount;
+        const parts: string[] = [];
+        if (providerNewCount > 0) parts.push(`${providerNewCount} new`);
+        if (providerUpdatedCount > 0) parts.push(`${providerUpdatedCount} updated`);
+        if (parts.length === 0) parts.push('0 synced');
+        const syncedPart = `${parts.join(', ')}${providerMessageCount > 0 ? ` (${providerMessageCount.toLocaleString()} messages)` : ''}`;
         const skippedPart = providerSkippedCount > 0
           ? `, ${providerSkippedCount} empty`
           : '';
@@ -231,6 +234,7 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
     syncedCount: totalSyncedCount,
     messageCount: totalMessageCount,
     errorCount: totalErrorCount,
+    updatedExistingCount: totalUpdatedExisting,
   };
 }
 
@@ -250,7 +254,11 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
       return;
     }
     log(chalk.cyan('\n  Sync Summary'));
-    log(chalk.white(`  Sessions synced: ${result.syncedCount}`));
+    const newCount = Math.max(result.syncedCount - result.updatedExistingCount, 0);
+    log(chalk.white(`  Sessions new: ${newCount}`));
+    if (result.updatedExistingCount > 0) {
+      log(chalk.white(`  Sessions updated: ${result.updatedExistingCount}`));
+    }
     log(chalk.white(`  Messages synced: ${result.messageCount}`));
     if (result.errorCount > 0) {
       log(chalk.red(`  Errors: ${result.errorCount}`));

--- a/cli/src/db/write.ts
+++ b/cli/src/db/write.ts
@@ -165,6 +165,18 @@ function getStmts() {
  * incrementally added — they'll be recalculated via recalculateUsageStats().
  */
 export function insertSessionWithProject(session: ParsedSession, isForce = false): void {
+  insertSessionWithProjectInternal(session, isForce);
+}
+
+/**
+ * Insert a session and return whether it was new to the DB.
+ * Lets callers avoid a duplicate sessionExists() query.
+ */
+export function insertSessionWithProjectAndReturnIsNew(session: ParsedSession, isForce = false): boolean {
+  return insertSessionWithProjectInternal(session, isForce);
+}
+
+function insertSessionWithProjectInternal(session: ParsedSession, isForce: boolean): boolean {
   const db = getDb();
   const { projectId, source: projectIdSource, gitRemoteUrl } = generateStableProjectId(session.projectPath);
   const deviceInfo = getDeviceInfo();
@@ -180,6 +192,7 @@ export function insertSessionWithProject(session: ParsedSession, isForce = false
   });
 
   tx();
+  return isNew;
 }
 
 


### PR DESCRIPTION
## Summary
- Update sync to update existing sessions by default and refresh virtual-path sessions when the backing DB changes.
- Recalculate usage stats only when existing sessions were updated (or on --force).
- Add sync tests covering existing-session updates, virtual-path refresh, and no recalc on new-only syncs.
- Optimize DB check by returning isNew from insertSessionWithProject and use it in sync.
- Improve sync summary output to show new vs updated sessions.

## Testing
- pnpm -C cli test