### PR TITLE
docs: add Phase 10 coverage — Share Card, zero-config, guided empty states

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,9 +30,16 @@ code-insights/
 ├── dashboard/              # Vite + React SPA
 │   └── src/
 │       ├── components/     # React components (shadcn/ui)
+│       │   ├── empty-states/  # Guided empty states (EmptyDashboard, EmptySessions, EmptyInsights)
+│       │   └── patterns/      # Patterns page components (WeekAtAGlanceStrip, WeekSelector)
 │       ├── hooks/          # React Query hooks
 │       ├── lib/            # LLM providers, utilities, telemetry
+│       │   ├── share-card-utils.ts   # Canvas 2D share card rendering (drawShareCard, downloadShareCard)
+│       │   ├── share-card-icons.ts   # Lucide icon + tool logo rendering for Canvas 2D
+│       │   └── prompt-quality-utils.ts  # PQ category labels, strength set detection
 │       └── App.tsx         # SPA entry point
+│   └── public/
+│       └── icons/          # Source tool logos (Claude Code SVG, Cursor PNG, Codex PNG, Copilot PNG)
 ├── server/                 # Hono API server
 │   └── src/
 │       ├── routes/         # REST API endpoints
@@ -113,7 +120,7 @@ Providers are registered in `providers/registry.ts`. To add a new source tool:
 | `insights` | LLM-generated insights (5 types) | V1, V2 (index) |
 | `usage_stats` | Global usage aggregation | V1 |
 | `session_facets` | Cross-session facet data (friction, patterns, workflow) | V3 |
-| `reflect_snapshots` | Cached synthesis results, composite PK `(period, project_id)` | V4 |
+| `reflect_snapshots` | Cached synthesis results, composite PK `(period, project_id, source_tool)` | V4 |
 | `analysis_usage` | Per-session LLM analysis cost data, composite PK `(session_id, analysis_type)` | V7 |
 | `schema_version` | Migration tracking | V1 |
 
@@ -145,6 +152,7 @@ Dashboard (dashboard/src/)   -> Reads from Server API
 | `EffectivePattern` | Pattern with required `category`, `description`, `confidence`; optional `driver` field (`'user-driven' \| 'ai-driven' \| 'collaborative'`); CoT `_reasoning` scratchpad stored in JSON blob |
 | `SessionCharacter` | 7 classifications: deep_focus, bug_hunt, feature_build, exploration, refactor, learning, quick_task |
 | `ClaudeInsightConfig` | Config format |
+| `PQDimensionScores` | Per-dimension PQ averages (overall, context_provision, request_specificity, scope_management, information_timing, correction_quality); used by share card |
 | `SyncState` | File modification tracking for incremental sync |
 
 ### Friction & Pattern Normalization
@@ -253,5 +261,33 @@ Both friction points and effective patterns use canonical category taxonomies wi
 | Analytics | `/analytics` | Charts: cost, models, projects |
 | Patterns | `/patterns` | Cross-session synthesis (Friction & Wins, Rules & Skills, Working Style) |
 | Export | `/export` | LLM-powered export wizard (4 formats, 3 depths) |
-| Journal | `/journal` | Session journal/notes |
+| Journal | `/journal` | Chronological timeline of learnings and decisions by ISO week |
 | Settings | `/settings` | Configuration UI |
+
+---
+
+## Share Card Pipeline
+
+The share card generates a 1200×630 PNG (OG image standard) from Canvas 2D:
+
+```
+PatternsPage → useFacetAggregation(period) → WeekAtAGlanceStrip → "Share" button
+                                                                       ↓
+                                              downloadShareCard() → drawShareCard()
+                                                                       ↓
+                                              Canvas 2D (2400×1260 @ 2× DPR) → toBlob() → PNG download
+```
+
+**Data sources for the card:**
+- `computePQScores()` in `server/src/routes/shared-aggregation.ts` — 4-week rolling PQ dimension averages
+- Working-style tagline from Reflect LLM synthesis
+- Effective patterns from facet aggregation (top 3 by frequency)
+- Lifetime session count (all-time, no date filter)
+- Token sum from 4-week scoring window
+- Source tools from sessions in scope
+
+**Key files:**
+- `dashboard/src/lib/share-card-utils.ts` — Canvas 2D drawing logic (`drawShareCard()`, `downloadShareCard()`)
+- `dashboard/src/lib/share-card-icons.ts` — Lucide icon + tool logo rendering (`drawIcon()`, `drawToolIcon()`)
+- `dashboard/src/components/patterns/WeekAtAGlanceStrip.tsx` — UI component with download trigger
+- `dashboard/public/icons/` — Static tool logo assets (SVG/PNG)

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -114,16 +114,57 @@ Cross-session pattern detection and synthesis, powered by session facets:
 
 **Upcoming:** Progress tracking — "Am I getting better?" Weekly snapshots comparing friction trends and pattern emergence over time, helping developers see how their AI collaboration skills evolve.
 
