### PR TITLE
fix: parse Codex CLI input_text content type

### DIFF
--- a/cli/src/providers/codex.ts
+++ b/cli/src/providers/codex.ts
@@ -460,7 +460,7 @@ function extractUserContent(payload: Record<string, unknown>): string | null {
   if (typeof payload.content === 'string') return payload.content;
   if (Array.isArray(payload.content)) {
     return (payload.content as Array<Record<string, string>>)
-      .filter(c => c.type === 'text')
+      .filter(c => c.type === 'text' || c.type === 'input_text')
       .map(c => c.text)
       .join('\n');
   }


### PR DESCRIPTION
## Summary
- Codex CLI uses OpenAI's Responses API format where user message content items have `type: "input_text"` instead of `type: "text"`
- The `extractUserContent()` function in the codex provider only checked for `"text"`, causing all 9 session files to be parsed as empty and discarded
- Single-line fix: also accept `"input_text"` content type

## Test plan
- [x] `pnpm build` passes
- [ ] Run `code-insights sync --source codex-cli` and verify sessions are now parsed
- [ ] Run `code-insights stats --source codex-cli` and verify sessions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)