### PR TITLE
feat: dashboard + docs updates for Phase 12 native analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Analyzes your sessions from **Claude Code, Cursor, Codex CLI, Copilot CLI, and V
 
 ---
 
+> **Claude Code users: zero-config analysis, zero cost.**
+> Install the hook once. Every session gets analyzed automatically using your Claude subscription.
+> ```bash
+> code-insights install-hook
+> ```
+
+---
+
 > **Works with Ollama — free, local, zero API keys.**
 > If you have [Ollama](https://ollama.com) installed, `code-insights` will detect it automatically and use it for AI analysis. No account, no cost, no data leaves your machine.
 >
@@ -108,6 +116,7 @@ npx @code-insights/cli
 # Or install globally
 npm install -g @code-insights/cli
 code-insights                          # sync sessions + open dashboard
+code-insights install-hook             # auto-sync + auto-analyze on session end
 ```
 
 ### Common Commands
@@ -123,7 +132,7 @@ code-insights sync --source cursor     # sync from a specific tool
 code-insights reflect                  # cross-session pattern synthesis
 code-insights reflect --week 2026-W11  # reflect on a specific week
 code-insights config llm               # configure LLM provider
-code-insights install-hook             # auto-sync when sessions end
+code-insights install-hook             # auto-sync + auto-analyze when sessions end
 ```
 
 See [`cli/README.md`](cli/README.md) for the full CLI reference.

--- a/dashboard/src/components/LlmNudgeBanner.tsx
+++ b/dashboard/src/components/LlmNudgeBanner.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router';
-import { X, Sparkles } from 'lucide-react';
+import { X, Sparkles, Terminal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLlmConfig } from '@/hooks/useConfig';
 
@@ -8,17 +8,9 @@ interface LlmNudgeBannerProps {
   context: 'insights' | 'patterns';
 }
 
-const COPY: Record<LlmNudgeBannerProps['context'], { title: string; description: string }> = {
-  insights: {
-    title: 'Get AI-powered insights',
-    description:
-      'Configure a provider to extract decisions, learnings, and patterns from your sessions.',
-  },
-  patterns: {
-    title: 'Enable cross-session pattern detection',
-    description:
-      'An AI provider is required to generate weekly friction and pattern analysis.',
-  },
+const TITLES: Record<LlmNudgeBannerProps['context'], string> = {
+  insights: 'Get AI-powered insights',
+  patterns: 'Enable cross-session pattern detection',
 };
 
 function localStorageKey(context: LlmNudgeBannerProps['context']): string {
@@ -51,17 +43,41 @@ export function LlmNudgeBanner({ context }: LlmNudgeBannerProps) {
     setDismissed(true);
   }
 
-  const { title, description } = COPY[context];
+  const title = TITLES[context];
 
   return (
-    <div role="status" className="flex items-start gap-3 rounded-lg border bg-muted/40 px-4 py-3 text-sm">
-      <Sparkles className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
-      <div className="flex-1 min-w-0">
-        <p className="font-medium">{title}</p>
-        <p className="text-muted-foreground mt-0.5">
-          {description}{' '}
-          <span className="text-muted-foreground">
-            Install{' '}
+    <div role="status" className="rounded-lg border bg-muted/40 px-4 py-3 text-sm">
+      <div className="flex items-start gap-3">
+        <Sparkles className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+        <div className="flex-1 min-w-0">
+          <p className="font-medium">{title}</p>
+
+          {/* Primary path: Claude Code hook */}
+          <div className="mt-2.5 rounded-md border border-dashed px-3 py-2.5 bg-background/60">
+            <div className="flex items-start gap-2">
+              <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <p className="font-medium text-foreground text-xs">Using Claude Code?</p>
+                <p className="text-muted-foreground text-xs mt-0.5">
+                  Analyze sessions automatically with your Claude subscription — no API key needed.
+                </p>
+                <code className="inline-block mt-1.5 rounded bg-muted px-2 py-0.5 text-[11px] font-mono text-foreground">
+                  code-insights install-hook
+                </code>
+              </div>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="flex items-center gap-2 my-2.5">
+            <div className="flex-1 border-t" />
+            <span className="text-[10px] text-muted-foreground/60 uppercase tracking-wide">or</span>
+            <div className="flex-1 border-t" />
+          </div>
+
+          {/* Secondary path: configure a provider */}
+          <p className="text-muted-foreground text-xs">
+            Configure a provider for manual analysis. Install{' '}
             <a
               href="https://ollama.com"
               target="_blank"
@@ -70,23 +86,24 @@ export function LlmNudgeBanner({ context }: LlmNudgeBannerProps) {
             >
               Ollama
             </a>{' '}
-            for free, local analysis — or configure any provider in Settings.
-          </span>
-        </p>
-      </div>
-      <div className="flex items-center gap-2 shrink-0 ml-2">
-        <Button variant="outline" size="sm" className="h-7 text-xs" asChild>
-          <Link to="/settings">Configure AI Provider</Link>
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onClick={handleDismiss}
-          aria-label="Dismiss"
-        >
-          <X className="h-3.5 w-3.5" />
-        </Button>
+            for free local analysis, or set up any provider in Settings.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0 ml-2">
+          <Button variant="outline" size="sm" className="h-7 text-xs" asChild>
+            <Link to="/settings">Configure AI Provider</Link>
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={handleDismiss}
+            aria-label="Dismiss"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/dashboard/src/components/sessions/AnalysisCostLine.tsx
+++ b/dashboard/src/components/sessions/AnalysisCostLine.tsx
@@ -53,6 +53,7 @@ export function AnalysisCostLine({ sessionId, isAnalyzing }: AnalysisCostLinePro
   }
 
   const { usage, totalCostUsd, cacheSavingsUsd } = data;
+  const allNative = usage.every(row => row.provider === 'claude-code-native');
   const allOllama = usage.every(row => row.provider === 'ollama');
 
   // Use the model and provider from the first usage row for the sublabel
@@ -63,6 +64,9 @@ export function AnalysisCostLine({ sessionId, isAnalyzing }: AnalysisCostLinePro
   const totalInput = usage.reduce((s, r) => s + r.input_tokens, 0);
   const totalOutput = usage.reduce((s, r) => s + r.output_tokens, 0);
 
+  // Total duration across all rows (for native provider display)
+  const totalDurationMs = usage.reduce((s, r) => s + (r.duration_ms ?? 0), 0);
+
   // Build sublabel
   const sublabelParts: string[] = [modelLabel];
   if (totalInput > 0) sublabelParts.push(`${formatTokens(totalInput)} in`);
@@ -70,9 +74,26 @@ export function AnalysisCostLine({ sessionId, isAnalyzing }: AnalysisCostLinePro
   if (cacheSavingsUsd > 0.005) sublabelParts.push(`saved ${formatCost(cacheSavingsUsd)}`);
   const sublabel = sublabelParts.join(' · ');
 
-  // Legacy sessions: usage row exists but cost is 0 and provider is not Ollama
+  // Legacy sessions: usage row exists but cost is 0 and provider is not Ollama or native
   // This shouldn't happen post-V7, but guard against it gracefully.
-  const isLegacy = totalCostUsd === 0 && !allOllama;
+  const isLegacy = totalCostUsd === 0 && !allOllama && !allNative;
+
+  // Native analysis via Claude Code — billed to Claude subscription, not a tracked cost
+  if (allNative) {
+    const durationSec = totalDurationMs > 0 ? Math.round(totalDurationMs / 1000) : null;
+    const nativeLabel = durationSec != null
+      ? `Analyzed via Claude Code · ${durationSec}s`
+      : 'Analyzed via Claude Code';
+    return (
+      <div className="flex flex-col gap-0.5 px-1 py-1 select-none">
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Sparkles className="h-3.5 w-3.5 text-purple-500 shrink-0" />
+          <span>{nativeLabel}</span>
+        </div>
+        <div className="text-[10px] text-muted-foreground/60 pl-5">{modelLabel}</div>
+      </div>
+    );
+  }
 
   const primaryText = allOllama
     ? 'Analysis: local (free)'
@@ -124,7 +145,7 @@ export function AnalysisCostLine({ sessionId, isAnalyzing }: AnalysisCostLinePro
                     {analysisTypeLabel(row.analysis_type)}
                   </span>
                   <span className="text-xs font-medium text-foreground shrink-0">
-                    {row.provider === 'ollama' ? 'free' : formatCost(row.estimated_cost_usd)}
+                    {row.provider === 'ollama' || row.provider === 'claude-code-native' ? 'free' : formatCost(row.estimated_cost_usd)}
                   </span>
                 </div>
                 <p className="text-[10px] text-muted-foreground mt-0.5">
@@ -145,7 +166,7 @@ export function AnalysisCostLine({ sessionId, isAnalyzing }: AnalysisCostLinePro
               <div className="flex items-center justify-between">
                 <span className="text-xs font-semibold text-foreground">Total</span>
                 <span className="text-xs font-semibold text-foreground">
-                  {allOllama ? 'free' : formatCost(totalCostUsd)}
+                  {allOllama || allNative ? 'free' : formatCost(totalCostUsd)}
                 </span>
               </div>
             </>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -229,7 +229,7 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 | 4.5.0 | — | Parallel LLM analysis, search ESCAPE fix, dynamic review specialists | ✅ Done |
 | 4.6.1 | — | User profile on share cards, GitHub avatar CORS fix | ✅ Done |
 | 4.7.0 | — | Ollama auto-detection, LlmNudgeBanner for unconfigured LLM | ✅ Done |
-| 4.8.0 | 12 | Native analysis via Claude Code hooks, unified `insights` command, runner interface | Planned |
+| 4.8.0 | 12 | Native analysis via Claude Code hooks, unified `insights` command, runner interface, V8 schema | ✅ Done |
 
 ---
 
@@ -265,12 +265,12 @@ This roadmap outlines the development phases for Code Insights. Timelines are fl
 
 ### Milestones
 
-- [ ] **12.1 Prompt Module Migration** (#238) — Move prompt builders from server to CLI for shared access
-- [ ] **12.2 Runner Interface** (#239) — AnalysisRunner abstraction with ClaudeNativeRunner + ProviderRunner
-- [ ] **12.3 `insights` CLI Command** (#240) — Unified command with `--native` and `--hook` modes, V8 schema migration
-- [ ] **12.4 Hook Installation** (#241) — `install-hook` adds SessionEnd analysis hook alongside existing sync hook
-- [ ] **12.5 Backfill Recovery** (#242) — `insights check` for unanalyzed sessions (7-day lookback)
-- [ ] **12.6 Dashboard + Docs** (#243) — Updated LlmNudgeBanner, analysis provenance, documentation
+- [x] **12.1 Prompt Module Migration** (#238) — Move prompt builders from server to CLI for shared access
+- [x] **12.2 Runner Interface** (#239) — AnalysisRunner abstraction with ClaudeNativeRunner + ProviderRunner
+- [x] **12.3 `insights` CLI Command** (#240) — Unified command with `--native` and `--hook` modes, V8 schema migration
+- [x] **12.4 Hook Installation** (#241) — `install-hook` adds SessionEnd analysis hook alongside existing sync hook
+- [x] **12.5 Backfill Recovery** (#242) — `insights check` for unanalyzed sessions (7-day lookback)
+- [x] **12.6 Dashboard + Docs** (#243) — Updated LlmNudgeBanner, analysis provenance, documentation
 
 ---
 


### PR DESCRIPTION
## What

Dashboard and documentation updates for the Phase 12 Native Analysis feature (v4.8.0).

## Why

Phase 12 ships zero-config analysis via Claude Code hooks. The dashboard and docs need to reflect this new capability — surfacing the hook as the primary CTA for unconfigured users, showing provenance on analyzed sessions, and updating the README/ROADMAP for the release.

## How

Four targeted changes, no new routes or API endpoints needed:

1. **LlmNudgeBanner rewrite** — Dual-path CTA: hook install block (primary, with `code-insights install-hook` command) + API provider configure button (secondary). Layout: bordered dashed box for hook path, `or` divider, then Ollama/provider text. Preserves existing dismiss logic and Ollama mention.

2. **AnalysisCostLine provenance badge** — When `provider = 'claude-code-native'`, renders "Analyzed via Claude Code · Xs" with model name sublabel instead of cost display. No cost shown — native analysis is billed to the Claude subscription. Follows same `allOllama` detection pattern already in the component.

3. **README.md callout** — Added `> Claude Code users: zero-config analysis, zero cost.` block above the existing Ollama callout. Updated `install-hook` description to "auto-sync + auto-analyze". Added `install-hook` to quickstart.

4. **ROADMAP.md** — All Phase 12 milestones 12.1–12.6 checked. v4.8.0 row updated from "Planned" to "✅ Done" with V8 schema mention.

## Schema Impact

- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes — `claude-code-native` provider is a new value in the existing `provider` column; the `AnalysisCostLine` branches on it before the existing Ollama/cost path

## Testing

- `pnpm build` (from repo root): **passed** — zero errors, all 3 packages built
- `pnpm test` (cli/): **passed** — 558 tests across 27 test files, zero failures
- Dashboard: no new routes or hooks; changes are isolated to two component files