### PR TITLE
release: v3.5.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `@code-insights/cli` will be documented in this file.
 
+## [3.5.1] - 2026-03-03
+
+### Changed
+
+- **Product tagline** — Updated tagline to "Turn your AI coding sessions into knowledge" across package description, README, and product docs ahead of ProductHunt launch.
+
+### Improved
+
+- **Insights page UX polish** — Aligned Insights page layout, filters, and empty states with the Sessions page for a consistent dashboard experience.
+- **README screenshots** — Added 5 screenshots (dashboard, sessions, insights, analytics, terminal stats) to the root README for better first impressions on GitHub.
+
 ## [3.4.1] - 2026-03-02
 
 ### Fixed

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-insights/cli",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Turn your AI coding sessions into knowledge",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `@code-insights/cli` from 3.5.0 to 3.5.1
- Add CHANGELOG entry for v3.5.1

### What's in this release
- **Product tagline** — "Turn your AI coding sessions into knowledge" (PR #103)
- **Insights page UX polish** — Aligned with Sessions page layout (PR #101)
- **README screenshots** — 5 screenshots added to root README

## Test plan
- [x] `pnpm build` passes
- [ ] `npm publish` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)