### PR TITLE
fix(cursor): fix 3 data quality issues — project names, Lexical JSON, URI objects

### DIFF
--- a/cli/src/providers/cursor.ts
+++ b/cli/src/providers/cursor.ts
@@ -188,7 +188,7 @@ function extractLexicalText(input: unknown): string | null {
   let parsed: unknown = input;
   if (typeof input === 'string') {
     // Quick guard: Lexical JSON always starts with {"root"
-    if (!input.startsWith('{') || !input.includes('"root"')) return null;
+    if (!input.startsWith('{"root"')) return null;
     try {
       parsed = JSON.parse(input);
     } catch {
@@ -201,7 +201,7 @@ function extractLexicalText(input: unknown): string | null {
   const root = obj.root as Record<string, unknown>;
   if (!Array.isArray(root.children)) return null;
 
-  const text = collectLexicalText(root.children as Array<Record<string, unknown>>);
+  const text = collectLexicalText(root.children as Array<Record<string, unknown>>).trim();
   return text.length > 0 ? text : null;
 }
 
@@ -216,7 +216,13 @@ function collectLexicalText(nodes: Array<Record<string, unknown>>): string {
     }
     if (Array.isArray(node.children)) {
       const childText = collectLexicalText(node.children as Array<Record<string, unknown>>);
-      if (childText) parts.push(childText);
+      if (childText) {
+        parts.push(childText);
+        // Preserve paragraph boundaries for block-level nodes
+        if (typeof node.type === 'string' && ['paragraph', 'heading', 'list-item', 'quote'].includes(node.type)) {
+          parts.push('\n');
+        }
+      }
     }
   }
   return parts.join('');
@@ -673,7 +679,7 @@ function parseBubbles(conversation: Array<Record<string, unknown>>, sessionId: s
       } else {
         content = typeof bubble.richText === 'string'
           ? bubble.richText
-          : String(bubble.richText ?? '');
+          : '';
       }
     } else {
       content = contentField;


### PR DESCRIPTION
## What

Fixes 3 data quality issues in the Cursor provider that were causing broken data in the dashboard, as documented in `docs/source-tool-format-analysis.md`.

## Why

All 55 Cursor sessions were showing `project_name = "global"`, 20% of user messages were rendering as raw Lexical JSON instead of text, and all code edit tool calls showed `[object Object]` as the file path. The dashboard was essentially unusable for Cursor sessions.

## How

**Issue 1 — All projects = "global":**
- Added `extractFilePath()` helper to handle VSCode URI objects (needed by both Issue 1 and Issue 3)
- Added `extractProjectPathFromBubbles()` that matches absolute paths in `codeBlocks[].uri` against relative paths in `relevantFiles[]` to derive the project root
- `extractProjectPathFromComposerData()` delegates to the above for inline `conversation` arrays
- `extractMessages()` now returns `[parsedMessages, rawBubbles]` so raw bubble data is available for project path extraction even in `fullConversationHeadersOnly` sessions (the modern format, ~72% of sessions) where codeBlocks live in separate DB rows
- Final fallback changed from `cursor://global` to `cursor://workspace-<hash8>` — sessions without extractable project paths are now differentiated by workspace hash instead of all lumped into one project
- Fixed `decodeURIComponent` in `resolveWorkspacePath` (handles paths with spaces in workspace.json)

**Issue 2 — Lexical JSON in user messages:**
- Added `extractLexicalText()` that recursively walks Lexical node tree and collects all text nodes
- Changed `parseBubbles()` content extraction to prefer `bubble.text` (plain string) over `bubble.richText` (Lexical tree) — Cursor already maintains both fields simultaneously
- Falls back to Lexical extraction only when `text` is empty
- Handles `linebreak` nodes, nested children, and both pre-parsed objects and JSON strings

**Issue 3 — URI objects as `[object Object]`:**
- `extractFilePath(uri)` handles VSCode URI objects with field priority: `_fsPath > fsPath > path > file:// URL fields`
- Replaces the `as string` cast in `parseBubbles()` codeBlocks extraction

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [x] Backward compatible: yes — existing sessions will show improved data on `--force` re-sync

## Testing

Manual verification against live Cursor DB:
- Lexical extraction: confirmed text extracted correctly from 5 sample user bubbles with `richText` containing Lexical JSON
- Project path: confirmed `blog`, `crm` projects extracted correctly from codeBlock URI + relevantFiles matching
- URI objects: confirmed `extractFilePath()` returns correct paths for both `_fsPath=null/fsPath=null` URIs (falls to `path`) and URIs with `fsPath` set
- Build: `pnpm build` passes across all 3 packages (CLI, server, dashboard)