### PR TITLE
feat: add --model flag to native analysis, default to Sonnet

### DIFF
--- a/batch-native-analysis.sh
+++ b/batch-native-analysis.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# batch-native-analysis.sh — Analyze all unanalyzed sessions via `claude -p`.
+#
+# Uses `code-insights insights <id> --native --force` for each session.
+# Stops immediately on rate limit (429) errors to avoid wasting API calls.
+# Resume-safe: re-run anytime — already-analyzed sessions are skipped.
+#
+# Usage:
+#   ./batch-native-analysis.sh              # Run all unanalyzed sessions
+#   ./batch-native-analysis.sh --dry-run    # List sessions without running
+#   ./batch-native-analysis.sh --delay 10   # Custom delay between calls (default: 5s)
+#   ./batch-native-analysis.sh --min-msgs 5 # Min message count filter (default: 3)
+#   ./batch-native-analysis.sh --retry-failed  # Re-run only previously failed sessions
+#   ./batch-native-analysis.sh --model opus    # Use a specific model (default: sonnet)
+
+set -euo pipefail
+
+DB_PATH="${CODE_INSIGHTS_DB:-$HOME/.code-insights/data.db}"
+FAILED_LOG="batch-native-failures.log"
+DRY_RUN=false
+DELAY_BETWEEN=5
+MIN_MESSAGES=3
+RETRY_FAILED=false
+MODEL="sonnet"
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --delay) DELAY_BETWEEN="$2"; shift 2 ;;
+    --min-msgs) MIN_MESSAGES="$2"; shift 2 ;;
+    --retry-failed) RETRY_FAILED=true; shift ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --help|-h)
+      head -14 "$0" | tail -9
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+
+if ! command -v sqlite3 &>/dev/null; then
+  echo "Error: sqlite3 not found"
+  exit 1
+fi
+
+if ! command -v claude &>/dev/null; then
+  echo "Error: claude CLI not found in PATH"
+  echo "Install from: https://claude.ai/download"
+  exit 1
+fi
+
+if ! command -v code-insights &>/dev/null; then
+  echo "Error: code-insights CLI not found in PATH"
+  echo "Run: cd cli && pnpm build && npm link"
+  exit 1
+fi
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "Error: Database not found at $DB_PATH"
+  exit 1
+fi
+
+# ── Build session list ────────────────────────────────────────────────────────
+
+if [ "$RETRY_FAILED" = true ] && [ -f "$FAILED_LOG" ]; then
+  # Re-run only previously failed sessions
+  SESSION_IDS=$(cat "$FAILED_LOG" | sort -u)
+  SOURCE="failed log ($FAILED_LOG)"
+else
+  # All sessions missing analysis_usage (never analyzed), with enough messages
+  SESSION_IDS=$(sqlite3 "$DB_PATH" "
+    SELECT s.id
+    FROM sessions s
+    LEFT JOIN analysis_usage au ON au.session_id = s.id AND au.analysis_type = 'session'
+    WHERE s.deleted_at IS NULL
+      AND s.message_count >= $MIN_MESSAGES
+      AND au.session_id IS NULL
+    ORDER BY s.message_count DESC;
+  ")
+  SOURCE="unanalyzed (min ${MIN_MESSAGES} messages)"
+fi
+
+if [ -z "$SESSION_IDS" ]; then
+  echo "No sessions to analyze."
+  exit 0
+fi
+
+TOTAL=$(echo "$SESSION_IDS" | wc -l | tr -d ' ')
+
+echo "============================================"
+echo " Code Insights — Batch Native Analysis"
+echo "============================================"
+echo "  Source:       $SOURCE"
+echo "  Sessions:     $TOTAL"
+echo "  Model:        $MODEL"
+echo "  Delay:        ${DELAY_BETWEEN}s between calls"
+echo "  Min messages: $MIN_MESSAGES"
+echo "  Dry run:      $DRY_RUN"
+echo "  DB:           $DB_PATH"
+echo "============================================"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo "Sessions to analyze:"
+  IDX=0
+  for SESSION_ID in $SESSION_IDS; do
+    IDX=$((IDX + 1))
+    INFO=$(sqlite3 "$DB_PATH" "SELECT message_count || ' msgs | ' || project_name FROM sessions WHERE id = '$SESSION_ID';")
+    echo "  [$IDX/$TOTAL] $INFO  $SESSION_ID"
+  done
+  echo ""
+  echo "(dry run — no analysis calls made)"
+  exit 0
+fi
+
+# ── Run analysis ──────────────────────────────────────────────────────────────
+
+# Clear failed log for this run (append mode — retry-failed reads it first)
+> "$FAILED_LOG"
+
+START_TIME=$(date +%s)
+SUCCESS=0
+FAILED=0
+IDX=0
+
+for SESSION_ID in $SESSION_IDS; do
+  IDX=$((IDX + 1))
+
+  INFO=$(sqlite3 "$DB_PATH" "
+    SELECT message_count || ' msgs | ' || project_name
+    FROM sessions WHERE id = '$SESSION_ID';
+  ")
+
+  printf "[$IDX/$TOTAL] $INFO ... "
+
+  SESSION_START=$(date +%s)
+
+  # Run analysis — capture both stdout and stderr
+  OUTPUT=""
+  EXIT_CODE=0
+  OUTPUT=$(code-insights insights "$SESSION_ID" --native --force --model "$MODEL" 2>&1) || EXIT_CODE=$?
+
+  ELAPSED=$(( $(date +%s) - SESSION_START ))
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    SUCCESS=$((SUCCESS + 1))
+    echo "done (${ELAPSED}s)"
+  else
+    # ── Rate limit / overloaded detection ──────────────────────────────
+    # Check for 429, rate limit, overloaded, or capacity errors in output.
+    # These mean we should STOP — not retry — to avoid hammering the API.
+    if echo "$OUTPUT" | grep -qiE '429|rate.?limit|overloaded|too many requests|capacity|throttl'; then
+      echo "RATE LIMITED"
+      echo ""
+      echo "============================================"
+      echo " STOPPED — Rate limit or capacity error"
+      echo "============================================"
+      echo " Error output:"
+      echo "   $OUTPUT" | head -5
+      echo ""
+      echo " $SUCCESS sessions completed before hitting the limit."
+      echo " Remaining: $((TOTAL - IDX)) sessions not attempted."
+      echo ""
+      echo " To resume, wait a few minutes then re-run:"
+      echo "   ./batch-native-analysis.sh"
+      echo "============================================"
+
+      # Log this session as failed so --retry-failed picks it up
+      echo "$SESSION_ID" >> "$FAILED_LOG"
+
+      # Also log remaining un-attempted sessions
+      REMAINING_IDS=$(echo "$SESSION_IDS" | tail -n +$((IDX + 1)))
+      if [ -n "$REMAINING_IDS" ]; then
+        echo "$REMAINING_IDS" >> "$FAILED_LOG"
+      fi
+
+      # Print summary and exit
+      END_TIME=$(date +%s)
+      TOTAL_ELAPSED=$(( END_TIME - START_TIME ))
+      echo ""
+      echo "  Completed:   $SUCCESS"
+      echo "  Failed:      $((FAILED + 1))"
+      echo "  Not started: $((TOTAL - IDX))"
+      echo "  Elapsed:     $((TOTAL_ELAPSED / 60))m $((TOTAL_ELAPSED % 60))s"
+      echo "  Failed log:  $FAILED_LOG ($((FAILED + 1 + TOTAL - IDX)) session IDs)"
+      exit 2
+    fi
+
+    # Non-rate-limit error — log and continue
+    FAILED=$((FAILED + 1))
+    echo "FAILED (${ELAPSED}s)"
+    echo "  Error: $(echo "$OUTPUT" | head -3)"
+    echo "$SESSION_ID" >> "$FAILED_LOG"
+  fi
+
+  # Delay between calls (skip after last session)
+  if [ "$IDX" -lt "$TOTAL" ]; then
+    sleep "$DELAY_BETWEEN"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+END_TIME=$(date +%s)
+TOTAL_ELAPSED=$(( END_TIME - START_TIME ))
+
+echo ""
+echo "============================================"
+echo " Summary"
+echo "============================================"
+echo "  Total:      $TOTAL"
+echo "  Model:      $MODEL"
+echo "  Success:    $SUCCESS"
+echo "  Failed:     $FAILED"
+echo "  Elapsed:    $((TOTAL_ELAPSED / 60))m $((TOTAL_ELAPSED % 60))s"
+if [ "$FAILED" -gt 0 ]; then
+  echo "  Failed log: $FAILED_LOG ($FAILED session IDs)"
+  echo ""
+  echo "  To retry failed sessions:"
+  echo "    ./batch-native-analysis.sh --retry-failed"
+fi
+echo "============================================"

--- a/cli/src/analysis/__tests__/native-runner.test.ts
+++ b/cli/src/analysis/__tests__/native-runner.test.ts
@@ -70,7 +70,7 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'claude',
-      expect.arrayContaining(['-p', '--output-format', 'json', '--append-system-prompt-file', expect.stringContaining('ci-prompt-')]),
+      expect.arrayContaining(['-p', '--model', 'sonnet', '--output-format', 'json', '--append-system-prompt-file', expect.stringContaining('ci-prompt-')]),
       expect.objectContaining({
         input: 'Analyze this session.',
         encoding: 'utf-8',
@@ -82,6 +82,32 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     // --json-schema flag must NOT appear when jsonSchema is not provided
     const callArgs = mockExecFileSync.mock.calls[0][1] as string[];
     expect(callArgs).not.toContain('--json-schema');
+  });
+
+  it('passes custom model to claude -p args', async () => {
+    const llmJson = '{"summary": {"title": "t", "content": "c", "bullets": []}}';
+    mockExecFileSync.mockReturnValueOnce(makeEnvelope(llmJson) as unknown as Buffer);
+    const runner = new ClaudeNativeRunner({ model: 'opus' });
+
+    await runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' });
+
+    const callArgs = mockExecFileSync.mock.calls[0][1] as string[];
+    const modelIndex = callArgs.indexOf('--model');
+    expect(modelIndex).toBeGreaterThan(-1);
+    expect(callArgs[modelIndex + 1]).toBe('opus');
+  });
+
+  it('uses sonnet as default model when no model option provided', async () => {
+    const llmJson = '{"summary": {"title": "t", "content": "c", "bullets": []}}';
+    mockExecFileSync.mockReturnValueOnce(makeEnvelope(llmJson) as unknown as Buffer);
+    const runner = new ClaudeNativeRunner();
+
+    const result = await runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' });
+
+    const callArgs = mockExecFileSync.mock.calls[0][1] as string[];
+    const modelIndex = callArgs.indexOf('--model');
+    expect(callArgs[modelIndex + 1]).toBe('sonnet');
+    expect(result.model).toBe('sonnet');
   });
 
   it('includes --json-schema arg when jsonSchema is provided', async () => {
@@ -124,7 +150,7 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     expect(result.rawJson).toBe(llmJson);
     expect(result.inputTokens).toBe(0);
     expect(result.outputTokens).toBe(0);
-    expect(result.model).toBe('claude-native');
+    expect(result.model).toBe('sonnet'); // DEFAULT_NATIVE_MODEL
     expect(result.provider).toBe('claude-code-native');
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });

--- a/cli/src/analysis/native-runner.ts
+++ b/cli/src/analysis/native-runner.ts
@@ -63,8 +63,16 @@ function extractResultFromEnvelope(rawOutput: string): string {
   return resultEvent.result;
 }
 
+/** Default model used by ClaudeNativeRunner when --model is not specified. */
+export const DEFAULT_NATIVE_MODEL = 'sonnet';
+
 export class ClaudeNativeRunner implements AnalysisRunner {
   readonly name = 'claude-code-native';
+  private readonly model: string;
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? DEFAULT_NATIVE_MODEL;
+  }
 
   /**
    * Validate that the `claude` CLI is available in PATH.
@@ -101,6 +109,7 @@ export class ClaudeNativeRunner implements AnalysisRunner {
     try {
       const args = [
         '-p',
+        '--model', this.model,
         '--output-format', 'json',
         '--append-system-prompt-file', promptFile,
       ];
@@ -128,7 +137,7 @@ export class ClaudeNativeRunner implements AnalysisRunner {
         durationMs: Date.now() - start,
         inputTokens: 0,
         outputTokens: 0,
-        model: 'claude-native',
+        model: this.model,
         provider: 'claude-code-native',
       };
     } finally {

--- a/cli/src/analysis/queue-worker.ts
+++ b/cli/src/analysis/queue-worker.ts
@@ -18,6 +18,7 @@ export interface ProcessQueueOptions {
   quiet?: boolean;
   /** Runner type to use — 'native' uses claude -p, anything else uses configured provider */
   runnerType?: string;
+  model?: string;
 }
 
 /**
@@ -40,7 +41,7 @@ export async function processQueue(options: ProcessQueueOptions = {}): Promise<n
   let runner: ClaudeNativeRunner | undefined;
   try {
     ClaudeNativeRunner.validate();
-    runner = new ClaudeNativeRunner();
+    runner = new ClaudeNativeRunner({ model: options.model });
   } catch {
     // claude CLI not available — fall back to provider runner (runInsightsCommand handles this)
     runner = undefined;

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -93,6 +93,7 @@ export interface InsightsCommandOptions {
   force?: boolean;
   quiet?: boolean;
   source?: string;
+  model?: string;
   /** Pre-built runner to reuse across batch calls. Skips runner construction and validate(). */
   _runner?: AnalysisRunner;
 }
