### PR TITLE
fix: preserve LLM-generated title from sync overwrite

### DIFF
--- a/cli/src/db/write.ts
+++ b/cli/src/db/write.ts
@@ -104,7 +104,7 @@ function getStmts() {
         ?, ?, ?, ?
       )
       ON CONFLICT(id) DO UPDATE SET
-        generated_title         = excluded.generated_title,
+        generated_title         = COALESCE(sessions.generated_title, excluded.generated_title),
         title_source            = excluded.title_source,
         session_character       = excluded.session_character,
         ended_at                = excluded.ended_at,


### PR DESCRIPTION
## Summary
- Session upsert's `ON CONFLICT DO UPDATE` unconditionally overwrote `generated_title` with the parser's heuristic title on every sync, clobbering the LLM-generated title set by `applyGeneratedTitle()` after analysis
- Changed to `COALESCE(sessions.generated_title, excluded.generated_title)` so existing titles are preserved and only set on first sync

## Test plan
- [x] All 557 CLI tests pass
- [x] Build succeeds
- [ ] Run `code-insights sync`, then generate insights from dashboard, then `code-insights sync` again — verify `generated_title` retains the LLM title

🤖 Generated with [Claude Code](https://claude.com/claude-code)