### PR TITLE
refactor(dashboard): remove dead API exports

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -105,7 +105,7 @@ export function fetchDashboardStats(range: '7d' | '30d' | '90d' | 'all' = '7d') 
 
 // ── Analysis (Phase 4) ────────────────────────────────────────────────────────
 
-export interface AnalysisApiResult {
+interface AnalysisApiResult {
   success: boolean;
   insights?: Array<{ id: string; type: string; title: string }>;
   error?: string;
@@ -161,18 +161,6 @@ export function analyzePromptQuality(sessionId: string) {
   return request<AnalysisApiResult>('/analysis/prompt-quality', {
     method: 'POST',
     body: JSON.stringify({ sessionId }),
-  });
-}
-
-export function findRecurringInsights(body?: { projectId?: string; limit?: number }) {
-  return request<{
-    success: boolean;
-    groups?: Array<{ insightIds: string[]; theme: string }>;
-    updatedCount?: number;
-    error?: string;
-  }>('/analysis/recurring', {
-    method: 'POST',
-    body: JSON.stringify(body ?? {}),
   });
 }
 
@@ -418,19 +406,3 @@ export async function reflectGenerateStream(
   return res;
 }
 
-export async function backfillFacetsStream(
-  sessionIds: string[],
-  signal?: AbortSignal
-): Promise<Response> {
-  const res = await fetch(`${BASE}/facets/backfill`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ sessionIds }),
-    signal,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`Backfill failed ${res.status}: ${text}`);
-  }
-  return res;
-}


### PR DESCRIPTION
## What
Removes three dead exports from `dashboard/src/lib/api.ts` that were never imported by any component or hook.

## Why
Dead exports add surface area, confuse readers into thinking these APIs are in use, and can mislead future refactors. Closes #158.

## How
- Removed `backfillFacetsStream()` — a raw SSE variant of `backfillFacets()` that was never wired up. `backfillFacets()` (the non-stream variant) handles SSE internally and is the active consumer.
- Removed `findRecurringInsights()` — POST to `/analysis/recurring`. No dashboard consumer exists.
- Removed `export` from `AnalysisApiResult` — the interface is still used internally by `analyzeSession()` and `analyzePromptQuality()`, just no longer exported.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes

## Testing
- Verified with `grep` — none of the three identifiers appear in any `.ts`/`.tsx` file outside `api.ts`
- `pnpm build` passes across the workspace