### PR TITLE
fix: apply LLM-generated title from CLI insights path

### DIFF
--- a/cli/src/analysis/analysis-db.ts
+++ b/cli/src/analysis/analysis-db.ts
@@ -192,6 +192,18 @@ export function convertPQToInsightRow(response: PromptQualityResponse, session: 
 // --- DB writes ---
 
 /**
+ * Auto-apply an LLM-generated summary title as the session's generated_title.
+ * Called after saving insights so the session title reflects the analysis output.
+ */
+export function applyGeneratedTitle(sessionId: string, insights: Array<{ type: string; title?: string }>): void {
+  const summaryInsight = insights.find(i => i.type === 'summary');
+  if (!summaryInsight?.title) return;
+  const db = getDb();
+  db.prepare('UPDATE sessions SET generated_title = ? WHERE id = ? AND deleted_at IS NULL')
+    .run(summaryInsight.title.slice(0, 120), sessionId);
+}
+
+/**
  * Write insight rows to SQLite using prepared statements.
  */
 export function saveInsightsToDb(insights: InsightRow[]): void {

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -38,6 +38,7 @@ import {
   saveFacetsToDb,
   convertToInsightRows,
   convertPQToInsightRow,
+  applyGeneratedTitle,
 } from '../analysis/analysis-db.js';
 import { saveAnalysisUsage } from '../analysis/analysis-usage-db.js';
 import type { AnalysisRunner } from '../analysis/runner-types.js';
@@ -194,6 +195,7 @@ export async function runInsightsCommand(options: InsightsCommandOptions): Promi
   // Save session insights (upsert: insert new, delete old)
   const sessionInsights = convertToInsightRows(parsedSession.data, sessionData);
   saveInsightsToDb(sessionInsights);
+  applyGeneratedTitle(session.id, sessionInsights);
   deleteSessionInsights(session.id, {
     excludeTypes: ['prompt_quality'],
     excludeIds: sessionInsights.map(i => i.id),

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { getDb } from '@code-insights/cli/db/client';
 import { trackEvent } from '@code-insights/cli/utils/telemetry';
+import { applyGeneratedTitle } from '@code-insights/cli/analysis/analysis-db';
 import { parseIntParam } from '../utils.js';
 import { loadLLMConfig } from '../llm/client.js';
 import { analyzeSession, analyzePromptQuality, findRecurringInsights } from '../llm/analysis.js';
@@ -60,14 +61,6 @@ app.get('/usage', async (c) => {
   });
 });
 
-/** Auto-apply an LLM-generated summary title as the session's generated_title. */
-function applyGeneratedTitle(sessionId: string, insights: Array<{ type: string; title?: string }>) {
-  const summaryInsight = insights.find(i => i.type === 'summary');
-  if (!summaryInsight?.title) return;
-  const db = getDb();
-  db.prepare('UPDATE sessions SET generated_title = ? WHERE id = ? AND deleted_at IS NULL')
-    .run(summaryInsight.title.slice(0, 120), sessionId);
-}
 
 // POST /api/analysis/session
 // Body: { sessionId: string }


### PR DESCRIPTION
## Summary
- **Moved** `applyGeneratedTitle()` from `server/src/routes/analysis.ts` to `cli/src/analysis/analysis-db.ts` (shared location)
- **Added** call to `applyGeneratedTitle()` in the CLI's `runInsightsCommand()` after saving session insights
- **Updated** server to import from CLI package instead of defining its own copy

Previously, only the dashboard-triggered analysis (`POST /api/analysis/session`) updated the session's `generated_title`. The CLI/hook path (`code-insights insights <id> --native`) saved insights but silently skipped the title update.

## Test plan
- [x] CLI tests pass (558/558)
- [x] Server tests pass (486/486)
- [ ] Manual: run `code-insights insights <session_id> --native` on a session with a user_message title, verify `generated_title` updates to the LLM summary title

🤖 Generated with [Claude Code](https://claude.com/claude-code)