### PR TITLE
fix: handle object-shaped bullets in PromptQualityCard

### DIFF
--- a/dashboard/src/components/insights/PromptQualityCard.tsx
+++ b/dashboard/src/components/insights/PromptQualityCard.tsx
@@ -214,12 +214,13 @@ export function PromptQualityContent({ insight }: { insight: Insight }) {
               if (typeof bullet === 'string') {
                 return <li key={i}>{bullet}</li>;
               }
-              const obj = bullet as { tip?: string; example?: string };
+              const text = bullet.tip || bullet.example;
+              if (!text) return null;
               return (
                 <li key={i}>
-                  {obj.tip}
-                  {obj.example && (
-                    <p className="ml-5 mt-0.5 text-xs italic">{obj.example}</p>
+                  {text}
+                  {bullet.tip && bullet.example && (
+                    <p className="ml-5 mt-0.5 text-xs italic">{bullet.example}</p>
                   )}
                 </li>
               );


### PR DESCRIPTION
## Summary
- Fixes React Error #31 crash on the Prompt Quality tab when LLM returns bullets as `{tip, example}` objects instead of plain strings
- Backward compatible: handles both plain string bullets (old/less capable models) and structured object bullets (newer analysis)
- Renders the `example` field when present as an italic sub-line

## Root Cause
The `bullets` field in prompt quality insights can contain either `string[]` or `{tip, example}[]` depending on the LLM model. The component assumed `string[]` and passed objects directly as React children, causing Error #31.

## Test plan
- [ ] Open a session with prompt quality analysis containing object-shaped bullets → Tips section renders without crash
- [ ] Verify sessions with plain string bullets still render correctly
- [ ] Verify the `example` sub-text appears when present in structured bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)