### PR TITLE
feat(dashboard): polish Insights page UX to match Sessions page

### DIFF
--- a/dashboard/src/components/insights/InsightListItem.tsx
+++ b/dashboard/src/components/insights/InsightListItem.tsx
@@ -1,19 +1,36 @@
 import { useState, useEffect, useRef } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { FileText, GitCommit, BookOpen, Target, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
+import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { INSIGHT_TYPE_COLORS, INSIGHT_TYPE_LABELS } from '@/lib/constants/colors';
 import { cn } from '@/lib/utils';
+import { getScoreTier } from '@/lib/score-utils';
 import type { Insight, InsightType, InsightMetadata } from '@/lib/types';
 import { parseJsonField } from '@/lib/types';
 import { OutcomeBadge, renderTypeContent } from './insight-metadata';
+import { PromptQualityContent } from './PromptQualityCard';
 
-const typeIcons: Record<InsightType, typeof FileText> = {
-  summary: FileText,
-  decision: GitCommit,
-  learning: BookOpen,
-  technique: BookOpen,
-  prompt_quality: Target,
+const SCORE_BADGE_COLORS: Record<string, string> = {
+  excellent: 'bg-green-500/15 text-green-600',
+  good: 'bg-yellow-500/15 text-yellow-600',
+  fair: 'bg-orange-500/15 text-orange-600',
+  poor: 'bg-red-500/15 text-red-600',
+};
+
+const DOT_COLORS: Record<InsightType, string> = {
+  summary: 'bg-purple-500',
+  decision: 'bg-blue-500',
+  learning: 'bg-green-500',
+  technique: 'bg-green-500',
+  prompt_quality: 'bg-rose-500',
+};
+
+const EXPAND_BORDER_COLORS: Record<InsightType, string> = {
+  summary: 'border-purple-500/40',
+  decision: 'border-blue-500/40',
+  learning: 'border-green-500/40',
+  technique: 'border-green-500/40',
+  prompt_quality: 'border-rose-500/40',
 };
 
 interface InsightListItemProps {
@@ -29,7 +46,6 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
   const [showRing, setShowRing] = useState(highlighted);
   const itemRef = useRef<HTMLDivElement>(null);
 
-  // Sync showRing when highlighted prop changes
   useEffect(() => {
     setShowRing(!!highlighted);
   }, [highlighted]);
@@ -43,7 +59,7 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
       return () => clearTimeout(timer);
     }
   }, [highlighted]);
-  const Icon = typeIcons[insight.type];
+
   const colorClass = INSIGHT_TYPE_COLORS[insight.type];
   const bullets = parseJsonField<string[]>(insight.bullets, []);
   const metadata = parseJsonField<InsightMetadata>(insight.metadata, {});
@@ -58,64 +74,45 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
     : 0;
 
   const iconColorClass = colorClass.split(' ').find(c => c.startsWith('text-')) || 'text-muted-foreground';
+  const expandedTypeContent = insight.type !== 'prompt_quality'
+    ? renderTypeContent(insight.type, metadata, bullets)
+    : null;
 
