### PR TITLE
fix(cli): detach hook analysis to survive Claude Code hook cleanup

### DIFF
--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -16,7 +16,12 @@
  */
 
 import chalk from 'chalk';
+import { spawn } from 'child_process';
+import { openSync, mkdirSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { getDb } from '../db/client.js';
+import { getConfigDir } from '../utils/config.js';
 import { ClaudeNativeRunner } from '../analysis/native-runner.js';
 import { ProviderRunner } from '../analysis/provider-runner.js';
 import {
@@ -262,6 +267,12 @@ export async function runInsightsCommand(options: InsightsCommandOptions): Promi
 
 // ── CLI command entry point ───────────────────────────────────────────────────
 
+/** Resolve the CLI entry point for spawning child processes. */
+const CLI_ENTRY = resolve(fileURLToPath(import.meta.url), '../../index.js');
+
+/** Log file for background hook analysis. */
+const HOOK_LOG_PATH = join(getConfigDir(), 'hook-analysis.log');
+
 export async function insightsCommand(
   sessionId: string | undefined,
   opts: {
@@ -279,7 +290,16 @@ export async function insightsCommand(
     let resolvedSessionId: string;
 
     if (opts.hook) {
-      // Hook mode: read { session_id, transcript_path, cwd } from stdin
+      // Hook mode: two-phase execution.
+      //
+      // Phase 1 (foreground): Read stdin, sync the session file to SQLite.
+      //   Must complete before the hook returns so data is in the DB.
+      //
+      // Phase 2 (detached): Spawn a background process to run analysis.
+      //   Detached from Claude Code's hook process tree so it survives
+      //   hook cleanup. Uses `insights <id> --native -q` (no --hook),
+      //   so no stdin dependency.
+
       const stdinData = await readStdin();
       let parsed: { session_id?: string; transcript_path?: string; cwd?: string };
       try {
@@ -294,11 +314,33 @@ export async function insightsCommand(
 
       resolvedSessionId = parsed.session_id;
 
-      // Sync the single file before analysis
+      // Phase 1: Sync the single file before analysis
       if (parsed.transcript_path) {
         const { syncSingleFile } = await import('./sync.js');
         await syncSingleFile({ filePath: parsed.transcript_path, sourceTool: opts.source, quiet });
       }
+
+      // Phase 2: Detach the analysis into a background process.
+      // claude -p spawned inside a hook subprocess gets cancelled by
+      // Claude Code's hook manager. Spawning a detached process with
+      // its own process group escapes that process tree.
+      const configDir = getConfigDir();
+      if (!existsSync(configDir)) {
+        mkdirSync(configDir, { recursive: true, mode: 0o700 });
+      }
+      const logFd = openSync(HOOK_LOG_PATH, 'a');
+
+      const args = [CLI_ENTRY, 'insights', resolvedSessionId, '--native', '-q'];
+      if (opts.force) args.push('--force');
+
+      const child = spawn(process.execPath, args, {
+        detached: true,
+        stdio: ['ignore', logFd, logFd],
+      });
+      child.unref();
+
+      // Hook returns immediately — analysis continues in background.
+      return;
     } else {
       if (!sessionId) {
         throw new Error('Session ID is required (or use --hook to read from stdin)');


### PR DESCRIPTION
## Summary
- Split hook-mode analysis into two phases: foreground sync + detached background analysis
- Fixes `claude -p` getting cancelled by Claude Code's hook process-tree management

## Why
The v4.8.0 SessionEnd hook runs `code-insights insights --hook --native -q`, which calls `claude -p` synchronously. Claude Code's hook manager owns the hook subprocess tree and terminates `claude -p` ("Hook cancelled"). The flagship zero-config analysis feature is silently broken for 100% of users.

## How
**Phase 1 (foreground):** Read stdin JSON (`session_id`, `transcript_path`), sync session file to SQLite via `syncSingleFile()`. Must complete before hook returns.

**Phase 2 (detached):** Spawn `node <cli-entry> insights <session_id> --native -q` as a detached process using `child_process.spawn({ detached: true })` + `child.unref()`. The new process gets its own process group, escaping Claude Code's hook cleanup. Hook returns immediately.

Background process stdout/stderr logged to `~/.code-insights/hook-analysis.log` (append mode) for debuggability.

## Investigation evidence
- `SessionEnd` fires correctly (confirmed via debug hook capturing stdin)
- stdin JSON is well-formed: `{"session_id":"...","transcript_path":"...","hook_event_name":"SessionEnd"}`
- `claude -p` starts (temp prompt file created) but gets killed ("Hook cancelled")
- Detached process spawns correctly (verified via `ps aux` — separate PID, own process group)
- Cannot fully verify `claude -p` completion from within a Claude Code session (hook interference)

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: no
- [ ] Backward compatible: yes

## Testing
- Build: PASS (`pnpm build`)
- Tests: PASS (558 tests, 27 files)
- Detached spawn verified (process starts with correct args, own PID)
- Full e2e verification requires testing from outside Claude Code session

## Test plan
- [ ] Start a Claude Code session, do work, exit
- [ ] Check `~/.code-insights/hook-analysis.log` for analysis output
- [ ] Open dashboard — session should have insights populated
- [ ] `insights check` should show 0 unanalyzed sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)