### PR TITLE
refactor(dashboard): consolidate ISO week utils into date-utils.ts

### DIFF
--- a/dashboard/src/components/patterns/WeekSelector.tsx
+++ b/dashboard/src/components/patterns/WeekSelector.tsx
@@ -1,34 +1,13 @@
 import { useEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { parseIsoWeekBounds } from '@/lib/date-utils';
 import type { WeekInfo } from '@/lib/api';
 
 interface WeekSelectorProps {
   currentWeek: string;      // e.g., "2026-W10"
   weeks: WeekInfo[];        // from GET /api/reflect/weeks, most recent first
   onWeekChange: (week: string) => void;
-}
-
-// Parse an ISO week string into UTC Monday/Sunday boundaries.
-// Adapted from parseIsoWeek in server/src/routes/shared-aggregation.ts --
-// uses inclusive end (Sunday) for display instead of exclusive end (next Monday) for SQL queries.
-// Kept here to avoid a server-side import in the dashboard bundle.
-function parseIsoWeekBounds(weekStr: string): { start: Date; end: Date } | null {
-  const match = /^(\d{4})-W(\d{2})$/.exec(weekStr);
-  if (!match) return null;
-
-  const year = parseInt(match[1], 10);
-  const week = parseInt(match[2], 10);
-
-  const jan4 = new Date(Date.UTC(year, 0, 4));
-  const jan4Day = jan4.getUTCDay();
-  const daysToMonday = jan4Day === 0 ? 6 : jan4Day - 1;
-  const week1Monday = new Date(jan4.getTime() - daysToMonday * 86400000);
-
-  const start = new Date(week1Monday.getTime() + (week - 1) * 7 * 86400000);
-  const end = new Date(start.getTime() + 6 * 86400000); // Sunday (inclusive for display)
-
-  return { start, end };
 }
 
 // Format a UTC date as "Mar 4" using UTC to avoid local timezone day shift.

--- a/dashboard/src/lib/date-utils.ts
+++ b/dashboard/src/lib/date-utils.ts
@@ -1,0 +1,43 @@
+// ISO week date utilities — keep in sync with server/src/routes/shared-aggregation.ts
+// Duplicated here to avoid a server-side import in the dashboard bundle.
+
+// Compute the current ISO week identifier (YYYY-WNN) in UTC.
+export function getCurrentIsoWeek(): string {
+  const now = new Date();
+  const nowDay = now.getUTCDay();
+  const daysToMonday = nowDay === 0 ? 6 : nowDay - 1;
+  const monday = new Date(now.getTime() - daysToMonday * 86400000);
+
+  // Thursday of this week determines the ISO year
+  const thursday = new Date(monday.getTime() + 3 * 86400000);
+  const year = thursday.getUTCFullYear();
+
+  // Find Monday of week 1 for this ISO year
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay();
+  const daysToW1Monday = jan4Day === 0 ? 6 : jan4Day - 1;
+  const week1Monday = new Date(jan4.getTime() - daysToW1Monday * 86400000);
+
+  const weekNum = Math.round((monday.getTime() - week1Monday.getTime()) / (7 * 86400000)) + 1;
+  return `${year}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+// Parse an ISO week string into UTC Monday/Sunday boundaries.
+// Uses inclusive end (Sunday) for display instead of exclusive end (next Monday) for SQL queries.
+export function parseIsoWeekBounds(weekStr: string): { start: Date; end: Date } | null {
+  const match = /^(\d{4})-W(\d{2})$/.exec(weekStr);
+  if (!match) return null;
+
+  const year = parseInt(match[1], 10);
+  const week = parseInt(match[2], 10);
+
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay();
+  const daysToMonday = jan4Day === 0 ? 6 : jan4Day - 1;
+  const week1Monday = new Date(jan4.getTime() - daysToMonday * 86400000);
+
+  const start = new Date(week1Monday.getTime() + (week - 1) * 7 * 86400000);
+  const end = new Date(start.getTime() + 6 * 86400000); // Sunday (inclusive for display)
+
+  return { start, end };
+}

--- a/dashboard/src/pages/PatternsPage.tsx
+++ b/dashboard/src/pages/PatternsPage.tsx
@@ -7,6 +7,7 @@ import { WeekSelector } from '@/components/patterns/WeekSelector';
 import { WeekAtAGlanceStrip } from '@/components/patterns/WeekAtAGlanceStrip';
 import { CollapsibleCategoryList } from '@/components/patterns/CollapsibleCategoryList';
 import { WorkingStyleHighlights } from '@/components/patterns/WorkingStyleHighlights';
+import { getCurrentIsoWeek } from '@/lib/date-utils';
 import { parseSSEStream } from '@/lib/sse';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -29,30 +30,6 @@ function formatRelativeDate(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
-}
-
-// Compute the current ISO week identifier (YYYY-WNN) in UTC.
-// Mirrors formatIsoWeek/parseIsoWeek in server/src/routes/shared-aggregation.ts
-// -- kept here to avoid a server-side import in the dashboard bundle.
-// IMPORTANT: keep in sync with the canonical server implementation.
-function getCurrentIsoWeek(): string {
-  const now = new Date();
-  const nowDay = now.getUTCDay();
-  const daysToMonday = nowDay === 0 ? 6 : nowDay - 1;
-  const monday = new Date(now.getTime() - daysToMonday * 86400000);
-
-  // Thursday of this week determines the ISO year
-  const thursday = new Date(monday.getTime() + 3 * 86400000);
-  const year = thursday.getUTCFullYear();
-
-  // Find Monday of week 1 for this ISO year
-  const jan4 = new Date(Date.UTC(year, 0, 4));
-  const jan4Day = jan4.getUTCDay();
-  const daysToW1Monday = jan4Day === 0 ? 6 : jan4Day - 1;
-  const week1Monday = new Date(jan4.getTime() - daysToW1Monday * 86400000);
-
-  const weekNum = Math.round((monday.getTime() - week1Monday.getTime()) / (7 * 86400000)) + 1;
-  return `${year}-W${String(weekNum).padStart(2, '0')}`;
 }
 
 export default function PatternsPage() {


### PR DESCRIPTION
## What
Creates `dashboard/src/lib/date-utils.ts` with `getCurrentIsoWeek()` and `parseIsoWeekBounds()`, replacing identical inline copies in `PatternsPage.tsx` and `WeekSelector.tsx`.

Closes #165

## Why
Both functions were duplicated with "keep in sync" comments pointing at `server/src/routes/shared-aggregation.ts`. A shared module eliminates the sync burden — one file to update if the server implementation ever changes.

## How
- New file: `dashboard/src/lib/date-utils.ts` — exports both functions with a single top-of-file "keep in sync with server" comment
- `PatternsPage.tsx` — removed inline `getCurrentIsoWeek`, added import
- `WeekSelector.tsx` — removed inline `parseIsoWeekBounds`, added import
- No logic changes anywhere

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes (pure dashboard refactor)

## Testing
- `npx tsc --noEmit` — no errors in changed files (pre-existing errors in unrelated files only)
- `pnpm build` — passes across all workspace packages