### PR TITLE
fix(cli): rewrite Codex CLI parser to handle current JSONL format

### DIFF
--- a/cli/src/providers/codex.ts
+++ b/cli/src/providers/codex.ts
@@ -62,12 +62,13 @@ function getCodexHome(): string | null {
  * Format A lives at: sessions/YYYY/MM/DD/rollout-<timestamp>-<uuid>.jsonl
  * Format B lives at: sessions/rollout-<date>-<uuid>.json (flat)
  */
-function collectRolloutFiles(dir: string, files: string[]): void {
+function collectRolloutFiles(dir: string, files: string[], depth = 0): void {
+  if (depth > 10) return; // Guard against symlink loops
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      collectRolloutFiles(fullPath, files);
+      collectRolloutFiles(fullPath, files, depth + 1);
     } else if (
       (entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) ||
       (entry.name.startsWith('rollout-') && entry.name.endsWith('.json'))
@@ -143,6 +144,7 @@ interface FormatBSession {
   session: {
     timestamp: string;
     id: string;
+    cwd?: string;
     instructions?: string;
     model?: string;
   };
@@ -175,12 +177,13 @@ function parseCodexSession(filePath: string): ParsedSession | null {
     const content = fs.readFileSync(filePath, 'utf-8').trim();
     if (!content) return null;
 
-    // Detect format: Format B starts with '{' (single JSON object)
-    if (content.startsWith('{')) {
-      return parseFormatB(filePath, content);
+    // Detect format by file extension — content-sniffing is unreliable because
+    // JSONL files also start with '{' on line 1 (the session_meta object).
+    if (filePath.endsWith('.json')) {
+      return parseFormatB(content);
     }
 
-    return parseFormatA(filePath, content);
+    return parseFormatA(content);
   } catch {
     return null;
   }
@@ -190,7 +193,7 @@ function parseCodexSession(filePath: string): ParsedSession | null {
 // Format A parser (v0.104.0+ JSONL with envelope/payload structure)
 // ---------------------------------------------------------------------------
 
-function parseFormatA(filePath: string, content: string): ParsedSession | null {
+function parseFormatA(content: string): ParsedSession | null {
   const lines = content.split('\n').filter(line => line.trim());
   if (lines.length === 0) return null;
 
@@ -273,25 +276,7 @@ function parseFormatA(filePath: string, content: string): ParsedSession | null {
           break;
         }
 
-        if (role === 'user') {
-          flushAssistantTurn();
-          const userContent = extractContent(payload);
-          if (userContent && !isSystemContextMessage(userContent)) {
-            messages.push({
-              id: (payload.id as string) || `codex-user-${messages.length}`,
-              sessionId: sessionId,
-              type: 'user',
-              content: userContent.slice(0, 10000),
-              thinking: null,
-              toolCalls: [],
-              toolResults: [],
-              usage: null,
-              timestamp: parseEnvelopeTimestamp(event) || lastTimestamp,
-              parentId: null,
-            });
-            lastTimestamp = messages[messages.length - 1].timestamp;
-          }
-        } else if (role === 'assistant') {
+        if (role === 'assistant') {
           // response_item assistant message: content has output_text items
           const assistantContent = extractContent(payload);
           if (assistantContent) {
@@ -299,6 +284,9 @@ function parseFormatA(filePath: string, content: string): ParsedSession | null {
           }
           lastTimestamp = parseEnvelopeTimestamp(event) || lastTimestamp;
         }
+        // Skip role === 'user' — handled by event_msg/user_message case.
+        // Both response_item/message(role=user) and event_msg/user_message fire for
+        // every user prompt, so only capturing from one source avoids doubling the count.
         break;
       }
 
@@ -327,9 +315,9 @@ function parseFormatA(filePath: string, content: string): ParsedSession | null {
       }
 
       case 'agent_message': {
-        // event_msg/agent_message: primary source of assistant text output
-        const agentText = (payload.message as string) || '';
-        if (agentText) currentAssistantText += agentText + '\n';
+        // event_msg/agent_message fires alongside response_item/message(role=assistant).
+        // Text is already captured via that handler — only update timestamp here to
+        // avoid duplicating assistant content.
         lastTimestamp = parseEnvelopeTimestamp(event) || lastTimestamp;
         break;
       }
@@ -458,6 +446,9 @@ function parseFormatA(filePath: string, content: string): ParsedSession | null {
       case 'turn_context':
         // Lifecycle/telemetry events — skip
         break;
+
+      default:
+        break;
     }
   }
 
@@ -471,7 +462,7 @@ function parseFormatA(filePath: string, content: string): ParsedSession | null {
 // Format B parser (pre-2025 single JSON object: { session, items })
 // ---------------------------------------------------------------------------
 
-function parseFormatB(filePath: string, content: string): ParsedSession | null {
+function parseFormatB(content: string): ParsedSession | null {
   let parsed: FormatBSession;
   try {
     parsed = JSON.parse(content) as FormatBSession;
@@ -601,7 +592,8 @@ function parseFormatB(filePath: string, content: string): ParsedSession | null {
   // Flush any remaining assistant content
   flushAssistantTurn();
 
-  return buildSession(sessionId, 'codex://unknown', null, sessionTimestamp, messages, usageEntries, model);
+  const projectPath = parsed.session.cwd || 'codex://unknown';
+  return buildSession(sessionId, projectPath, null, sessionTimestamp, messages, usageEntries, model);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Complete rewrite of `cli/src/providers/codex.ts` to correctly parse both Codex CLI session formats. The old parser produced 0 assistant messages, 0 tool calls, and collapsed all timestamps.

## Why

The parser was written for a hypothetical intermediate format that doesn't match what Codex CLI v0.104.0+ actually emits. From the format analysis: 9 sessions with 46 messages, all user — 100% of assistant content, tool calls, and tool results were silently dropped.

## How

**Format A fixes (v0.104.0+ JSONL):**
- Added 6 missing switch cases: `function_call`, `function_call_output`, `custom_tool_call`, `custom_tool_call_output`, `agent_message`, `task_complete`
- Fixed `extractContent()` to handle `output_text` content type (assistant messages use this, not `input_text`)
- Fixed `agent_reasoning` to accumulate thinking text correctly
- Timestamps: use `event.timestamp` (envelope-level ISO 8601 present on every line) instead of only `meta.timestamp`
- Filter `developer` role messages — system prompts/permissions, not real content
- Filter context-injection `user` role messages (AGENTS.md, environment_context blocks) via `isSystemContextMessage()`
- Kept `turn.completed` case for backward compat with any older versions

**Format B support (pre-2025 `.json` files):**
- Discovery: `collectRolloutFiles()` now accepts `.json` extension alongside `.jsonl`
- Parse detection: if content starts with `{` it's Format B (single JSON object)
- `parseFormatB()` handles `{ session, items }` structure with bare `function_call`, `function_call_output`, and `reasoning` items
- Shared `buildSession()` helper avoids duplicating session aggregation logic

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes — only changes the parser internals; SQLite write path is unchanged

## Testing

```bash
pnpm build   # passes cleanly — all 3 packages (cli, server, dashboard)
```

Manual verification (if Codex CLI sessions exist on the machine):
```bash
code-insights sync --force --source codex-cli --dry-run
```