@@ -113,7 +114,7 @@ export async function runInsightsCommand(options: InsightsCommandOptions): Promi
     runner = options._runner;
   } else if (options.native) {
     ClaudeNativeRunner.validate();
-    runner = new ClaudeNativeRunner();
+    runner = new ClaudeNativeRunner({ model: options.model });
   } else {
     runner = ProviderRunner.fromConfig();
   }
@@ -267,6 +268,7 @@ export async function insightsCommand(
     source?: string;
     force?: boolean;
     quiet?: boolean;
+    model?: string;
   }
 ): Promise<void> {
   const quiet = opts.quiet ?? false;
@@ -290,6 +292,7 @@ export async function insightsCommand(
       force: opts.force ?? false,
       quiet,
       source: opts.source,
+      model: opts.model,
     });
   } catch (error) {
     if (!quiet) {
@@ -308,6 +311,7 @@ export async function insightsCheckCommand(opts: {
   days?: number;
   quiet?: boolean;
   analyze?: boolean;
+  model?: string;
 }): Promise<void> {
   const days = opts.days ?? 7;
   const quiet = opts.quiet ?? false;
@@ -343,7 +347,7 @@ export async function insightsCheckCommand(opts: {
     // --analyze: process all found sessions with progress output
     if (analyze) {
       ClaudeNativeRunner.validate();
-      const runner = new ClaudeNativeRunner();
+      const runner = new ClaudeNativeRunner({ model: opts.model });
       let successCount = 0;
 
       for (let i = 0; i < rows.length; i++) {
@@ -370,7 +374,7 @@ export async function insightsCheckCommand(opts: {
     // Auto-analyze silently when 1-2 unanalyzed sessions
     if (count <= 2) {
       ClaudeNativeRunner.validate();
-      const runner = new ClaudeNativeRunner();
+      const runner = new ClaudeNativeRunner({ model: opts.model });
       for (const row of rows) {
         try {
           await runInsightsCommand({ sessionId: row.id, native: true, quiet: true, _runner: runner });

--- a/cli/src/commands/queue.ts
+++ b/cli/src/commands/queue.ts
@@ -59,12 +59,12 @@ export async function queueStatusCommand(opts: { quiet?: boolean } = {}): Promis
 
 // ── queue process ─────────────────────────────────────────────────────────────
 
-export async function queueProcessCommand(opts: { quiet?: boolean } = {}): Promise<void> {
+export async function queueProcessCommand(opts: { quiet?: boolean; model?: string } = {}): Promise<void> {
   const { quiet = false } = opts;
   const log = quiet ? () => {} : console.log.bind(console);
 
   try {
-    const count = await processQueue({ quiet });
+    const count = await processQueue({ quiet, model: opts.model });
     if (count === 0) {
       log(chalk.dim('[Code Insights] No pending items in queue'));
     } else {
@@ -131,7 +131,8 @@ export function buildQueueCommand(): Command {
     .command('process')
     .description('Process pending queue items (foreground)')
     .option('-q, --quiet', 'Suppress output')
-    .action((opts) => queueProcessCommand({ quiet: opts.quiet }));
+    .option('--model <model>', 'Model for native analysis (default: sonnet)')
+    .action((opts) => queueProcessCommand({ quiet: opts.quiet, model: opts.model }));
 
   queueCmd
     .command('retry [session_id]')

--- a/cli/src/commands/session-end.ts
+++ b/cli/src/commands/session-end.ts
@@ -34,6 +34,7 @@ export interface SessionEndOptions {
   native?: boolean;
   quiet?: boolean;
   source?: string;
+  model?: string;
 }
 
 /**
@@ -85,10 +86,10 @@ export async function sessionEndCommand(options: SessionEndOptions = {}): Promis
   enqueue(sessionId, native ? 'native' : 'provider');
 
   // Phase 3: Spawn detached worker to process the queue
-  spawnWorker(quiet);
+  spawnWorker(quiet, options.model);
 }
 
-function spawnWorker(quiet: boolean): void {
+function spawnWorker(quiet: boolean, model?: string): void {
   try {
     const configDir = getConfigDir();
     if (!existsSync(configDir)) {
@@ -98,6 +99,7 @@ function spawnWorker(quiet: boolean): void {
 
     const args = [CLI_ENTRY, 'queue', 'process'];
     if (quiet) args.push('-q');
+    if (model) args.push('--model', model);
 
     const child = spawn(process.execPath, args, {
       detached: true,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -127,8 +127,9 @@ program
   .option('--native', 'Use claude -p for analysis worker (default: true)')
   .option('-s, --source <tool>', 'Source tool identifier (default: claude-code)')
   .option('-q, --quiet', 'Suppress output')
+  .option('--model <model>', 'Model for native analysis (default: sonnet)')
   .action(async (opts) => {
-    await sessionEndCommand({ native: opts.native ?? true, quiet: opts.quiet, source: opts.source });
+    await sessionEndCommand({ native: opts.native ?? true, quiet: opts.quiet, source: opts.source, model: opts.model });
   });
 
 // queue command suite — manage the analysis_queue
@@ -143,6 +144,7 @@ const insightsCmd = program
   .option('-s, --source <tool>', 'Source tool identifier (default: claude-code)')
   .option('--force', 'Re-analyze even if already analyzed at this session length')
   .option('-q, --quiet', 'Suppress output')
+  .option('--model <model>', 'Model for native analysis (default: sonnet)')
   .action(async (sessionId: string | undefined, opts) => {
     await insightsCommand(sessionId, opts);
   });
@@ -153,11 +155,13 @@ insightsCmd
   .option('--days <n>', 'Lookback window in days', '7')
   .option('-q, --quiet', 'Machine-readable output (just count)')
   .option('--analyze', 'Process all found sessions sequentially')
+  .option('--model <model>', 'Model for native analysis (default: sonnet)')
   .action(async (opts) => {
     await insightsCheckCommand({
       days: opts.days ? parseInt(opts.days, 10) : 7,
       quiet: opts.quiet,
       analyze: opts.analyze,
+      model: opts.model,
     });
   });
 


### PR DESCRIPTION
## What
Adds a `--model <model>` flag to all native analysis paths (`insights`, `insights check`, `session-end`, `queue process`, `batch-native-analysis.sh`). Defaults to `sonnet`.

## Why
Closes #264. Users may want to choose a different model (e.g., `opus` for complex sessions, `haiku` for speed) without being locked to whatever default the claude CLI picks. Defaulting to Sonnet is cost-effective for structured JSON extraction tasks.

## How
- `ClaudeNativeRunner`: added `DEFAULT_NATIVE_MODEL = 'sonnet'` constant, optional `{ model? }` constructor param, injects `--model <value>` into `claude -p` args after `-p`, returns `this.model` instead of hardcoded `'claude-native'` in the result (so `analysis_usage.model` records the actual model used)
- Model threads through the full call chain: `insights` → `runInsightsCommand` → `ClaudeNativeRunner`; `session-end` → `spawnWorker(model)` → `queue process --model` → `processQueue({ model })` → `ClaudeNativeRunner`
- `batch-native-analysis.sh`: added `--model` flag, shows model in summary header

## Schema Impact
- [ ] SQLite schema changed: no — `analysis_usage.model` column already exists as `TEXT NOT NULL`
- [ ] Types changed: yes — `InsightsCommandOptions`, `ProcessQueueOptions`, `SessionEndOptions`, `InsightsCheckCommand opts` all gained optional `model?`
- [ ] Server API changed: no
- [ ] Backward compatible: yes — all additions are optional with `'sonnet'` default

## Testing
- `pnpm build` from repo root: passes (zero errors)
- `pnpm test` from cli/: 559 tests pass (27 test files)
- Added 2 new tests to `native-runner.test.ts`: custom model arg injection, default model verification
- Updated existing test: `result.model` now asserts `'sonnet'` instead of `'claude-native'`