### PR TITLE
fix(cli): prevent infinite hook loop via env guard

### DIFF
--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -290,6 +290,14 @@ export async function insightsCommand(
     let resolvedSessionId: string;
 
     if (opts.hook) {
+      // Guard: prevent infinite loop.
+      // The detached child runs `claude -p`, which creates a Claude Code session.
+      // When that session ends, Claude Code fires SessionEnd again, re-triggering
+      // this hook. The env var breaks the cycle.
+      if (process.env.CODE_INSIGHTS_HOOK_ACTIVE) {
+        return;
+      }
+
       // Hook mode: two-phase execution.
       //
       // Phase 1 (foreground): Read stdin, sync the session file to SQLite.
@@ -336,6 +344,7 @@ export async function insightsCommand(
       const child = spawn(process.execPath, args, {
         detached: true,
         stdio: ['ignore', logFd, logFd],
+        env: { ...process.env, CODE_INSIGHTS_HOOK_ACTIVE: '1' },
       });
       child.unref();
 


### PR DESCRIPTION
## Summary
- Add `CODE_INSIGHTS_HOOK_ACTIVE` env var guard to prevent infinite SessionEnd hook loop

## Why
**Critical bug in v4.8.0/PR #256.** The detached child process runs `claude -p`, which creates a new Claude Code session. When that session ends, Claude Code fires `SessionEnd` again → triggers our hook → spawns another `claude -p` → infinite loop. This consumed the user's entire Claude usage quota.

## How
1. At the top of the `--hook` path, check `process.env.CODE_INSIGHTS_HOOK_ACTIVE` — if set, return immediately
2. When spawning the detached child, set `CODE_INSIGHTS_HOOK_ACTIVE=1` in its env
3. The child inherits this env var, so any `claude -p` session that triggers SessionEnd will see the guard and exit

## Testing
- Build: PASS
- Tests: PASS (558 tests)
- Loop prevention: env guard checked before any stdin read or sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)