### PR TITLE
fix: reflect snapshot shows week end date instead of generation time

### DIFF
--- a/server/src/routes/reflect.ts
+++ b/server/src/routes/reflect.ts
@@ -213,7 +213,7 @@ app.post('/generate', requireLLM(), async (c) => {
           period,
           projectKey,
           JSON.stringify(results),
-          windowEnd,
+          new Date().toISOString(),
           windowStart,
           windowEnd,
           aggregated.totalSessions,


### PR DESCRIPTION
## Summary
- Fixed `generated_at` column in `reflect_snapshots` being set to `windowEnd` (the ISO week's end date) instead of the actual current timestamp
- This caused the "Generated Xd ago" label on the Patterns page to show how long ago the week ended, not when the reflection was generated (e.g., "42d ago" for a week ending Feb 2 when viewed on March 16)

## Root cause
Positional parameter mismatch in the INSERT statement at `server/src/routes/reflect.ts:216` — `windowEnd` was passed for both the `generated_at` and `window_end` columns.

## Test plan
- [x] All 468 server tests pass
- [ ] Generate a new reflection → verify "Generated just now" appears instead of stale date

🤖 Generated with [Claude Code](https://claude.com/claude-code)