-  // For collapsed preview: show key field based on type
-  const collapsedPreview = !expanded && (() => {
-    if (insight.type === 'decision' && metadata.choice) {
-      return <p className="text-xs text-muted-foreground mt-1 line-clamp-1">Choice: {metadata.choice}</p>;
-    }
-    if ((insight.type === 'learning' || insight.type === 'technique') && metadata.takeaway) {
-      return <p className="text-xs text-muted-foreground mt-1 line-clamp-1">Takeaway: {metadata.takeaway}</p>;
-    }
-    if (insight.type === 'summary' && metadata.outcome) {
-      return (
-        <div className="mt-1">
-          <OutcomeBadge outcome={metadata.outcome} />
-        </div>
-      );
-    }
-    // Generic fallback: show bullets
-    if (bullets.length > 0) {
-      return (
-        <ul className="mt-2 space-y-0.5">
-          {bullets.slice(0, 3).map((bullet, i) => (
-            <li key={i} className="text-xs text-muted-foreground flex gap-1.5">
-              <span className="shrink-0 mt-0.5">-</span>
-              <span className="line-clamp-1">{bullet}</span>
-            </li>
-          ))}
-        </ul>
-      );
-    }
-    return null;
-  })();
-
-  // For expanded content: type-specific or generic fallback
-  const expandedTypeContent = renderTypeContent(insight.type, metadata, bullets);
+  // Prompt quality score for collapsed badge
+  const pqScore = insight.type === 'prompt_quality'
+    ? (typeof (metadata as Record<string, unknown>).efficiencyScore === 'number'
+        ? (metadata as Record<string, unknown>).efficiencyScore as number
+        : null)
+    : null;
 
   return (
     <div
       ref={itemRef}
       className={cn(
-        'border rounded-lg overflow-hidden transition-shadow duration-500',
-        showRing && 'ring-2 ring-primary'
+        'border-b last:border-b-0 transition-shadow duration-500',
+        showRing && 'ring-2 ring-primary rounded-sm'
       )}
     >
       <button
-        className="w-full text-left p-4 hover:bg-muted/30 transition-colors"
+        className="w-full text-left px-3 py-2.5 hover:bg-muted/30 transition-colors"
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
       >
-        <div className="flex items-start gap-3">
-          <div className={cn('mt-0.5 shrink-0 rounded-md p-1.5', colorClass)}>
-            <Icon className="h-4 w-4" />
-          </div>
-
+        <div className="flex items-start gap-2.5">
+          <span className={cn('w-2 h-2 rounded-full shrink-0 mt-1.5', DOT_COLORS[insight.type])} />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-0.5 flex-wrap">
               <span className={cn('text-xs font-medium', iconColorClass)}>
                 {INSIGHT_TYPE_LABELS[insight.type]}
               </span>
+              {pqScore != null && (
+                <span className={cn(
+                  'inline-flex items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold leading-none',
+                  SCORE_BADGE_COLORS[getScoreTier(pqScore)]
+                )}>
+                  {pqScore}
+                </span>
+              )}
               {recurringCount > 0 && (
                 <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 border-amber-500/20 text-xs py-0">
                   Recurring {recurringCount + 1}x
@@ -123,8 +120,7 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
               )}
             </div>
             <p className="text-sm font-medium leading-snug">{insight.title}</p>
-
-            <div className="flex items-center justify-between gap-2 mt-1 flex-wrap">
+            <div className="flex items-center justify-between gap-2 mt-0.5 flex-wrap">
               {showProject && (
                 <span className="text-xs text-muted-foreground">{insight.project_name}</span>
               )}
@@ -132,11 +128,8 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
                 {formatDistanceToNow(new Date(insight.timestamp), { addSuffix: true })}
               </span>
             </div>
-
-            {collapsedPreview}
           </div>
-
-          <div className="shrink-0 mt-0.5 text-muted-foreground">
+          <div className="shrink-0 mt-1 text-muted-foreground">
             {expanded
               ? <ChevronDown className="h-4 w-4" />
               : <ChevronRight className="h-4 w-4" />}
@@ -145,21 +138,21 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
       </button>
 
       {expanded && (
-        <div className="px-4 pb-4 pt-0 border-t bg-muted/20">
-          {expandedTypeContent ? (
-            <div className="mt-3">
-              {expandedTypeContent}
-            </div>
+        <div className={cn(
+          'mx-3 mb-2.5 ml-[1.85rem] pl-3 pr-3 py-2.5 border-l-2 bg-muted/20 rounded-r-md',
+          EXPAND_BORDER_COLORS[insight.type]
+        )}>
+          {insight.type === 'prompt_quality' ? (
+            <PromptQualityContent insight={insight} />
+          ) : expandedTypeContent ? (
+            <div>{expandedTypeContent}</div>
           ) : (
             <>
               {insight.content && (
-                <div className="mt-3">
-                  <p className="text-sm text-foreground leading-relaxed">{insight.content}</p>
-                </div>
+                <p className="text-sm text-foreground leading-relaxed">{insight.content}</p>
               )}
-
               {bullets.length > 0 && (
-                <ul className="mt-3 space-y-1">
+                <ul className="mt-2 space-y-1">
                   {bullets.map((bullet, i) => (
                     <li key={i} className="text-sm text-muted-foreground flex gap-2">
                       <span className="shrink-0 mt-0.5">-</span>
@@ -171,9 +164,11 @@ export function InsightListItem({ insight, showProject = false, allInsightIds, h
             </>
           )}
 
-          <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
-            <span>Confidence: {Math.round(insight.confidence * 100)}%</span>
-          </div>
+          {metadata.outcome && insight.type === 'summary' && (
+            <div className="mt-2">
+              <OutcomeBadge outcome={metadata.outcome} />
+            </div>
+          )}
 
           <div className="mt-3">
             <a

--- a/dashboard/src/components/insights/PromptQualityCard.tsx
+++ b/dashboard/src/components/insights/PromptQualityCard.tsx
@@ -61,7 +61,8 @@ function getScoreColor(score: number): string {
   return SCORE_COLORS[getScoreTier(score)];
 }
 
-export function PromptQualityCard({ insight }: PromptQualityCardProps) {
+/** Inner content for prompt quality — used by both PromptQualityCard and InsightListItem. */
+export function PromptQualityContent({ insight }: { insight: Insight }) {
   const metadata = parseJsonField<Record<string, unknown>>(insight.metadata, {});
   const bullets = parseJsonField<string[]>(insight.bullets, []);
 
@@ -71,6 +72,155 @@ export function PromptQualityCard({ insight }: PromptQualityCardProps) {
   const sessionTraits = Array.isArray(metadata.sessionTraits) ? metadata.sessionTraits as SessionTrait[] : [];
   const reduction = typeof metadata.potentialMessageReduction === 'number' ? metadata.potentialMessageReduction : 0;
 
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <div className="text-center">
+          <ProgressRing value={score} />
+          <p className="text-xs text-muted-foreground mt-1">/100</p>
+        </div>
+        <div>
+          <p className={`text-sm font-medium ${getScoreColor(score)}`}>
+            {getScoreLabel(score)}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {insight.content}
+          </p>
+        </div>
+      </div>
+
+      {reduction > 0 && (
+        <div className="flex items-center gap-2 text-sm rounded-md bg-muted/50 p-2">
+          <TrendingDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span>
+            Could have been done in <strong>{reduction} fewer</strong> messages
+          </span>
+        </div>
+      )}
+
+      {antiPatterns.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 text-sm font-medium">
+            <AlertTriangle className="h-3.5 w-3.5 text-orange-500" />
+            Anti-Patterns Detected
+          </div>
+          <div className="space-y-1.5">
+            {antiPatterns.map((pattern, i) => (
+              <div key={i} className="text-sm rounded-md border p-2 space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">{pattern.name}</span>
+                  <Badge variant="secondary" className="text-xs">
+                    {pattern.count}x
+                  </Badge>
+                </div>
+                {pattern.description && (
+                  <p className="text-xs text-muted-foreground">{pattern.description}</p>
+                )}
+                {pattern.examples.length > 0 && (
+                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                    e.g. &ldquo;{pattern.examples[0]}&rdquo;
+                  </p>
+                )}
+                {pattern.fix && (
+                  <p className="text-xs text-green-600 mt-1">Fix: {pattern.fix}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {sessionTraits.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 text-sm font-medium">
+            <Compass className="h-3.5 w-3.5 text-blue-500" />
+            Session Traits
+          </div>
+          <div className="space-y-1.5">
+            {sessionTraits.map((t, i) => (
+              <div key={i} className="text-sm rounded-md border p-2 space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">{TRAIT_LABELS[t.trait] || t.trait}</span>
+                  <Badge variant="outline" className={`text-xs ${
+                    t.trait === 'good_structure'
+                      ? 'text-green-500 bg-green-500/10 border-green-500/20'
+                      : SEVERITY_COLORS[t.severity] || ''
+                  }`}>
+                    {t.trait === 'good_structure' ? 'positive' : t.severity}
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">{t.description}</p>
+                {t.evidence && (
+                  <p className="text-xs text-muted-foreground italic">{t.evidence}</p>
+                )}
+                {t.suggestion && (
+                  <p className="text-xs text-green-600">Suggestion: {t.suggestion}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {wastedTurns.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">
+            Wasted Turns ({wastedTurns.length})
+          </p>
+          <div className="space-y-2 max-h-48 overflow-y-auto">
+            {wastedTurns.slice(0, 5).map((turn, i) => (
+              <div key={i} className="text-sm rounded-md border p-2 space-y-1">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline" className="text-xs shrink-0">
+                    Msg #{turn.messageIndex + 1}
+                    {turn.turnsWasted && turn.turnsWasted > 1 ? ` (${turn.turnsWasted} turns)` : ''}
+                  </Badge>
+                  <span className="text-muted-foreground">{turn.whatWentWrong || turn.reason}</span>
+                </div>
+                {turn.originalMessage && (
+                  <p className="text-xs text-muted-foreground italic line-clamp-2">
+                    &ldquo;{turn.originalMessage}&rdquo;
+                  </p>
+                )}
+                {turn.suggestedRewrite && (
+                  <details className="text-xs">
+                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                      Better prompt
+                    </summary>
+                    <p className="mt-1 bg-muted/50 rounded p-1.5">
+                      {turn.suggestedRewrite}
+                    </p>
+                  </details>
+                )}
+              </div>
+            ))}
+            {wastedTurns.length > 5 && (
+              <p className="text-xs text-muted-foreground">
+                +{wastedTurns.length - 5} more wasted turns...
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {bullets.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5 text-sm font-medium">
+            <Lightbulb className="h-3.5 w-3.5 text-yellow-500" />
+            Tips
+          </div>
+          <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+            {bullets.map((tip, i) => (
+              <li key={i}>{tip}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PromptQualityCard({ insight }: PromptQualityCardProps) {
   return (
     <Card className="border-rose-500/20">
       <CardHeader className="pb-3">
@@ -87,149 +237,8 @@ export function PromptQualityCard({ insight }: PromptQualityCardProps) {
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        <div className="flex items-center gap-4">
-          <div className="text-center">
-            <ProgressRing value={score} />
-            <p className="text-xs text-muted-foreground mt-1">/100</p>
-          </div>
-          <div>
-            <p className={`text-sm font-medium ${getScoreColor(score)}`}>
-              {getScoreLabel(score)}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              {insight.content}
-            </p>
-          </div>
-        </div>
-
-        {reduction > 0 && (
-          <div className="flex items-center gap-2 text-sm rounded-md bg-muted/50 p-2">
-            <TrendingDown className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span>
-              Could have been done in <strong>{reduction} fewer</strong> messages
-            </span>
-          </div>
-        )}
-
-        {antiPatterns.length > 0 && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
-              <AlertTriangle className="h-3.5 w-3.5 text-orange-500" />
-              Anti-Patterns Detected
-            </div>
-            <div className="space-y-1.5">
-              {antiPatterns.map((pattern, i) => (
-                <div key={i} className="text-sm rounded-md border p-2 space-y-1">
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium">{pattern.name}</span>
-                    <Badge variant="secondary" className="text-xs">
-                      {pattern.count}x
-                    </Badge>
-                  </div>
-                  {pattern.description && (
-                    <p className="text-xs text-muted-foreground">{pattern.description}</p>
-                  )}
-                  {pattern.examples.length > 0 && (
-                    <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
-                      e.g. &ldquo;{pattern.examples[0]}&rdquo;
-                    </p>
-                  )}
-                  {pattern.fix && (
-                    <p className="text-xs text-green-600 mt-1">Fix: {pattern.fix}</p>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {sessionTraits.length > 0 && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
-              <Compass className="h-3.5 w-3.5 text-blue-500" />
-              Session Traits
-            </div>
-            <div className="space-y-1.5">
-              {sessionTraits.map((t, i) => (
-                <div key={i} className="text-sm rounded-md border p-2 space-y-1">
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium">{TRAIT_LABELS[t.trait] || t.trait}</span>
-                    <Badge variant="outline" className={`text-xs ${
-                      t.trait === 'good_structure'
-                        ? 'text-green-500 bg-green-500/10 border-green-500/20'
-                        : SEVERITY_COLORS[t.severity] || ''
-                    }`}>
-                      {t.trait === 'good_structure' ? 'positive' : t.severity}
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-muted-foreground">{t.description}</p>
-                  {t.evidence && (
-                    <p className="text-xs text-muted-foreground italic">{t.evidence}</p>
-                  )}
-                  {t.suggestion && (
-                    <p className="text-xs text-green-600">Suggestion: {t.suggestion}</p>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {wastedTurns.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-sm font-medium">
-              Wasted Turns ({wastedTurns.length})
-            </p>
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {wastedTurns.slice(0, 5).map((turn, i) => (
-                <div key={i} className="text-sm rounded-md border p-2 space-y-1">
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="text-xs shrink-0">
-                      Msg #{turn.messageIndex + 1}
-                      {turn.turnsWasted && turn.turnsWasted > 1 ? ` (${turn.turnsWasted} turns)` : ''}
-                    </Badge>
-                    <span className="text-muted-foreground">{turn.whatWentWrong || turn.reason}</span>
-                  </div>
-                  {turn.originalMessage && (
-                    <p className="text-xs text-muted-foreground italic line-clamp-2">
-                      &ldquo;{turn.originalMessage}&rdquo;
-                    </p>
-                  )}
-                  {turn.suggestedRewrite && (
-                    <details className="text-xs">
-                      <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-                        Better prompt
-                      </summary>
-                      <p className="mt-1 bg-muted/50 rounded p-1.5">
-                        {turn.suggestedRewrite}
-                      </p>
-                    </details>
-                  )}
-                </div>
-              ))}
-              {wastedTurns.length > 5 && (
-                <p className="text-xs text-muted-foreground">
-                  +{wastedTurns.length - 5} more wasted turns...
-                </p>
-              )}
-            </div>
-          </div>
-        )}
-
-        {bullets.length > 0 && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
-              <Lightbulb className="h-3.5 w-3.5 text-yellow-500" />
-              Tips
-            </div>
-            <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
-              {bullets.map((tip, i) => (
-                <li key={i}>{tip}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+      <CardContent>
+        <PromptQualityContent insight={insight} />
       </CardContent>
     </Card>
   );

--- a/dashboard/src/pages/InsightsPage.tsx
+++ b/dashboard/src/pages/InsightsPage.tsx
@@ -6,7 +6,8 @@ import { useFilterParams } from '@/hooks/useFilterParams';
 import { useProjects } from '@/hooks/useProjects';
 import { buildPatternGroups } from '@/lib/pattern-grouping';
 import { InsightListItem } from '@/components/insights/InsightListItem';
-import { PromptQualityCard } from '@/components/insights/PromptQualityCard';
+// PromptQualityCard still used in SessionDetailPanel; on this page prompt_quality
+// insights render inline via InsightListItem → PromptQualityContent.
 import { RecurringPatternsSection } from '@/components/insights/RecurringPatternsSection';
 import { InsightCardSkeleton } from '@/components/skeletons/InsightCardSkeleton';
 import { ErrorCard } from '@/components/ErrorCard';
@@ -21,12 +22,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Sparkles, SearchX, X } from 'lucide-react';
+import { Sparkles, SearchX, X, FileText, GitCommit, BookOpen, Target } from 'lucide-react';
 import { getDateGroup, sortDateGroups } from '@/lib/utils';
 import { INSIGHT_TYPE_LABELS } from '@/lib/constants/colors';
 import type { Insight, InsightType } from '@/lib/types';
 
 const INSIGHT_TYPES: InsightType[] = ['summary', 'decision', 'learning', 'technique', 'prompt_quality'];
+
+const TYPE_SECTION_ICONS: Record<string, { icon: typeof FileText; color: string }> = {
+  summary: { icon: FileText, color: 'text-purple-500' },
+  decision: { icon: GitCommit, color: 'text-blue-500' },
+  learning: { icon: BookOpen, color: 'text-green-500' },
+  technique: { icon: BookOpen, color: 'text-green-500' },
+  prompt_quality: { icon: Target, color: 'text-rose-500' },
+};
 
 const VIEW_MODES = [
   { value: 'timeline', label: 'Timeline' },
@@ -154,95 +163,94 @@ export default function InsightsPage() {
   }, [filtered, filters.view]);
 
   return (
-    <div className="p-6 space-y-4">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold">Insights</h1>
-        {!isLoading && (
-          <p className="text-muted-foreground text-sm">
-            {filtered.length} insight{filtered.length !== 1 ? 's' : ''}
-            {hasFilters ? ' matching filters' : ''}
-          </p>
+    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+      {/* Sticky header: title + filters */}
+      <div className="shrink-0 sticky top-0 z-10 bg-background border-b px-6 pt-5 pb-3 space-y-3">
+        <div>
+          <h1 className="text-2xl font-bold">Insights</h1>
+          {!isLoading && (
+            <p className="text-muted-foreground text-sm">
+              {filtered.length} insight{filtered.length !== 1 ? 's' : ''}
+              {hasFilters ? ' matching filters' : ''}
+            </p>
+          )}
+        </div>
+
+        {/* Pattern filter banner */}
+        {filters.pattern && (
+          <div className="flex items-center gap-2 rounded-lg border bg-amber-500/5 border-amber-500/20 px-3 py-2">
+            <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 border-amber-500/20">
+              Pattern
+            </Badge>
+            <span className="text-sm text-muted-foreground">
+              Showing {filtered.length} insight{filtered.length !== 1 ? 's' : ''} in this recurring pattern
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 ml-auto shrink-0"
+              onClick={() => setFilter('pattern', '')}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
         )}
-      </div>
 
-      {/* Pattern filter banner */}
-      {filters.pattern && (
-        <div className="flex items-center gap-2 rounded-lg border bg-amber-500/5 border-amber-500/20 px-3 py-2">
-          <Badge variant="secondary" className="bg-amber-500/10 text-amber-600 border-amber-500/20">
-            Pattern
-          </Badge>
-          <span className="text-sm text-muted-foreground">
-            Showing {filtered.length} insight{filtered.length !== 1 ? 's' : ''} in this recurring pattern
-          </span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 ml-auto shrink-0"
-            onClick={() => setFilter('pattern', '')}
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      )}
-
-      {/* Filters + View Mode */}
-      <div className="space-y-2">
+        {/* Filters + View Mode */}
         <div className="flex flex-wrap items-center gap-3">
-          <Input
-            placeholder="Search insights..."
-            value={filters.q}
-            onChange={(e) => setFilter('q', e.target.value)}
-            className="max-w-sm"
-          />
-          <Tabs
-            value={filters.view}
-            onValueChange={(v) => setFilter('view', v)}
-          >
-            <TabsList variant="default" className="h-9">
-              {VIEW_MODES.map((mode) => (
-                <TabsTrigger key={mode.value} value={mode.value} className="text-xs px-3">
-                  {mode.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          </Tabs>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Select value={filters.project} onValueChange={(v) => setFilter('project', v)}>
-            <SelectTrigger className="w-[160px]">
-              <SelectValue placeholder="All Projects" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Projects</SelectItem>
-              {projects.map((p) => (
-                <SelectItem key={p.id} value={p.id}>
-                  {p.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <Input
+          placeholder="Search insights..."
+          value={filters.q}
+          onChange={(e) => setFilter('q', e.target.value)}
+          className="max-w-xs"
+        />
 
-          <Select
-            value={filters.type}
-            onValueChange={(v) => setFilter('type', v)}
-          >
-            <SelectTrigger className="w-[160px]">
-              <SelectValue placeholder="All Types" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Types</SelectItem>
-              {INSIGHT_TYPES.map((t) => (
-                <SelectItem key={t} value={t}>
-                  {INSIGHT_TYPE_LABELS[t]}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <Select value={filters.project} onValueChange={(v) => setFilter('project', v)}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="All Projects" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Projects</SelectItem>
+            {projects.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={filters.type} onValueChange={(v) => setFilter('type', v)}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="All Types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Types</SelectItem>
+            {INSIGHT_TYPES.map((t) => (
+              <SelectItem key={t} value={t}>
+                {INSIGHT_TYPE_LABELS[t]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Tabs
+          value={filters.view}
+          onValueChange={(v) => setFilter('view', v)}
+          className="ml-auto"
+        >
+          <TabsList variant="default" className="h-9">
+            {VIEW_MODES.map((mode) => (
+              <TabsTrigger key={mode.value} value={mode.value} className="text-xs px-3">
+                {mode.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
         </div>
       </div>
 
-      {/* Content */}
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
       {isError && !isLoading ? (
         <ErrorCard message="Failed to load insights" onRetry={refetch} />
       ) : isLoading ? (
@@ -278,16 +286,18 @@ export default function InsightsPage() {
             <RecurringPatternsSection insights={insights} />
           )}
 
-          {grouped.map((group) => (
-            <div key={group.key}>
-              <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                {group.label} ({group.count})
-              </h2>
-              <div className="space-y-3">
-                {group.insights.map((insight) =>
-                  insight.type === 'prompt_quality' ? (
-                    <PromptQualityCard key={insight.id} insight={insight} />
-                  ) : (
+          {grouped.map((group) => {
+            const sectionMeta = filters.view === 'type' ? TYPE_SECTION_ICONS[group.key] : null;
+            const SectionIcon = sectionMeta?.icon;
+
+            return (
+              <div key={group.key}>
+                <h2 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                  {SectionIcon && <SectionIcon className={`h-3.5 w-3.5 ${sectionMeta.color}`} />}
+                  {group.label} ({group.count})
+                </h2>
+                <div className="rounded-md border overflow-hidden">
+                  {group.insights.map((insight) => (
                     <InsightListItem
                       key={insight.id}
                       insight={insight}
@@ -296,13 +306,14 @@ export default function InsightsPage() {
                       highlighted={insight.id === highlightedInsightId}
                       defaultExpanded={insight.id === highlightedInsightId}
                     />
-                  )
-                )}
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Compact insight rows** — Replaced large icon boxes with small colored dots, tighter padding, border-left accent on expand (matching Sessions panel pattern)
- **Unified prompt quality** — Prompt quality insights now render as collapsible rows like all other types, with score badge in collapsed state and full analysis on expand (extracted `PromptQualityContent` for reuse)
- **Single-row filters** — Consolidated 2-row filter layout into one row: Search + Project + Type + View Mode tabs (pushed right)
- **Grouped containers** — Insight items wrapped in bordered containers with `border-b` separators instead of individual floating cards
- **Sticky header** — Title, pattern banner, and filter bar stay pinned while content scrolls
- **Colored section icons** — "By Type" view shows type-colored icons in section headers

## Test plan

- [ ] Verify all insight types (summary, decision, learning, technique, prompt_quality) render as compact rows
- [ ] Expand each type and verify content renders correctly (especially prompt quality with score ring, anti-patterns, traits, tips)
- [ ] Verify filters stay sticky on scroll
- [ ] Verify "By Type" view shows colored section icons
- [ ] Verify deep-linking to a specific insight still highlights and scrolls
- [ ] Verify PromptQualityCard still renders correctly in Sessions detail panel (Prompt Quality tab)
- [ ] Check light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)