### PR TITLE
fix: enable Gemini JSON response mode to prevent malformed output

### DIFF
--- a/server/src/llm/providers/gemini.ts
+++ b/server/src/llm/providers/gemini.ts
@@ -23,6 +23,11 @@ export function createGeminiClient(apiKey: string, model: string): LLMClient {
         generationConfig: {
           temperature: 0.7,
           maxOutputTokens: 8192,
+          // Force valid JSON output at the decoding level.
+          // Without this, Gemini Flash often wraps JSON in markdown fences,
+          // prefixes prose, or produces structurally broken JSON that even
+          // jsonrepair cannot fix.
+          responseMimeType: 'application/json',
         },
       };
 


### PR DESCRIPTION
## Summary
- Adds `responseMimeType: 'application/json'` to the Gemini provider's `generationConfig`
- Fixes JSON parse failures when running session analysis with Gemini Flash — the model frequently returns malformed JSON (markdown fences, prose prefixes, broken structure) that even `jsonrepair` cannot recover from
- This constrains Gemini's token decoder to only emit valid JSON, eliminating the issue at the API level

## Test plan
- [x] All 779 tests pass
- [ ] Run `rerun-analysis.sh` with Gemini Flash and verify no more `JSONRepairError` failures
- [ ] Verify analysis results are correctly parsed and saved to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)