### PR TITLE
feat(dashboard): parallelize LLM analysis calls per session

### DIFF
--- a/dashboard/src/components/analysis/AnalysisContext.tsx
+++ b/dashboard/src/components/analysis/AnalysisContext.tsx
@@ -2,6 +2,9 @@
  * Analysis context for the embedded dashboard.
  * Consumes SSE streaming endpoints for real-time progress and cancellation.
  * Uses fetch() + ReadableStream (not EventSource) for AbortController support.
+ *
+ * State model: Map<analysisKey, AnalysisState> where analysisKey = `${sessionId}:${type}`.
+ * Each analysis entry owns its own AbortController — multiple analyses can run concurrently.
  */
 import {
   createContext,
@@ -16,8 +19,6 @@ import { getSessionTitle } from '@/lib/utils';
 import type { Session } from '@/lib/types';
 import { toast } from 'sonner';
 import { parseSSEStream } from '@/lib/sse';
-
-const ANALYSIS_TOAST_ID = 'analysis-toast';
 
 export interface AnalysisState {
   status: 'idle' | 'analyzing' | 'complete' | 'error';
@@ -41,24 +42,27 @@ export interface AnalysisState {
   } | null;
 }
 
-interface AnalysisContextValue {
-  state: AnalysisState;
-  startAnalysis: (session: Session, type: 'session' | 'prompt_quality') => Promise<void>;
-  cancelAnalysis: () => void;
-  clearResult: () => void;
+type AnalysisType = 'session' | 'prompt_quality';
+
+function makeKey(sessionId: string, type: AnalysisType): string {
+  return `${sessionId}:${type}`;
 }
 
-const IDLE_STATE: AnalysisState = {
-  status: 'idle',
-  sessionId: null,
-  sessionTitle: null,
-  type: 'session',
-  progress: null,
-  result: null,
-};
+function makeToastId(sessionId: string, type: AnalysisType): string {
+  return `analysis-${sessionId}-${type}`;
+}
+
+interface AnalysisContextValue {
+  analyses: Map<string, AnalysisState>;
+  getAnalysisState: (sessionId: string, type: AnalysisType) => AnalysisState | undefined;
+  startAnalysis: (session: Session, type: AnalysisType) => Promise<void>;
+  cancelAnalysis: (sessionId: string, type: AnalysisType) => void;
+  clearResult: (sessionId: string, type: AnalysisType) => void;
+}
 
 const AnalysisContext = createContext<AnalysisContextValue>({
-  state: IDLE_STATE,
+  analyses: new Map(),
+  getAnalysisState: () => undefined,
   startAnalysis: async () => {},
   cancelAnalysis: () => {},
   clearResult: () => {},
@@ -87,54 +91,70 @@ function buildToastMessage(
 }
 
 export function AnalysisProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<AnalysisState>(IDLE_STATE);
+  const [analyses, setAnalyses] = useState<Map<string, AnalysisState>>(new Map());
   const queryClient = useQueryClient();
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const isAnalyzingRef = useRef(false);
+  // Map of analysisKey → AbortController for concurrent cancellation
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
 
-  const cancelAnalysis = useCallback(() => {
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    isAnalyzingRef.current = false;
-    setState(IDLE_STATE);
-    toast.info('Analysis cancelled', { id: ANALYSIS_TOAST_ID, duration: 2000 });
+  const getAnalysisState = useCallback(
+    (sessionId: string, type: AnalysisType): AnalysisState | undefined => {
+      return analyses.get(makeKey(sessionId, type));
+    },
+    [analyses]
+  );
+
+  const cancelAnalysis = useCallback((sessionId: string, type: AnalysisType) => {
+    const key = makeKey(sessionId, type);
+    abortControllersRef.current.get(key)?.abort();
+    abortControllersRef.current.delete(key);
+    setAnalyses((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+    toast.info('Analysis cancelled', { id: makeToastId(sessionId, type), duration: 2000 });
   }, []);
 
-  const clearResult = useCallback(() => {
-    setState(IDLE_STATE);
+  const clearResult = useCallback((sessionId: string, type: AnalysisType) => {
+    const key = makeKey(sessionId, type);
+    setAnalyses((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
   }, []);
 
   const startAnalysis = useCallback(
-    async (session: Session, type: 'session' | 'prompt_quality') => {
-      if (isAnalyzingRef.current) {
-        toast.warning('Analysis already in progress. Please wait or cancel it first.');
-        return;
-      }
-      isAnalyzingRef.current = true;
-
+    async (session: Session, type: AnalysisType) => {
+      const key = makeKey(session.id, type);
+      const toastId = makeToastId(session.id, type);
       const sessionTitle = getSessionTitle(session);
       const controller = new AbortController();
-      abortControllerRef.current = controller;
 
-      setState({
-        status: 'analyzing',
-        sessionId: session.id,
-        sessionTitle,
-        type,
-        progress: {
-          phase: 'loading_messages',
-          message: 'Loading messages...',
-        },
-        result: null,
+      abortControllersRef.current.set(key, controller);
+
+      setAnalyses((prev) => {
+        const next = new Map(prev);
+        next.set(key, {
+          status: 'analyzing',
+          sessionId: session.id,
+          sessionTitle,
+          type,
+          progress: {
+            phase: 'loading_messages',
+            message: 'Loading messages...',
+          },
+          result: null,
+        });
+        return next;
       });
 
-      toast.loading(`Loading messages for "${sessionTitle}"...`, {
-        id: ANALYSIS_TOAST_ID,
-      });
+      toast.loading(`Loading messages for "${sessionTitle}"...`, { id: toastId });
 
-      const endpoint = type === 'session'
-        ? `/api/analysis/session/stream?sessionId=${encodeURIComponent(session.id)}`
-        : `/api/analysis/prompt-quality/stream?sessionId=${encodeURIComponent(session.id)}`;
+      const endpoint =
+        type === 'session'
+          ? `/api/analysis/session/stream?sessionId=${encodeURIComponent(session.id)}`
+          : `/api/analysis/prompt-quality/stream?sessionId=${encodeURIComponent(session.id)}`;
 
       try {
         const response = await fetch(endpoint, {
@@ -167,8 +187,13 @@ export function AnalysisProvider({ children }: { children: ReactNode }) {
                 progress.currentChunk,
                 progress.totalChunks
               );
-              setState((prev) => ({ ...prev, progress }));
-              toast.loading(toastMsg, { id: ANALYSIS_TOAST_ID });
+              setAnalyses((prev) => {
+                const next = new Map(prev);
+                const entry = next.get(key);
+                if (entry) next.set(key, { ...entry, progress });
+                return next;
+              });
+              toast.loading(toastMsg, { id: toastId });
             } else if (sseEvent.event === 'complete') {
               const result = JSON.parse(sseEvent.data) as {
                 success: boolean;
@@ -186,33 +211,41 @@ export function AnalysisProvider({ children }: { children: ReactNode }) {
 
               const successMsg = `${result.insightCount} insight${result.insightCount !== 1 ? 's' : ''} saved for "${sessionTitle}"`;
 
-              setState({
-                status: 'complete',
-                sessionId: session.id,
-                sessionTitle,
-                type,
-                progress: null,
-                result: {
-                  success: true,
-                  insightCount: result.insightCount,
-                  tokenUsage: result.tokenUsage,
-                  costUsd: result.costUsd,
-                  provider: result.provider,
-                  model: result.model,
-                },
+              setAnalyses((prev) => {
+                const next = new Map(prev);
+                next.set(key, {
+                  status: 'complete',
+                  sessionId: session.id,
+                  sessionTitle,
+                  type,
+                  progress: null,
+                  result: {
+                    success: true,
+                    insightCount: result.insightCount,
+                    tokenUsage: result.tokenUsage,
+                    costUsd: result.costUsd,
+                    provider: result.provider,
+                    model: result.model,
+                  },
+                });
+                return next;
               });
-              toast.success(successMsg, { id: ANALYSIS_TOAST_ID });
+              toast.success(successMsg, { id: toastId });
             } else if (sseEvent.event === 'error') {
               const errorData = JSON.parse(sseEvent.data) as { error: string };
-              setState({
-                status: 'error',
-                sessionId: session.id,
-                sessionTitle,
-                type,
-                progress: null,
-                result: { success: false, error: errorData.error },
+              setAnalyses((prev) => {
+                const next = new Map(prev);
+                next.set(key, {
+                  status: 'error',
+                  sessionId: session.id,
+                  sessionTitle,
+                  type,
+                  progress: null,
+                  result: { success: false, error: errorData.error },
+                });
+                return next;
               });
-              toast.error(`Analysis failed: ${errorData.error}`, { id: ANALYSIS_TOAST_ID });
+              toast.error(`Analysis failed: ${errorData.error}`, { id: toastId });
             }
           } catch {
             // Malformed SSE event data — skip and continue
@@ -222,15 +255,18 @@ export function AnalysisProvider({ children }: { children: ReactNode }) {
 
         // Stream ended — if no terminal event was received, treat as unexpected close
         if (!controller.signal.aborted) {
-          setState((prev) => {
-            if (prev.status === 'analyzing') {
-              toast.error('Analysis connection closed unexpectedly', { id: ANALYSIS_TOAST_ID });
-              return {
-                ...prev,
+          setAnalyses((prev) => {
+            const entry = prev.get(key);
+            if (entry?.status === 'analyzing') {
+              toast.error('Analysis connection closed unexpectedly', { id: toastId });
+              const next = new Map(prev);
+              next.set(key, {
+                ...entry,
                 status: 'error',
                 progress: null,
                 result: { success: false, error: 'Connection closed unexpectedly' },
-              };
+              });
+              return next;
             }
             return prev;
           });
@@ -240,25 +276,28 @@ export function AnalysisProvider({ children }: { children: ReactNode }) {
           return;
         }
         const errorMsg = error instanceof Error ? error.message : 'Analysis failed';
-        setState({
-          status: 'error',
-          sessionId: session.id,
-          sessionTitle,
-          type,
-          progress: null,
-          result: { success: false, error: errorMsg },
+        setAnalyses((prev) => {
+          const next = new Map(prev);
+          next.set(key, {
+            status: 'error',
+            sessionId: session.id,
+            sessionTitle,
+            type,
+            progress: null,
+            result: { success: false, error: errorMsg },
+          });
+          return next;
         });
-        toast.error(`Analysis failed: ${errorMsg}`, { id: ANALYSIS_TOAST_ID });
+        toast.error(`Analysis failed: ${errorMsg}`, { id: toastId });
       } finally {
-        abortControllerRef.current = null;
-        isAnalyzingRef.current = false;
+        abortControllersRef.current.delete(key);
       }
     },
     [queryClient]
   );
 
   return (
-    <AnalysisContext.Provider value={{ state, startAnalysis, cancelAnalysis, clearResult }}>
+    <AnalysisContext.Provider value={{ analyses, getAnalysisState, startAnalysis, cancelAnalysis, clearResult }}>
       {children}
     </AnalysisContext.Provider>
   );

--- a/dashboard/src/components/analysis/AnalyzeButton.tsx
+++ b/dashboard/src/components/analysis/AnalyzeButton.tsx
@@ -24,19 +24,15 @@ interface AnalyzeButtonProps {
 
 export function AnalyzeButton({ session, hasExistingInsights, insightCount }: AnalyzeButtonProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const { state: analysisState, startAnalysis, cancelAnalysis } = useAnalysis();
+  const { getAnalysisState, startAnalysis, cancelAnalysis } = useAnalysis();
   const { data: llmConfig } = useLlmConfig();
 
   const configured = !!(llmConfig?.provider && llmConfig?.model);
 
-  const isAnalyzingThisSession =
-    analysisState.status === 'analyzing' && analysisState.sessionId === session.id && analysisState.type === 'session';
-  const isAnalyzingOther =
-    analysisState.status === 'analyzing' && !isAnalyzingThisSession;
+  const analysisState = getAnalysisState(session.id, 'session');
+  const isAnalyzingThisSession = analysisState?.status === 'analyzing';
   const isCompleteForThisSession =
-    (analysisState.status === 'complete' || analysisState.status === 'error') &&
-    analysisState.sessionId === session.id &&
-    analysisState.type === 'session';
+    (analysisState?.status === 'complete' || analysisState?.status === 'error');
 
   const handleAnalyze = () => {
     startAnalysis(session, 'session');
@@ -73,34 +69,18 @@ export function AnalyzeButton({ session, hasExistingInsights, insightCount }: An
         <div className="flex items-center gap-3">
           <Button disabled variant="outline" className="gap-2">
             <Loader2 className="h-4 w-4 animate-spin" />
-            {analysisState.progress?.message || `Analyzing "${analysisState.sessionTitle}"...`}
+            {analysisState?.progress?.message || `Analyzing "${analysisState?.sessionTitle}"...`}
           </Button>
           <Button
             variant="ghost"
             size="sm"
             className="gap-1.5 text-muted-foreground hover:text-foreground"
-            onClick={cancelAnalysis}
+            onClick={() => cancelAnalysis(session.id, 'session')}
           >
             <X className="h-3.5 w-3.5" />
             Cancel
           </Button>
         </div>
-      </div>
-    );
-  }
-
-  if (isAnalyzingOther) {
-    return (
-      <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <Button disabled variant="outline" className="gap-2">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Analysis in progress...
-          </Button>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Waiting for &quot;{analysisState.sessionTitle}&quot; to finish
-        </p>
       </div>
     );
   }
@@ -139,7 +119,7 @@ export function AnalyzeButton({ session, hasExistingInsights, insightCount }: An
         </p>
       )}
 
-      {isCompleteForThisSession && analysisState.result?.success && (
+      {isCompleteForThisSession && analysisState?.result?.success && (
         <div className="text-sm text-green-600">
           {analysisState.result.insightCount != null
             ? `Analysis complete! ${analysisState.result.insightCount} insight${analysisState.result.insightCount !== 1 ? 's' : ''} saved.`
@@ -147,10 +127,10 @@ export function AnalyzeButton({ session, hasExistingInsights, insightCount }: An
         </div>
       )}
 
-      {isCompleteForThisSession && !analysisState.result?.success && (
+      {isCompleteForThisSession && !analysisState?.result?.success && (
         <div className="flex items-start gap-2 text-sm text-red-500">
           <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-          <span>{analysisState.result?.error || 'Analysis failed'}</span>
+          <span>{analysisState?.result?.error || 'Analysis failed'}</span>
         </div>
       )}
 

--- a/dashboard/src/components/analysis/AnalyzeDropdown.tsx
+++ b/dashboard/src/components/analysis/AnalyzeDropdown.tsx
@@ -39,7 +39,7 @@ export function AnalyzeDropdown({
 }: AnalyzeDropdownProps) {
   const [confirmSessionOpen, setConfirmSessionOpen] = useState(false);
   const [confirmPromptOpen, setConfirmPromptOpen] = useState(false);
-  const { state: analysisState, startAnalysis, cancelAnalysis } = useAnalysis();
+  const { getAnalysisState, startAnalysis, cancelAnalysis } = useAnalysis();
   const { data: llmConfig } = useLlmConfig();
   const { data: costData } = useAnalysisCost(session.id);
 
@@ -65,14 +65,16 @@ export function AnalyzeDropdown({
 
   const inputTokensLabel = formatEstimatedInputTokens(session);
 
-  const isAnalyzingThisSession =
-    analysisState.status === 'analyzing' && analysisState.sessionId === session.id;
-  const isAnalyzingOther =
-    analysisState.status === 'analyzing' && analysisState.sessionId !== session.id;
+  const sessionAnalysisState = getAnalysisState(session.id, 'session');
+  const pqAnalysisState = getAnalysisState(session.id, 'prompt_quality');
+
+  const isAnalyzingSession = sessionAnalysisState?.status === 'analyzing';
+  const isAnalyzingPq = pqAnalysisState?.status === 'analyzing';
+  // Either analysis type is running on this session
+  const isAnalyzingThisSession = isAnalyzingSession || isAnalyzingPq;
+
   const isCompleteForSession =
-    analysisState.status === 'complete' &&
-    analysisState.sessionId === session.id &&
-    analysisState.type === 'session';
+    sessionAnalysisState?.status === 'complete';
 
   const handleSessionAnalyze = () => {
     startAnalysis(session, 'session');
@@ -91,10 +93,7 @@ export function AnalyzeDropdown({
   };
 
   const handlePromptClick = () => {
-    const isCompleteForPrompt =
-      analysisState.status === 'complete' &&
-      analysisState.sessionId === session.id &&
-      analysisState.type === 'prompt_quality';
+    const isCompleteForPrompt = pqAnalysisState?.status === 'complete';
 
     if (hasExistingPromptQuality && !isCompleteForPrompt) {
       setConfirmPromptOpen(true);
@@ -114,13 +113,16 @@ export function AnalyzeDropdown({
     );
   }
 
+  // Show spinner for whichever analysis is currently running on this session
   if (isAnalyzingThisSession) {
+    const activeState = isAnalyzingSession ? sessionAnalysisState : pqAnalysisState;
+    const activeType = isAnalyzingSession ? 'session' : 'prompt_quality';
     return (
       <div className="flex items-center gap-1.5">
         <Button disabled variant="outline" size="sm" className="h-8 gap-2">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
           <span className="hidden sm:inline">
-            {analysisState.progress?.message || 'Analyzing...'}
+            {activeState?.progress?.message || 'Analyzing...'}
           </span>
           <span className="sm:hidden">Analyzing...</span>
         </Button>
@@ -128,25 +130,11 @@ export function AnalyzeDropdown({
           variant="ghost"
           size="sm"
           className="h-8 gap-1 text-muted-foreground hover:text-foreground"
-          onClick={cancelAnalysis}
+          onClick={() => cancelAnalysis(session.id, activeType)}
         >
           <X className="h-3.5 w-3.5" />
           <span className="sr-only sm:not-sr-only">Cancel</span>
         </Button>
-      </div>
-    );
-  }
-
-  if (isAnalyzingOther) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <Button disabled variant="outline" size="sm" className="h-8 gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          Analysis in progress...
-        </Button>
-        <span className="text-xs text-muted-foreground">
-          Waiting for &quot;{analysisState.sessionTitle}&quot;
-        </span>
       </div>
     );
   }

--- a/dashboard/src/components/analysis/AnalyzePromptQualityButton.tsx
+++ b/dashboard/src/components/analysis/AnalyzePromptQualityButton.tsx
@@ -22,25 +22,15 @@ interface AnalyzePromptQualityButtonProps {
 
 export function AnalyzePromptQualityButton({ session, hasExistingScore }: AnalyzePromptQualityButtonProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const { state: analysisState, startAnalysis, cancelAnalysis } = useAnalysis();
+  const { getAnalysisState, startAnalysis, cancelAnalysis } = useAnalysis();
   const { data: llmConfig } = useLlmConfig();
 
   const configured = !!(llmConfig?.provider && llmConfig?.model);
 
-  const isAnalyzingThisSession =
-    analysisState.status === 'analyzing' &&
-    analysisState.sessionId === session.id &&
-    analysisState.type === 'prompt_quality';
-  const isAnalyzingOtherSession =
-    analysisState.status === 'analyzing' && analysisState.sessionId !== session.id;
-  const isAnalyzingThisSessionOtherType =
-    analysisState.status === 'analyzing' &&
-    analysisState.sessionId === session.id &&
-    analysisState.type !== 'prompt_quality';
+  const analysisState = getAnalysisState(session.id, 'prompt_quality');
+  const isAnalyzingThisSession = analysisState?.status === 'analyzing';
   const isCompleteForThisSession =
-    (analysisState.status === 'complete' || analysisState.status === 'error') &&
-    analysisState.sessionId === session.id &&
-    analysisState.type === 'prompt_quality';
+    analysisState?.status === 'complete' || analysisState?.status === 'error';
 
   const handleAnalyze = () => {
     startAnalysis(session, 'prompt_quality');
@@ -70,29 +60,18 @@ export function AnalyzePromptQualityButton({ session, hasExistingScore }: Analyz
         <div className="flex items-center gap-2">
           <Button disabled variant="outline" size="sm" className="gap-2">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            {analysisState.progress?.message || 'Analyzing prompts...'}
+            {analysisState?.progress?.message || 'Analyzing prompts...'}
           </Button>
           <Button
             variant="ghost"
             size="sm"
             className="gap-1 text-muted-foreground hover:text-foreground"
-            onClick={cancelAnalysis}
+            onClick={() => cancelAnalysis(session.id, 'prompt_quality')}
           >
             <X className="h-3 w-3" />
             Cancel
           </Button>
         </div>
-      </div>
-    );
-  }
-
-  if (isAnalyzingOtherSession || isAnalyzingThisSessionOtherType) {
-    return (
-      <div className="space-y-2">
-        <Button disabled variant="outline" size="sm" className="gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          Analysis in progress...
-        </Button>
       </div>
     );
   }
@@ -124,10 +103,10 @@ export function AnalyzePromptQualityButton({ session, hasExistingScore }: Analyz
         </p>
       )}
 
-      {isCompleteForThisSession && !analysisState.result?.success && (
+      {isCompleteForThisSession && !analysisState?.result?.success && (
         <div className="flex items-start gap-2 text-sm text-red-500">
           <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-          <span>{analysisState.result?.error || 'Analysis failed'}</span>
+          <span>{analysisState?.result?.error || 'Analysis failed'}</span>
         </div>
       )}
 

--- a/dashboard/src/components/sessions/PromptQualityAnalyzeButton.tsx
+++ b/dashboard/src/components/sessions/PromptQualityAnalyzeButton.tsx
@@ -7,12 +7,12 @@ import { Loader2, Target } from 'lucide-react';
 
 /** Minimal analyze button for the Prompt Quality empty state. */
 export function PromptQualityAnalyzeButton({ session }: { session: Session }) {
-  const { state: analysisState, startAnalysis } = useAnalysis();
+  const { getAnalysisState, startAnalysis } = useAnalysis();
   const { data: llmConfig } = useLlmConfig();
   const configured = !!(llmConfig?.provider && llmConfig?.model);
 
-  const isAnalyzing =
-    analysisState.status === 'analyzing' && analysisState.sessionId === session.id;
+  const analysisState = getAnalysisState(session.id, 'prompt_quality');
+  const isAnalyzing = analysisState?.status === 'analyzing';
 
   if (!configured) {
     return (

--- a/dashboard/src/components/sessions/SessionDetailPanel.tsx
+++ b/dashboard/src/components/sessions/SessionDetailPanel.tsx
@@ -80,9 +80,12 @@ export function SessionDetailPanel({ sessionId, onDelete }: SessionDetailPanelPr
   const [searchHighlightId, setSearchHighlightId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [loadingAllMessages, setLoadingAllMessages] = useState(false);
-  const { state: analysisState } = useAnalysis();
+  const { getAnalysisState } = useAnalysis();
+  // Show cost indicator when either analysis type is actively running
+  const sessionAnalysisState = getAnalysisState(sessionId, 'session');
+  const pqAnalysisState = getAnalysisState(sessionId, 'prompt_quality');
   const isAnalyzingThisSession =
-    analysisState.status === 'analyzing' && analysisState.sessionId === sessionId;
+    sessionAnalysisState?.status === 'analyzing' || pqAnalysisState?.status === 'analyzing';
   const { data: missingFacetsData } = useMissingFacets();
   const backfillMutation = useBackfillFacets();
   const missingFacetIds = useMemo(


### PR DESCRIPTION
## What
Replace the single-analysis mutex (`isAnalyzingRef` + single `AbortController`) with a `Map<analysisKey, AnalysisState>` model, enabling concurrent per-session analysis. Any number of sessions can now be analyzed simultaneously, and both analysis types (`session` and `prompt_quality`) for the same session can run in parallel.

## Why
The previous design serialized all analysis behind a single boolean guard — clicking Analyze on session B while session A was running showed a disabled spinner and "Waiting for X to finish" message. With per-session state, each analysis is fully independent with no cross-session blocking.

## How
- `AnalysisContext`: `state: AnalysisState` → `analyses: Map<string, AnalysisState>` keyed by `${sessionId}:${type}`. Each entry owns its own `AbortController`. Toast IDs changed from single `ANALYSIS_TOAST_ID` to `analysis-${sessionId}-${type}` so multiple toasts stack natively via Sonner. New helper `getAnalysisState(sessionId, type)` for consumers.
- Context API: `cancelAnalysis()` → `cancelAnalysis(sessionId, type)`, `clearResult()` → `clearResult(sessionId, type)`.
- `AnalyzeButton`, `AnalyzePromptQualityButton`, `AnalyzeDropdown`: removed all `isAnalyzingOther` / `isAnalyzingThisSessionOtherType` blocking branches. Each button reads only its own Map entry.
- `PromptQualityAnalyzeButton` (sessions/), `SessionDetailPanel`: updated to new API.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes (dashboard-only change)

## Testing
- `pnpm build` from worktree root: 3881 modules, ✓ built in 2.65s, zero errors
- `pnpm test` from cli/: 15 test files, 322 tests, all passing
- Dashboard-only change — no server modifications needed

## Test Plan
- [ ] Navigate to a session detail page — Analyze dropdown renders correctly
- [ ] Start analysis on session A, navigate to session B — Analyze button on B is immediately clickable (no "Waiting..." state)
- [ ] Start session analysis and PQ analysis on same session — both run concurrently, each shows its own spinner + cancel
- [ ] Cancel one analysis — only that entry is cancelled, the other continues
- [ ] Multiple toasts stack in Sonner without overwriting each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)