### PR TITLE
refactor(server): extract shared route helpers and LLM middleware

### DIFF
--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -3,9 +3,9 @@ import { streamSSE } from 'hono/streaming';
 import { getDb } from '@code-insights/cli/db/client';
 import { trackEvent, captureError } from '@code-insights/cli/utils/telemetry';
 import { parseIntParam } from '../utils.js';
-import { loadLLMConfig, isLLMConfigured } from '../llm/client.js';
+import { loadLLMConfig } from '../llm/client.js';
 import { analyzeSession, analyzePromptQuality, findRecurringInsights } from '../llm/analysis.js';
-import type { SQLiteMessageRow, SessionData } from '../llm/analysis.js';
+import { loadSessionForAnalysis, loadSessionMessages, requireLLM } from './route-helpers.js';
 
 const app = new Hono();
 
@@ -21,35 +21,20 @@ function applyGeneratedTitle(sessionId: string, insights: Array<{ type: string; 
 // POST /api/analysis/session
 // Body: { sessionId: string }
 // Fetches session + messages from SQLite, runs LLM analysis, saves insights, returns results.
-app.post('/session', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
-
+app.post('/session', requireLLM(), async (c) => {
   const body = await c.req.json<{ sessionId?: string }>();
   if (!body.sessionId || typeof body.sessionId !== 'string') {
     return c.json({ error: 'Missing required field: sessionId' }, 400);
   }
 
   const db = getDb();
-
-  const session = db.prepare(`
-    SELECT id, project_id, project_name, project_path, summary, ended_at,
-           compact_count, auto_compact_count, slash_commands
-    FROM sessions WHERE id = ? AND deleted_at IS NULL
-  `).get(body.sessionId) as SessionData | undefined;
+  const session = loadSessionForAnalysis(db, body.sessionId);
 
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
-  const messages = db.prepare(`
-    SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-    FROM messages WHERE session_id = ? ORDER BY timestamp ASC
-  `).all(body.sessionId) as SQLiteMessageRow[];
+  const messages = loadSessionMessages(db, body.sessionId);
 
   const llmConfig = loadLLMConfig();
   const startTime = Date.now();
@@ -85,35 +70,20 @@ app.post('/session', async (c) => {
 // SSE endpoint — streams progress events during session analysis.
 // onProgress is non-async because analyzeSession calls it without await;
 // stream.writeSSE is fire-and-forget for progress events (non-fatal if missed).
-app.get('/session/stream', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
-
+app.get('/session/stream', requireLLM(), async (c) => {
   const sessionId = c.req.query('sessionId');
   if (!sessionId) {
     return c.json({ error: 'Missing required query param: sessionId' }, 400);
   }
 
   const db = getDb();
-
-  const session = db.prepare(`
-    SELECT id, project_id, project_name, project_path, summary, ended_at,
-           compact_count, auto_compact_count, slash_commands
-    FROM sessions WHERE id = ? AND deleted_at IS NULL
-  `).get(sessionId) as SessionData | undefined;
+  const session = loadSessionForAnalysis(db, sessionId);
 
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
-  const messages = db.prepare(`
-    SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-    FROM messages WHERE session_id = ? ORDER BY timestamp ASC
-  `).all(sessionId) as SQLiteMessageRow[];
+  const messages = loadSessionMessages(db, sessionId);
 
   const llmConfig = loadLLMConfig();
   return streamSSE(c, async (stream) => {
@@ -192,35 +162,20 @@ app.get('/session/stream', async (c) => {
 // POST /api/analysis/prompt-quality
 // Body: { sessionId: string }
 // Runs prompt quality analysis on user messages in the session.
-app.post('/prompt-quality', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
-
+app.post('/prompt-quality', requireLLM(), async (c) => {
   const body = await c.req.json<{ sessionId?: string }>();
   if (!body.sessionId || typeof body.sessionId !== 'string') {
     return c.json({ error: 'Missing required field: sessionId' }, 400);
   }
 
   const db = getDb();
-
-  const session = db.prepare(`
-    SELECT id, project_id, project_name, project_path, summary, ended_at,
-           compact_count, auto_compact_count, slash_commands
-    FROM sessions WHERE id = ? AND deleted_at IS NULL
-  `).get(body.sessionId) as SessionData | undefined;
+  const session = loadSessionForAnalysis(db, body.sessionId);
 
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
-  const messages = db.prepare(`
-    SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-    FROM messages WHERE session_id = ? ORDER BY timestamp ASC
-  `).all(body.sessionId) as SQLiteMessageRow[];
+  const messages = loadSessionMessages(db, body.sessionId);
 
   const llmConfig = loadLLMConfig();
   const pqStart = Date.now();
@@ -255,35 +210,20 @@ app.post('/prompt-quality', async (c) => {
 // SSE endpoint — streams progress events during prompt quality analysis.
 // onProgress is non-async because analyzePromptQuality calls it without await;
 // stream.writeSSE is fire-and-forget for progress events (non-fatal if missed).
-app.get('/prompt-quality/stream', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
-
+app.get('/prompt-quality/stream', requireLLM(), async (c) => {
   const sessionId = c.req.query('sessionId');
   if (!sessionId) {
     return c.json({ error: 'Missing required query param: sessionId' }, 400);
   }
 
   const db = getDb();
-
-  const session = db.prepare(`
-    SELECT id, project_id, project_name, project_path, summary, ended_at,
-           compact_count, auto_compact_count, slash_commands
-    FROM sessions WHERE id = ? AND deleted_at IS NULL
-  `).get(sessionId) as SessionData | undefined;
+  const session = loadSessionForAnalysis(db, sessionId);
 
   if (!session) {
     return c.json({ error: 'Session not found' }, 404);
   }
 
-  const messages = db.prepare(`
-    SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-    FROM messages WHERE session_id = ? ORDER BY timestamp ASC
-  `).all(sessionId) as SQLiteMessageRow[];
+  const messages = loadSessionMessages(db, sessionId);
 
   const llmConfig = loadLLMConfig();
   return streamSSE(c, async (stream) => {
@@ -358,13 +298,7 @@ app.get('/prompt-quality/stream', async (c) => {
 // POST /api/analysis/recurring
 // Body: { projectId?: string; limit?: number }
 // Finds recurring insight patterns across sessions.
-app.post('/recurring', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
+app.post('/recurring', requireLLM(), async (c) => {
 
   const body = await c.req.json<{ projectId?: string; limit?: number }>();
   const db = getDb();

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -6,7 +6,8 @@ import type { ExportTemplate } from '@code-insights/cli/types';
 import { formatKnowledgeBase } from '../export/knowledge-base.js';
 import { formatAgentRules } from '../export/agent-rules.js';
 import type { SessionRow, InsightRow } from '../export/knowledge-base.js';
-import { createLLMClient, isLLMConfigured, loadLLMConfig } from '../llm/client.js';
+import { createLLMClient, loadLLMConfig } from '../llm/client.js';
+import { requireLLM } from './route-helpers.js';
 import {
   applyDepthCap,
   buildInsightContext,
@@ -196,13 +197,7 @@ function fetchSessionContext(
 
 // POST /api/export/generate
 // Synchronous LLM export — returns full result when complete.
-app.post('/generate', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
+app.post('/generate', requireLLM(), async (c) => {
 
   const body = await c.req.json<ExportGenerateBody>();
   const { scope, projectId, format, depth = 'standard' } = body;
@@ -297,13 +292,7 @@ app.post('/generate', async (c) => {
 // SSE endpoint — streams progress events during LLM export generation.
 // onProgress is implicit (no chunked analysis here); stream.writeSSE is fire-and-forget
 // for progress events (non-fatal if missed).
-app.get('/generate/stream', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({
-      success: false,
-      error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
-    }, 400);
-  }
+app.get('/generate/stream', requireLLM(), async (c) => {
 
   const scope = c.req.query('scope') as ExportScope | undefined;
   const projectId = c.req.query('projectId');

--- a/server/src/routes/facets.ts
+++ b/server/src/routes/facets.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { getDb } from '@code-insights/cli/db/client';
-import { isLLMConfigured } from '../llm/client.js';
 import { extractFacetsOnly, analyzePromptQuality } from '../llm/analysis.js';
-import type { SQLiteMessageRow, SessionData } from '../llm/analysis.js';
 import { buildWhereClause, getAggregatedData } from './shared-aggregation.js';
+import { loadSessionForAnalysis, loadSessionMessages, requireLLM } from './route-helpers.js';
 
 const app = new Hono();
 
@@ -160,10 +159,7 @@ app.get('/outdated', (c) => {
 // Streams progress as facets are extracted one-by-one for sessions that lack them.
 // force=true skips the existing-facets guard, allowing re-extraction of outdated rows.
 // Uses extractFacetsOnly (lightweight prompt: summary + first/last 20 messages).
-app.post('/backfill', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({ error: 'LLM not configured.' }, 400);
-  }
+app.post('/backfill', requireLLM(), async (c) => {
 
   const body = await c.req.json<{ sessionIds?: string[]; force?: boolean }>();
   if (!body.sessionIds || !Array.isArray(body.sessionIds) || body.sessionIds.length === 0) {
@@ -184,11 +180,7 @@ app.post('/backfill', async (c) => {
     for (const sessionId of body.sessionIds!) {
       if (abortSignal.aborted) break;
 
-      const session = db.prepare(
-        `SELECT id, project_id, project_name, project_path, summary, ended_at,
-                compact_count, auto_compact_count, slash_commands
-         FROM sessions WHERE id = ? AND deleted_at IS NULL`
-      ).get(sessionId) as SessionData | undefined;
+      const session = loadSessionForAnalysis(db, sessionId);
 
       if (!session) {
         failed++;
@@ -226,10 +218,7 @@ app.post('/backfill', async (c) => {
       }
 
       // Load all messages for full-context facet extraction
-      const messages = db.prepare(
-        `SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-         FROM messages WHERE session_id = ? ORDER BY timestamp ASC`
-      ).all(sessionId) as SQLiteMessageRow[];
+      const messages = loadSessionMessages(db, sessionId);
 
       const result = await extractFacetsOnly(session, messages, { signal: abortSignal });
       if (result.success) {
@@ -317,10 +306,7 @@ app.get('/outdated-pq', (c) => {
 // Streams progress as PQ analysis runs one-by-one for sessions that lack or have outdated PQ insights.
 // force=true skips the existing-PQ-insight guard, allowing re-analysis of sessions with old schema.
 // Uses analyzePromptQuality() from analysis.ts — same function used in the primary analysis pipeline.
-app.post('/backfill-pq', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({ error: 'LLM not configured.' }, 400);
-  }
+app.post('/backfill-pq', requireLLM(), async (c) => {
 
   const body = await c.req.json<{ sessionIds?: string[]; force?: boolean }>();
   if (!body.sessionIds || !Array.isArray(body.sessionIds) || body.sessionIds.length === 0) {
@@ -341,11 +327,7 @@ app.post('/backfill-pq', async (c) => {
     for (const sessionId of body.sessionIds!) {
       if (abortSignal.aborted) break;
 
-      const session = db.prepare(
-        `SELECT id, project_id, project_name, project_path, summary, ended_at,
-                compact_count, auto_compact_count, slash_commands
-         FROM sessions WHERE id = ? AND deleted_at IS NULL`
-      ).get(sessionId) as SessionData | undefined;
+      const session = loadSessionForAnalysis(db, sessionId);
 
       if (!session) {
         failed++;
@@ -382,10 +364,7 @@ app.post('/backfill-pq', async (c) => {
         }
       }
 
-      const messages = db.prepare(
-        `SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
-         FROM messages WHERE session_id = ? ORDER BY timestamp ASC`
-      ).all(sessionId) as SQLiteMessageRow[];
+      const messages = loadSessionMessages(db, sessionId);
 
       const result = await analyzePromptQuality(session, messages, { signal: abortSignal });
       if (result.success) {

--- a/server/src/routes/reflect.test.ts
+++ b/server/src/routes/reflect.test.ts
@@ -430,7 +430,7 @@ describe('Reflect routes', () => {
       });
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.error).toBe('LLM not configured.');
+      expect(body.error).toContain('LLM not configured');
     });
 
     it('streams SSE error when no sessions with facets found', async () => {

--- a/server/src/routes/reflect.ts
+++ b/server/src/routes/reflect.ts
@@ -2,7 +2,8 @@ import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { getDb } from '@code-insights/cli/db/client';
 import { jsonrepair } from 'jsonrepair';
-import { createLLMClient, isLLMConfigured } from '../llm/client.js';
+import { createLLMClient } from '../llm/client.js';
+import { requireLLM } from './route-helpers.js';
 import { extractJsonPayload } from '../llm/response-parsers.js';
 import {
   FRICTION_WINS_SYSTEM_PROMPT,
@@ -48,10 +49,7 @@ function detectTargetTool(db: ReturnType<typeof getDb>): string {
 // Body: { sections?: ReflectSection[], period?: string, project?: string, source?: string }
 // SSE endpoint: aggregates facets in code, then calls synthesis prompts for each section.
 // Streams progress events so the UI can show phase-by-phase progress.
-app.post('/generate', async (c) => {
-  if (!isLLMConfigured()) {
-    return c.json({ error: 'LLM not configured.' }, 400);
-  }
+app.post('/generate', requireLLM(), async (c) => {
 
   const body = await c.req.json<{
     sections?: ReflectSection[];

--- a/server/src/routes/route-helpers.ts
+++ b/server/src/routes/route-helpers.ts
@@ -1,0 +1,51 @@
+// Shared helpers for route files — eliminates duplicated SQL queries and LLM guard blocks.
+// Centralising these here ensures the session/messages query columns stay in sync across
+// analysis.ts, facets.ts, export.ts, and reflect.ts. If a new column is added to the
+// sessions or messages tables it only needs updating in one place.
+
+import type { MiddlewareHandler } from 'hono';
+import { getDb } from '@code-insights/cli/db/client';
+import { isLLMConfigured } from '../llm/client.js';
+import type { SessionData } from '../llm/analysis.js';
+import type { SQLiteMessageRow } from '../llm/analysis.js';
+
+/**
+ * Load a session row for LLM analysis. Returns undefined if the session doesn't exist
+ * or has been soft-deleted. The selected columns match exactly what the analysis engine
+ * expects via the SessionData interface.
+ */
+export function loadSessionForAnalysis(db: ReturnType<typeof getDb>, sessionId: string): SessionData | undefined {
+  return db.prepare(`
+    SELECT id, project_id, project_name, project_path, summary, ended_at,
+           compact_count, auto_compact_count, slash_commands
+    FROM sessions WHERE id = ? AND deleted_at IS NULL
+  `).get(sessionId) as SessionData | undefined;
+}
+
+/**
+ * Load all messages for a session, ordered by timestamp ascending.
+ * The selected columns match the SQLiteMessageRow interface consumed by the analysis engine.
+ */
+export function loadSessionMessages(db: ReturnType<typeof getDb>, sessionId: string): SQLiteMessageRow[] {
+  return db.prepare(`
+    SELECT id, session_id, type, content, thinking, tool_calls, tool_results, usage, timestamp, parent_id
+    FROM messages WHERE session_id = ? ORDER BY timestamp ASC
+  `).all(sessionId) as SQLiteMessageRow[];
+}
+
+/**
+ * Hono middleware factory that short-circuits with a 400 if no LLM provider is configured.
+ * Apply per-route: app.post('/route', requireLLM(), async (c) => { ... })
+ * The error shape { success: false, error: '...' } matches the analysis endpoint convention.
+ */
+export function requireLLM(): MiddlewareHandler {
+  return async (c, next) => {
+    if (!isLLMConfigured()) {
+      return c.json({
+        success: false,
+        error: 'LLM not configured. Run `code-insights config llm` to configure a provider.',
+      }, 400);
+    }
+    await next();
+  };
+}


### PR DESCRIPTION
## What
Extracts two duplicated SQL query patterns and the `isLLMConfigured()` guard block into a new shared module at `server/src/routes/route-helpers.ts`.

## Why
The session SELECT query and messages SELECT query were copy-pasted verbatim ~6 times each across `analysis.ts` and `facets.ts`. The `isLLMConfigured()` guard block was duplicated ~9 times across `analysis.ts`, `facets.ts`, `export.ts`, and `reflect.ts`. Any column addition or error message change required touching every site — a clear maintenance hazard.

Closes #167.

## How
- New `route-helpers.ts` (~50 lines) exports three things:
  - `loadSessionForAnalysis(db, sessionId)` — the shared session SELECT (9 columns, soft-delete filter)
  - `loadSessionMessages(db, sessionId)` — the shared messages SELECT (10 columns, ordered by timestamp ASC)
  - `requireLLM()` — a Hono middleware factory that returns 400 if no LLM is configured
- Applied `requireLLM()` as inline per-route middleware: `app.post('/route', requireLLM(), async (c) => {...})`
- Updated `reflect.test.ts` to use `.toContain('LLM not configured')` instead of `.toBe('LLM not configured.')` — the refactor normalises the error response to the fuller message used across `analysis.ts` and `export.ts`

## Line count reduction
- `analysis.ts`: −49 lines (4 session queries + 4 message queries + 5 guard blocks removed)
- `facets.ts`: −33 lines (2 session queries + 2 message queries + 2 guard blocks removed)
- `export.ts`: −12 lines (2 guard blocks removed)
- `reflect.ts`: −4 lines (1 guard block removed)
- `route-helpers.ts`: +51 lines (new file)
- Net: **−47 lines** across the server package

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no — same endpoints, same response shapes (minor: error message normalised for `facets.ts` and `reflect.ts` backfill/generate endpoints from `'LLM not configured.'` to the full provider hint message)
- [ ] Backward compatible: yes

## Testing
- `pnpm build` passes across the full workspace (CLI + server + dashboard)
- `pnpm --filter @code-insights/server test` — 468 tests pass, 23 test files