### PR TITLE
feat(dashboard): Patterns page UI redesign + outcome distribution bug fix

### DIFF
--- a/dashboard/src/components/patterns/CollapsibleCategoryList.tsx
+++ b/dashboard/src/components/patterns/CollapsibleCategoryList.tsx
@@ -116,7 +116,10 @@ export function CollapsibleCategoryList({
             {isExpanded && hasDescriptions && (
               <ul className="ml-8 mt-1 space-y-1 pb-1 bg-muted/30 rounded-md p-2">
                 {item.descriptions.slice(0, MAX_DESC_VISIBLE).map((desc, j) => (
-                  <li key={j} className="text-xs text-muted-foreground">{desc}</li>
+                  <li key={j} className="flex items-start gap-1.5 text-xs text-muted-foreground">
+                    <span className="mt-0.5 shrink-0 select-none">·</span>
+                    <span>{desc}</span>
+                  </li>
                 ))}
                 {item.descriptions.length > MAX_DESC_VISIBLE && (
                   <li className="text-xs text-muted-foreground italic">

--- a/dashboard/src/components/patterns/WeekAtAGlanceStrip.tsx
+++ b/dashboard/src/components/patterns/WeekAtAGlanceStrip.tsx
@@ -18,6 +18,7 @@ interface WeekAtAGlanceStripProps {
   characterDistribution?: Record<string, number>;
   streak?: number;
   rateLimitCount?: number;
+  rateLimitSessionsAffected?: number;
 }
 
 // DB outcome_satisfaction values: 'high' | 'medium' | 'low' | 'abandoned'
@@ -47,6 +48,7 @@ export function WeekAtAGlanceStrip({
   characterDistribution,
   streak,
   rateLimitCount,
+  rateLimitSessionsAffected,
 }: WeekAtAGlanceStripProps) {
   const outcomeTotal = Object.values(outcomeDistribution).reduce((s, v) => s + v, 0);
   const hasOutcomes = outcomeTotal > 0;
@@ -109,7 +111,13 @@ export function WeekAtAGlanceStrip({
             </span>
           )}
           {(rateLimitCount ?? 0) > 0 && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium border border-amber-500/20">
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 text-amber-600 dark:text-amber-400 px-2 py-0.5 text-xs font-medium border border-amber-500/20"
+              title={rateLimitSessionsAffected != null
+                ? `${rateLimitCount} rate limit${rateLimitCount !== 1 ? 's' : ''} affecting ${rateLimitSessionsAffected} session${rateLimitSessionsAffected !== 1 ? 's' : ''}`
+                : `${rateLimitCount} rate limit${rateLimitCount !== 1 ? 's' : ''}`
+              }
+            >
               <Zap className="h-3 w-3" />
               {rateLimitCount} rate limit{rateLimitCount !== 1 ? 's' : ''}
             </span>

--- a/dashboard/src/components/patterns/WorkingStyleHighlights.tsx
+++ b/dashboard/src/components/patterns/WorkingStyleHighlights.tsx
@@ -43,7 +43,7 @@ export function WorkingStyleHighlights({
     pills.push({
       icon: <CheckCircle2 className="h-4 w-4 text-emerald-500" />,
       value: `${successCount}/${totalSessions}`,
-      sublabel: 'completed',
+      sublabel: 'high-quality',
       className: 'bg-emerald-500/10 border-emerald-500/20',
     });
   }

--- a/dashboard/src/pages/PatternsPage.tsx
+++ b/dashboard/src/pages/PatternsPage.tsx
@@ -387,6 +387,7 @@ export default function PatternsPage() {
         characterDistribution={aggregation?.characterDistribution}
         streak={aggregation?.streak}
         rateLimitCount={aggregation?.rateLimitInfo?.count}
+        rateLimitSessionsAffected={aggregation?.rateLimitInfo?.sessionsAffected}
       />
 
       {/* 2-tab layout */}
@@ -394,14 +395,14 @@ export default function PatternsPage() {
         <TabsList variant="line" className="w-full justify-start border-b rounded-none px-0 h-auto pb-0">
           <TabsTrigger
             value="insights"
-            className="flex items-center gap-1.5 pb-2.5 data-[state=active]:border-b-2 data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400"
+            className="flex items-center gap-1.5 pb-2.5 data-[state=active]:after:bg-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400"
           >
             <Brain className="h-4 w-4" />
             Insights
           </TabsTrigger>
           <TabsTrigger
             value="artifacts"
-            className="flex items-center gap-1.5 pb-2.5 data-[state=active]:border-b-2 data-[state=active]:border-violet-500 data-[state=active]:text-violet-600 dark:data-[state=active]:text-violet-400"
+            className="flex items-center gap-1.5 pb-2.5 data-[state=active]:after:bg-violet-500 data-[state=active]:text-violet-600 dark:data-[state=active]:text-violet-400"
           >
             <Shield className="h-4 w-4" />
             Artifacts


### PR DESCRIPTION
## What
Redesigns the Patterns page hero section and card layout, and fixes a critical bug where the successful session count always showed 0.

## Why
- **Bug**: `outcomeDistribution['success']` always returned 0 because the DB stores `outcome_satisfaction` as `'high' | 'medium' | 'low' | 'abandoned'`, not `'success'`.
- **UI**: The previous strip was minimal — a thin bar with no icons, no character breakdown, no streak info, and no coverage stat. The redesign makes the hero section much more informative at a glance.

## How
1. **Bug fix**: Changed `outcomeDistribution['success']` → `outcomeDistribution['high']` in `PatternsPage.tsx`. Updated `WeekAtAGlanceStrip` outcome keys/colors/labels to match the actual DB values.
2. **WeekHeroCard** (`WeekAtAGlanceStrip.tsx` rewritten): Subtle gradient background, 3-stat row with Lucide icons (sessions, coverage %, high-quality count), character distribution badges using `SESSION_CHARACTER_COLORS`, streak badge (shown at ≥2 weeks), wider `h-2` outcome bar with percentage labels, rate limit badge.
3. **WorkingStyleHighlights.tsx** rewritten: Horizontal stat pills (icon + value + sublabel) replacing the old `<ul>` bullet list. Color-coded: emerald=success, red=friction, blue=pattern, character color for session type.
4. **Layout simplification**: Removed `Card` wrapper from Working Style section (now borderless, 3 total bordered containers instead of 5). Removed the friction narrative callout box.
5. **CollapsibleCategoryList**: Per-row 2px left color indicator (red for friction, emerald for patterns). Expanded area uses `bg-muted/30 rounded-md p-2 ml-8`.
6. **Color accents on cards**: Friction card gets `border-l-2 border-red-400` + AlertTriangle icon in title. Patterns card gets `border-l-2 border-emerald-400` + Sparkles icon.
7. **Tab polish**: Active tab colored underlines — blue for Insights, violet for Artifacts.

## Schema Impact
- SQLite schema changed: no
- Types changed: no (new props are from existing `FacetAggregation` type)
- Server API changed: no
- Backward compatible: yes

## Testing
- pnpm build passes across all packages
- Bug fix verified: outcomeDistribution key corrected to 'high' to match DB values
- Character distribution, streak, and rate limit props source from existing FacetAggregation fields

Closes #147