### PR TITLE
refactor(server): clean up re-export chain in analysis.ts

### DIFF
--- a/server/src/llm/analysis.ts
+++ b/server/src/llm/analysis.ts
@@ -32,11 +32,6 @@ import {
   type SessionData,
 } from './analysis-db.js';
 
-// Re-export SQLiteMessageRow so routes can import it from analysis.ts directly
-export type { SQLiteMessageRow };
-// Re-export DB types for backward compat (routes import InsightRow and SessionData from here)
-export type { InsightRow, SessionData } from './analysis-db.js';
-
 // Maximum tokens to send to LLM (leaving room for response)
 const MAX_INPUT_TOKENS = 80000;
 
@@ -64,8 +59,6 @@ export interface AnalysisResult {
   };
 }
 
-// Re-export ParseError so routes can import it from analysis.ts
-export type { ParseError };
 
 /**
  * Analyze a session and generate insights, saving them to SQLite.

--- a/server/src/llm/index.ts
+++ b/server/src/llm/index.ts
@@ -4,5 +4,6 @@ export type { LLMClient, LLMMessage, LLMResponse, ChatOptions } from './types.js
 export type { LLMProvider, LLMProviderConfig } from './types.js';
 export { createLLMClient, createClientFromConfig, loadLLMConfig, isLLMConfigured, testLLMConfig } from './client.js';
 export { analyzeSession, analyzePromptQuality, findRecurringInsights } from './analysis.js';
-export type { AnalysisResult, InsightRow, SessionData, RecurringInsightResult } from './analysis.js';
+export type { AnalysisResult, RecurringInsightResult } from './analysis.js';
+export type { InsightRow, SessionData } from './analysis-db.js';
 export { discoverOllamaModels } from './providers/ollama.js';

--- a/server/src/routes/route-helpers.ts
+++ b/server/src/routes/route-helpers.ts
@@ -8,8 +8,9 @@ import { streamSSE } from 'hono/streaming';
 import { getDb } from '@code-insights/cli/db/client';
 import { trackEvent, captureError } from '@code-insights/cli/utils/telemetry';
 import { isLLMConfigured, loadLLMConfig } from '../llm/client.js';
-import type { SessionData, AnalysisResult, AnalysisOptions } from '../llm/analysis.js';
-import type { SQLiteMessageRow } from '../llm/analysis.js';
+import type { AnalysisResult, AnalysisOptions } from '../llm/analysis.js';
+import type { SessionData } from '../llm/analysis-db.js';
+import type { SQLiteMessageRow } from '../llm/prompt-types.js';
 
 /**
  * Load a session row for LLM analysis. Returns undefined if the session doesn't exist


### PR DESCRIPTION
## What

Removes three re-export blocks from `server/src/llm/analysis.ts` that proxied types to route files via a single import point. Route files and `index.ts` now import types directly from their canonical modules.

Closes #171

## Why

`analysis.ts` re-exported `SQLiteMessageRow` and `ParseError` (owned by `prompt-types.ts`) and `InsightRow`/`SessionData` (owned by `analysis-db.ts`). This created false module dependencies: any edit to `prompt-types.ts` or `analysis-db.ts` would trigger TypeScript recompilation of every file that imported from `analysis.ts` — even route files with no logical connection to the changed type.

## How

- `server/src/routes/route-helpers.ts`: split the two `import type` lines from `analysis.js` into three — `AnalysisResult`/`AnalysisOptions` stay on `analysis.js`, `SessionData` moves to `analysis-db.js`, `SQLiteMessageRow` moves to `prompt-types.js`
- `server/src/llm/index.ts`: re-export of `InsightRow`/`SessionData` moved from `analysis.js` to `analysis-db.js`
- `server/src/llm/analysis.ts`: removed all three re-export lines and their comments

`ParseError` was re-exported but never consumed by routes — the import on line 13 was only for internal use within `analysis.ts` itself, so no consumer update was needed.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no (type _locations_ changed, not definitions)
- [ ] Server API changed: no
- [ ] Backward compatible: yes

## Testing

- `pnpm build` passes (CLI + server + dashboard)
- `cd server && pnpm test` — 468 tests pass across 23 test files