### PR TITLE
feat(cli): track telemetry opt-in/opt-out events

### DIFF
--- a/cli/src/commands/telemetry.ts
+++ b/cli/src/commands/telemetry.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadConfig, saveConfig } from '../utils/config.js';
-import { isTelemetryEnabled, buildEventPreview } from '../utils/telemetry.js';
+import { isTelemetryEnabled, buildEventPreview, trackEvent, shutdownTelemetry } from '../utils/telemetry.js';
 import type { ClaudeInsightConfig } from '../types.js';
 
 /**
@@ -70,8 +70,16 @@ function statusAction(): void {
  * If no config file exists yet we write a minimal one — the user clearly has
  * an intent to opt out and we should honour it without forcing them to run init
  * first.
+ *
+ * Fire telemetry_opted_out BEFORE writing the config — telemetry is still
+ * enabled at this point, so the event will actually be sent. Then flush
+ * and shut down the client before the process exits.
  */
-function disableAction(): void {
+async function disableAction(): Promise<void> {
+  // Fire and flush while telemetry is still enabled
+  trackEvent('telemetry_opted_out');
+  await shutdownTelemetry();
+
   const config = loadConfig() ?? { ...MINIMAL_CONFIG };
   config.telemetry = false;
   saveConfig(config);
@@ -81,11 +89,14 @@ function disableAction(): void {
 /**
  * Persist telemetry = true to config.
  * Same minimal-config fallback as disableAction.
+ *
+ * Write config FIRST so telemetry is enabled, then fire telemetry_opted_in.
  */
 function enableAction(): void {
   const config = loadConfig() ?? { ...MINIMAL_CONFIG };
   config.telemetry = true;
   saveConfig(config);
+  trackEvent('telemetry_opted_in');
   console.log(chalk.green('\n  Telemetry enabled.\n'));
 }
 
@@ -105,8 +116,8 @@ telemetryCommand
 telemetryCommand
   .command('disable')
   .description('Disable anonymous telemetry')
-  .action(() => {
-    disableAction();
+  .action(async () => {
+    await disableAction();
   });
 
 telemetryCommand

--- a/cli/src/utils/telemetry.ts
+++ b/cli/src/utils/telemetry.ts
@@ -29,7 +29,9 @@ export type TelemetryEventName =
   | 'analysis_run'
   | 'insight_generated'
   | 'export_run'
-  | 'dashboard_loaded';
+  | 'dashboard_loaded'
+  | 'telemetry_opted_out'
+  | 'telemetry_opted_in';
 
 // PostHog client — lazily initialized on first trackEvent call.
 // null when telemetry is disabled or init hasn't happened yet.


### PR DESCRIPTION
## What
Fire telemetry events when users opt in or out of telemetry, so we can measure adoption rates in PostHog.

## Why
We have no visibility into how many users are opting out (or back in) of telemetry. These events close that gap and let us track the telemetry adoption funnel.

## How
- Added `telemetry_opted_out` and `telemetry_opted_in` to the `TelemetryEventName` union type in `cli/src/utils/telemetry.ts`
- In `disableAction()`: fire `telemetry_opted_out` **before** writing `config.telemetry = false` — telemetry is still enabled at this point so the event actually sends. Then `await shutdownTelemetry()` to flush and guarantee delivery before the process exits. Made `disableAction` async.
- In `enableAction()`: write `config.telemetry = true` **first** so the PostHog client initialises with telemetry enabled, then call `trackEvent('telemetry_opted_in')`.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: yes — `TelemetryEventName` union extended with two new literals (additive, backward compatible)
- [ ] Server API changed: no
- [ ] Backward compatible: yes

## Testing
- `pnpm build` passes across the full workspace (CLI, server, dashboard)
- Manually: run `code-insights telemetry disable` → `telemetry_opted_out` event fires and flushes before config is written; run `code-insights telemetry enable` → `telemetry_opted_in` fires after config is written
- Edge case: if telemetry is already disabled, `trackEvent` is a no-op (guarded by `getPostHogClient()` returning null) — `disableAction` still flushes (no-op via `shutdownTelemetry` since client is null), writes config, and exits cleanly

Closes #98