### PR TITLE
fix(server): use JSON test prompt in testLLMConfig for llamacpp compatibility

### DIFF
--- a/server/src/llm/client.ts
+++ b/server/src/llm/client.ts
@@ -68,7 +68,7 @@ export function createClientFromConfig(config: LLMProviderConfig): LLMClient {
 export async function testLLMConfig(config: LLMProviderConfig): Promise<{ success: boolean; error?: string }> {
   try {
     const client = createClientFromConfig(config);
-    await client.chat([{ role: 'user', content: 'Say "ok" and nothing else.' }]);
+    await client.chat([{ role: 'user', content: 'Respond with exactly this JSON and nothing else: {"status":"ok"}' }]);
     return { success: true };
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

- Fix llama.cpp dashboard \"Test Connection\" button failing with API 422 error
- Root cause: test prompt requested plain text `ok`, but llamacpp provider enforces `response_format: json_object` on every request — small local models replied with literal `ok`, failing JSON validation on both attempts
- Changed test prompt to request explicit JSON output: `'Respond with exactly this JSON and nothing else: {"status":"ok"}'` — works universally across all providers

## Why

The llamacpp provider unconditionally uses JSON mode (required for structured output in analysis). The old test prompt was incompatible with this constraint. The fix is a one-line change in `testLLMConfig()` — no provider changes needed.

## How

Single change in `server/src/llm/client.ts` line 71: prompt updated to request JSON output so all providers (OpenAI, Anthropic, Gemini, Ollama, llamacpp) can pass the connectivity check.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no
- [ ] Server API changed: yes — `POST /api/config/llm/test` sends a different test prompt (behavior change: llamacpp test now succeeds instead of failing)
- [ ] Backward compatible: yes

## Testing
- `pnpm build`: PASS (zero errors)
- `pnpm test`: PASS (1049 tests, 50 test files)
- Manual: connect a llamacpp server and verify Settings → Test Connection returns success instead of 422

## Test plan
- [ ] Test connection works for llama.cpp provider on dashboard Settings page (previously failed with 422)
- [ ] Test connection still works for OpenAI/Anthropic/Gemini/Ollama providers