### PR TITLE
chore: update product tagline for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Code Insights</h1>
 
-A free, open-source, local-first tool for analyzing AI coding sessions.
+Turn your AI coding sessions into knowledge.
 
 Parses session history from Claude Code, Cursor, Codex CLI, and Copilot CLI. Stores structured data in a local SQLite database. Surfaces insights through terminal analytics and a built-in browser dashboard.
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@code-insights/cli",
   "version": "3.5.0",
-  "description": "AI coding session analytics with built-in dashboard",
+  "description": "Turn your AI coding sessions into knowledge",
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -2,7 +2,7 @@
 
 ## What It Is
 
-Code Insights transforms your AI coding session history into structured, searchable insights. It extracts patterns from your conversations—what you built, decisions you made, lessons learned—and presents them in a local visual dashboard.
+Turn your AI coding sessions into knowledge. Code Insights extracts patterns from your conversations—what you built, decisions you made, lessons learned—and presents them in a local visual dashboard.
 
 ## The Problem
 


### PR DESCRIPTION
## Summary
- Updates tagline to **"Turn your AI coding sessions into knowledge"** across package.json description, README, and PRODUCT.md
- Pre-launch alignment ahead of ProductHunt launch

## Changes
- `cli/package.json` — npm package description
- `README.md` — repo hero tagline
- `docs/PRODUCT.md` — product doc opening line

## Test plan
- [ ] Verify `npm info` shows updated description after next publish
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)