+### Share Card (AI Fluency Score)
+
+A shareable 1200×630 PNG image (OG standard for Twitter/X, LinkedIn, Slack, Discord) that visualizes a developer's AI coding fluency. Downloaded from the Patterns page.
+
+**What's on the card:**
+- **Archetype tagline** — LLM-generated identity label from working-style synthesis (e.g., "The Methodical Achiever")
+- **AI Fluency Score** — Composite 0–100 score derived from 5 Prompt Quality dimension averages, displayed as a hero circle with gradient arc
+- **Fingerprint bars** — 5 rainbow-colored dimension bars showing per-dimension PQ scores:
+  - Context (context_provision), Clarity (request_specificity), Focus (scope_management), Timing (information_timing), Orchestration (correction_quality)
+- **Evidence lines** — "Score from N sessions · XK tokens · last 4 weeks" + "N lifetime sessions · [tool logos]"
+- **Effective pattern pills** — Top 3 patterns by frequency (if data exists)
+- **Tool logos** — Deduplicated source tool icons (Claude Code, Cursor, Codex CLI, GitHub Copilot)
+- **CTA footer** — code-insights.app + `npx @code-insights/cli`
+
+**Scoring window:** 4-week rolling window (last 4 ISO weeks) for stable, representative scores. Lifetime session count is all-time.
+
+**Technical details:**
+- Canvas 2D rendering at 2× DPR (2400×1260 internal) exported as 1200×630 PNG
+- Dark gradient background with subtle radial glows
+- System font stack with monospace fallback for code elements
+- Tool logos loaded from `dashboard/public/icons/` static assets
+
+### Zero-Config First Run
+
+Running `code-insights` with no arguments works immediately — auto-creates the database, syncs sessions, and opens the dashboard. No `init` required. The dashboard includes guided empty states with CLI command snippets for first-time users.
+
+### Knowledge Journal
+
+The Journal page (`/journal`) provides a chronological view of learnings and decisions extracted from sessions:
+
+- **Timeline tab** — Weeks grouped by ISO week with visual timeline dots (yellow for learnings, blue for decisions). Week headers show learning/decision counts. Newest-first within each week.
+- **Patterns tab** — Links to LLM analysis workflow for pattern discovery across sessions.
+
+### Chat View Enhancements
+
+Session detail chat view includes system event rendering:
+- **Context break dividers** — Visual markers where conversation context was reset (compacts)
+- **Inline event chips** — Slash commands displayed as inline chips (e.g., `/grep`, `/read`)
+- **Raw message toggle** — Switch between filtered and full conversation view
+- **Agent message rendering** — Task notifications (amber) and teammate messages (colored border)
+
 ### Dashboard Views
 
 - **Dashboard** — Overview with activity charts
 - **Sessions** — Session list with source, project, date, character filters
-- **Session Detail** — Full session with analyze button for LLM insights
+- **Session Detail** — Full session with analyze button, cost tracking, chat view enhancements
 - **Insights** — Browse and search generated insights
 - **Analytics** — Charts showing effort distribution, cost, models, projects
-- **Patterns** — Cross-session pattern synthesis (Friction & Wins, Rules & Skills, Working Style)
+- **Patterns** — Cross-session pattern synthesis (Friction & Wins, Rules & Skills, Working Style) + Share Card download + Week-at-a-Glance strip with streak, session count, AI Fluency Score
 - **Export** — LLM-powered export wizard (4 formats, 3 depths)
-- **Journal** — Session journal/notes
+- **Journal** — Chronological timeline of learnings and decisions by ISO week
 - **Settings** — Configuration UI
 
 ### CLI Command Reference
@@ -151,7 +192,8 @@ code-insights uninstall-hook               # Remove auto-sync hook
 #### Dashboard & Browser
 
 ```bash
-code-insights dashboard                    # Start local server + open dashboard
+code-insights dashboard                    # Start local server + open dashboard (auto-syncs first)
+code-insights dashboard --no-sync          # Start server without syncing first
 code-insights dashboard --port 8080        # Custom port (default: 7890)
 code-insights dashboard --no-open          # Start server without opening browser
 code-insights open                         # Open dashboard in browser (without starting server)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,6 +167,43 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 
 ---
 
+## Phase 10: User Experience & Shareability ✅
+
+**Goal:** Zero-friction first run, guided onboarding, and shareable AI Fluency Score card for PLG growth
+
+### Milestones
+
+- [x] **10.1 Zero-Config First Run** (v4.1.0) ✅
+  - `code-insights` with no args → auto-sync + open dashboard (no `init` required)
+  - Database and config auto-created on first run
+  - Dashboard auto-sync before server start (`--no-sync` to skip)
+  - Guided empty states with CLI command snippets (EmptyDashboard, EmptySessions, EmptyInsights)
+
+- [x] **10.2 Shareable Working Style Card** (v4.2.0) ✅
+  - 1200×630 PNG export (OG image standard) via Canvas 2D at 2× DPR
+  - Working style archetype tagline from LLM synthesis
+  - Session count, streak, character distribution visualization
+  - Computed milestones (session count, streak, multi-tool)
+  - Download from Patterns page WeekAtAGlanceStrip
+
+- [x] **10.3 AI Fluency Score Card V3** (v4.3.0) ✅
+  - Hero AI Fluency Score (0–100 composite from 5 PQ dimension averages)
+  - 5 rainbow fingerprint bars: Context, Clarity, Focus, Timing, Orchestration
+  - 4-week rolling scoring window (stable, representative scores)
+  - Lifetime session count + token sum in evidence lines
+  - Deduplicated source tool logos (Claude Code, Cursor, Codex CLI, GitHub Copilot)
+  - Effective pattern pills (top 3 by frequency)
+  - Conservative sky-blue-to-rose color palette
+  - `PQDimensionScores` type + `computePQScores()` server aggregation
+
+### Deliverables
+- ✅ Zero-config first run with guided empty states
+- ✅ Dashboard auto-sync
+- ✅ Shareable AI Fluency Score card (1200×630 PNG)
+- ✅ PQ dimension scores API and 4-week rolling aggregation
+
+---
+
 ## Version Milestones
 
 | Version | Phase | Key Features | Status |
@@ -187,12 +224,13 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 | 4.0.0 | 8–9 | Reflect & Patterns, taxonomy revisions, ISO weeks, prompt caching, cost tracking (Schema V7) | ✅ Done |
 | 4.1.0 | 10 | Zero-config first-run experience, dashboard auto-sync, guided empty states | ✅ Done |
 | 4.2.0 | 10 | Shareable working style card (1200×630 PNG export), computed milestones, streak fix | ✅ Done |
+| 4.3.0 | 10 | AI Fluency Score card V3, PQ dimension scores, conservative palette, tool logos | ✅ Done |
 
 ---
 
 ## What's Next
 
-- Progress tracking: weekly snapshots, friction-to-pattern affinity map (ships here, not in taxonomy PR), transformation detection, `driver`-based filtering for user growth signals
+- Progress tracking: weekly snapshots, friction-to-pattern affinity map, transformation detection, `driver`-based filtering for user growth signals
 - Test suite expansion (Vitest)
 - Session merging across tools (linking related sessions from different AI tools)
 - Shareable badges Phase 2: stats card variant, milestone-specific cards (see `docs/plans/2026-03-08-gamification-shareable-badges.md`)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -87,12 +87,15 @@ Effective pattern taxonomy upgraded with `driver` field (`user-driven`/`ai-drive
 ### Phase 9: Infrastructure & Reliability ✅
 Message classification V6 schema added `compact_count`, `auto_compact_count`, and `slash_commands` to sessions, with prompt alignment for V6 signals (PRs #151, #154). Prompt caching implemented using provider-native shared prefix caching for Anthropic (PR #180). LLM cost tracking V7 schema (`analysis_usage` table) captures per-session token counts, cache metrics, and estimated USD cost with a pricing calculator and dashboard cost UI (PR #181).
 
+### Phase 10: User Experience & Shareability ✅
+Zero-config first run: `code-insights` with no args auto-syncs and opens the dashboard — no `init` required (v4.1.0). Guided empty states for first-time users. Dashboard auto-sync before server start. Knowledge Journal page with chronological timeline of learnings and decisions by ISO week. Shareable AI Fluency Score card (v4.2.0–v4.3.0): 1200×630 PNG export with hero score (0–100 composite from 5 PQ dimensions), rainbow fingerprint bars, tool logos, effective pattern pills, and 4-week rolling scoring window.
+
 ### What's Next
 - Progress tracking: "Am I getting better?" — weekly snapshots comparing friction trends and pattern emergence, tracking user-actionable friction declining and new patterns solidifying
 - Friction-to-pattern affinity map (e.g., stale-assumptions friction → context-gathering pattern)
 - Test suite expansion (Vitest)
 - Session merging across tools (linking related sessions from different AI tools)
-- Gamification and shareable badges
+- Shareable badges Phase 2: stats card variant, milestone-specific cards
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

Documentation audit found all four docs were missing v4.1.0–v4.3.0 features (Phase 10). This PR closes the gaps:

- **PRODUCT.md**: Add Share Card (AI Fluency Score) section, zero-config first run, Knowledge Journal details, chat view enhancements, `--no-sync` flag
- **ROADMAP.md**: Add Phase 10 section with 3 milestones (10.1–10.3), v4.3.0 to version table
- **ARCHITECTURE.md**: Add share card pipeline diagram, `PQDimensionScores` type, dashboard component tree detail, fix `reflect_snapshots` composite PK (was missing `source_tool`)
- **VISION.md**: Add Phase 10 summary, update "What's Next" (shareable badges Phase 1 → complete)

## Audit findings not addressed here (implementation gaps)

These are documented as upcoming but not yet implemented — to be triaged after merge:

- Progress tracking (weekly snapshots, friction-to-pattern affinity map)
- Enhanced filtering (full-text search, saved filters)
- Session merging across tools
- Shareable badges Phase 2 (stats card, milestone cards)
- Test suite expansion (Vitest)
- Plugin architecture (deferred)

## Test plan

- [ ] Verify all four docs render correctly on GitHub
- [ ] Confirm no broken internal links
- [ ] Spot-check Share Card section against actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)