### PR TITLE
fix(cursor): fix timestamps, cost/token usage, gitBranch, and messageCount consistency

### DIFF
--- a/cli/src/providers/__tests__/cursor.test.ts
+++ b/cli/src/providers/__tests__/cursor.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import Database from 'better-sqlite3';
+import { CursorProvider } from '../cursor.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — build a minimal Cursor-style SQLite database in a temp dir.
+//
+// CursorProvider.parse() accepts a virtual path: `<dbPath>#<composerId>`.
+// We create a real SQLite file with the `cursorDiskKV` table that Cursor uses
+// and store JSON composer data blobs exactly as Cursor would.
+// ---------------------------------------------------------------------------
+
+const COMPOSER_ID = 'test-composer-abc123';
+
+function makeCursorDb(dir: string, composerData: Record<string, unknown>): string {
+  const dbPath = path.join(dir, 'state.vscdb');
+  const db = new Database(dbPath);
+  db.exec('CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT);');
+  db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)').run(
+    `composerData:${COMPOSER_ID}`,
+    JSON.stringify(composerData),
+  );
+  db.close();
+  return dbPath;
+}
+
+function virtualPath(dbPath: string): string {
+  return `${dbPath}#${COMPOSER_ID}`;
+}
+
+function userBubble(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { bubbleId: 'bubble-user-1', type: 1, text: 'How do I fix the login bug?', ...overrides };
+}
+
+function assistantBubble(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { bubbleId: 'bubble-assistant-1', type: 2, text: 'Here is how to fix the login bug.', ...overrides };
+}
+
+describe('CursorProvider — parsing accuracy fixes', () => {
+  let tempDir: string;
+  const provider = new CursorProvider();
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Timestamps ────────────────────────────────────────────────────────────
+
+  it('uses timingInfo.clientRpcSendTime as the timestamp for assistant bubbles', async () => {
+    const rpcTime = 1748076005959;
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble(),
+        assistantBubble({ timingInfo: { clientRpcSendTime: rpcTime, clientStartTime: 926228.7 } }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const assistantMsg = session!.messages.find(m => m.type === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.timestamp.getTime()).toBe(rpcTime);
+  });
+
+  it('falls back to epoch when timingInfo is absent on an assistant bubble', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [userBubble(), assistantBubble()],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const assistantMsg = session!.messages.find(m => m.type === 'assistant');
+    expect(assistantMsg!.timestamp.getTime()).toBe(0);
+  });
+
+  it('ignores clientStartTime (performance offset < 1e12) and falls back to epoch', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble(),
+        assistantBubble({ timingInfo: { clientStartTime: 926228.7 } }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const assistantMsg = session!.messages.find(m => m.type === 'assistant');
+    expect(assistantMsg!.timestamp.getTime()).toBe(0);
+  });
+
+  it('falls back to epoch for user bubbles (no timestamp available)', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble(),
+        assistantBubble({ timingInfo: { clientRpcSendTime: 1748076005959 } }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const userMsg = session!.messages.find(m => m.type === 'user');
+    expect(userMsg!.timestamp.getTime()).toBe(0);
+  });
+
+  // ── Cost (usageData) ───────────────────────────────────────────────────────
+
+  it('converts usageData.default.costInCents to estimatedCostUsd', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [userBubble(), assistantBubble()],
+      usageData: { default: { costInCents: 44 } },
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.usage).toBeDefined();
+    expect(session!.usage!.estimatedCostUsd).toBeCloseTo(0.44);
+  });
+
+  it('leaves usage undefined when usageData is absent and no token counts', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [userBubble(), assistantBubble()],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.usage).toBeUndefined();
+  });
+
+  it('leaves usage undefined when usageData.default is absent', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [userBubble(), assistantBubble()],
+      usageData: {},
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.usage).toBeUndefined();
+  });
+
+  // ── Token counts ──────────────────────────────────────────────────────────
+
+  it('aggregates tokenCount from multiple assistant bubbles', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ bubbleId: 'u1', text: 'First question' }),
+        assistantBubble({ bubbleId: 'a1', text: 'First answer', tokenCount: { inputTokens: 100, outputTokens: 50 } }),
+        userBubble({ bubbleId: 'u2', text: 'Second question' }),
+        assistantBubble({ bubbleId: 'a2', text: 'Second answer', tokenCount: { inputTokens: 200, outputTokens: 75 } }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.usage).toBeDefined();
+    expect(session!.usage!.totalInputTokens).toBe(300);
+    expect(session!.usage!.totalOutputTokens).toBe(125);
+  });
+
+  it('skips tokenCount on user bubbles (always 0/0)', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ tokenCount: { inputTokens: 0, outputTokens: 0 } }),
+        assistantBubble({ tokenCount: { inputTokens: 150, outputTokens: 60 } }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.usage!.totalInputTokens).toBe(150);
+    expect(session!.usage!.totalOutputTokens).toBe(60);
+  });
+
+  // ── gitBranch ─────────────────────────────────────────────────────────────
+
+  it('extracts gitBranch from gitStatusRaw on the first user bubble', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ gitStatusRaw: "On branch main\nYour branch is up to date.\n\nnothing to commit" }),
+        assistantBubble(),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.gitBranch).toBe('main');
+  });
+
+  it('returns null gitBranch when gitStatusRaw shows detached HEAD', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ gitStatusRaw: 'HEAD detached at abc1234\nnothing to commit' }),
+        assistantBubble(),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.gitBranch).toBeNull();
+  });
+
+  it('returns null gitBranch when git reports "(no branch)"', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ gitStatusRaw: 'On branch (no branch)\nInteractive rebase in progress' }),
+        assistantBubble(),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.gitBranch).toBeNull();
+  });
+
+  it('returns null gitBranch when no gitStatusRaw is present', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [userBubble(), assistantBubble()],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.gitBranch).toBeNull();
+  });
+
+  // ── messageCount consistency ──────────────────────────────────────────────
+
+  it('messageCount equals userMessageCount + assistantMessageCount', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ bubbleId: 'u1' }),
+        assistantBubble({ bubbleId: 'a1' }),
+        userBubble({ bubbleId: 'u2', text: 'follow-up question' }),
+        assistantBubble({ bubbleId: 'a2', text: 'follow-up answer' }),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    expect(session!.messageCount).toBe(session!.userMessageCount + session!.assistantMessageCount);
+    expect(session!.userMessageCount).toBe(2);
+    expect(session!.assistantMessageCount).toBe(2);
+    expect(session!.messageCount).toBe(4);
+  });
+});

--- a/cli/src/providers/codex.ts
+++ b/cli/src/providers/codex.ts
@@ -646,7 +646,7 @@ function buildSession(
     sessionCharacter: null,
     startedAt,
     endedAt,
-    messageCount: messages.length,
+    messageCount: userMessages.length + assistantMessages.length,
     userMessageCount: userMessages.length,
     assistantMessageCount: assistantMessages.length,
     toolCallCount,

--- a/cli/src/providers/copilot-cli.ts
+++ b/cli/src/providers/copilot-cli.ts
@@ -428,7 +428,7 @@ function parseCopilotSession(filePath: string): ParsedSession | null {
       sessionCharacter: null,
       startedAt,
       endedAt,
-      messageCount: messages.length,
+      messageCount: userMessages.length + assistantMessages.length,
       userMessageCount: userMessages.length,
       assistantMessageCount: assistantMessages.length,
       toolCallCount,

--- a/cli/src/providers/copilot.ts
+++ b/cli/src/providers/copilot.ts
@@ -354,7 +354,7 @@ function parseCopilotSession(filePath: string): ParsedSession | null {
       sessionCharacter: null,
       startedAt,
       endedAt,
-      messageCount: messages.length,
+      messageCount: userMessages.length + assistantMessages.length,
       userMessageCount: userMessages.length,
       assistantMessageCount: assistantMessages.length,
       toolCallCount,

--- a/cli/src/providers/cursor.ts
+++ b/cli/src/providers/cursor.ts
@@ -500,7 +500,11 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
       if ((bubble.type === 1 || bubble.role === 'user') && typeof bubble.gitStatusRaw === 'string') {
         const match = bubble.gitStatusRaw.match(/^On branch (.+)/m);
         if (match) {
-          gitBranch = match[1].trim();
+          const branchName = match[1].trim();
+          // Exclude detached HEAD state which git reports as "(no branch)"
+          if (branchName !== '(no branch)') {
+            gitBranch = branchName;
+          }
           break;
         }
       }
@@ -509,7 +513,7 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
     // Build session usage from composerData.usageData (cost in cents) and
     // per-bubble tokenCount aggregation (inputTokens/outputTokens on assistant bubbles).
     let usage: import('../types.js').SessionUsage | undefined;
-    const usageData = composerData.usageData as Record<string, { costInCents?: number; amount?: number }> | undefined;
+    const usageData = composerData.usageData as Record<string, { costInCents?: number }> | undefined;
     const costInCents = usageData?.default?.costInCents;
 
     // Sum token counts from assistant bubbles (user bubbles always report 0)

--- a/cli/src/providers/cursor.ts
+++ b/cli/src/providers/cursor.ts
@@ -472,10 +472,10 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
     const timestamps = messages.map(m => m.timestamp.getTime()).filter(t => t > 0);
     let startedAt = timestamps.length > 0
       ? new Date(timestamps.reduce((a, b) => a < b ? a : b))
-      : new Date();
+      : new Date(0); // Epoch fallback — avoids misleading "now" timestamps
     let endedAt = timestamps.length > 0
       ? new Date(timestamps.reduce((a, b) => a > b ? a : b))
-      : new Date();
+      : new Date(0);
 
     // If timestamps are missing or invalid, try composerData timestamps
     const createdAt = composerData.createdAt as number | undefined;
@@ -492,6 +492,52 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
     const assistantMessages = messages.filter(m => m.type === 'assistant');
     const toolCallCount = messages.reduce((sum, m) => sum + m.toolCalls.length, 0);
 
+    // Extract gitBranch from the first user bubble that has gitStatusRaw.
+    // gitStatusRaw looks like: "On branch master\nYour branch is up to date..."
+    // gitStatusRaw is not surfaced on ParsedMessage — scan rawBubbles directly.
+    let gitBranch: string | null = null;
+    for (const bubble of rawBubbles) {
+      if ((bubble.type === 1 || bubble.role === 'user') && typeof bubble.gitStatusRaw === 'string') {
+        const match = bubble.gitStatusRaw.match(/^On branch (.+)/m);
+        if (match) {
+          gitBranch = match[1].trim();
+          break;
+        }
+      }
+    }
+
+    // Build session usage from composerData.usageData (cost in cents) and
+    // per-bubble tokenCount aggregation (inputTokens/outputTokens on assistant bubbles).
+    let usage: import('../types.js').SessionUsage | undefined;
+    const usageData = composerData.usageData as Record<string, { costInCents?: number; amount?: number }> | undefined;
+    const costInCents = usageData?.default?.costInCents;
+
+    // Sum token counts from assistant bubbles (user bubbles always report 0)
+    let totalInput = 0;
+    let totalOutput = 0;
+    for (const bubble of rawBubbles) {
+      if (bubble.type === 2 || bubble.role === 'assistant') {
+        const tc = bubble.tokenCount as Record<string, number> | undefined;
+        if (tc) {
+          totalInput += tc.inputTokens || 0;
+          totalOutput += tc.outputTokens || 0;
+        }
+      }
+    }
+
+    if (typeof costInCents === 'number' || totalInput > 0 || totalOutput > 0) {
+      usage = {
+        totalInputTokens: totalInput,
+        totalOutputTokens: totalOutput,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        estimatedCostUsd: typeof costInCents === 'number' ? costInCents / 100 : 0,
+        modelsUsed: [],
+        primaryModel: 'unknown',
+        usageSource: 'session',
+      };
+    }
+
     const session: ParsedSession = {
       id: `cursor:${composerId}`,
       projectPath,
@@ -502,17 +548,17 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
       sessionCharacter: null,
       startedAt,
       endedAt,
-      messageCount: messages.length,
+      messageCount: userMessages.length + assistantMessages.length,
       userMessageCount: userMessages.length,
       assistantMessageCount: assistantMessages.length,
       toolCallCount,
       compactCount: 0,
       autoCompactCount: 0,
       slashCommands: [],
-      gitBranch: null, // Not available from Cursor's DB
+      gitBranch,
       claudeVersion: null,
       sourceTool: 'cursor',
-      usage: undefined, // No token data in Cursor's DB
+      usage,
       messages,
     };
 
@@ -707,10 +753,17 @@ function parseBubbles(conversation: Array<Record<string, unknown>>, sessionId: s
     // Truncate to 10,000 chars (same as Claude Code parser)
     const truncatedContent = content.length > 10000 ? content.slice(0, 10000) : content;
 
-    // Extract timestamp (milliseconds)
+    // Extract timestamp (milliseconds).
+    // Cursor does not store a createdAt field on bubbles. Real wall-clock time lives
+    // in assistant bubbles under timingInfo.clientRpcSendTime (Unix ms). User bubbles
+    // have no timestamp — leave as epoch so session bounds code filters them out.
+    // NOTE: clientStartTime is a performance offset (e.g. 926228.7 ms), NOT a wall clock.
     let timestamp: Date;
-    if (bubble.createdAt) {
-      timestamp = new Date(typeof bubble.createdAt === 'number' ? bubble.createdAt : Date.parse(bubble.createdAt as string));
+    const timingInfo = bubble.timingInfo as Record<string, unknown> | undefined;
+    const clientRpcSendTime = timingInfo?.clientRpcSendTime;
+    if (typeof clientRpcSendTime === 'number' && clientRpcSendTime > 1_000_000_000_000) {
+      // Sanity-check: must be after 2001-09-09 (Unix ms > 1e12) to be a wall clock
+      timestamp = new Date(clientRpcSendTime);
     } else {
       timestamp = new Date(0); // Epoch fallback — filtered out of session bounds calculation
     }
@@ -761,7 +814,7 @@ function parseBubbles(conversation: Array<Record<string, unknown>>, sessionId: s
       thinking: null, // Cursor doesn't expose thinking
       toolCalls,
       toolResults: [], // Not available from Cursor's format
-      usage: null, // No per-message usage data
+      usage: null, // Per-message usage not available; session-level tokens aggregated from rawBubbles
       timestamp,
       parentId: null,
     });

--- a/cli/src/providers/cursor.ts
+++ b/cli/src/providers/cursor.ts
@@ -538,6 +538,12 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
       };
     }
 
+    // Check if Cursor tagged this session as an agentic session.
+    // unifiedMode === 'agent' (vs 'ask') or isAgentic === true marks agent-mode sessions.
+    const isAgentic =
+      composerData.unifiedMode === 'agent' ||
+      composerData.isAgentic === true;
+
     const session: ParsedSession = {
       id: `cursor:${composerId}`,
       projectPath,
@@ -567,8 +573,11 @@ function parseCursorSession(dbPath: string, composerId: string): ParsedSession |
     session.generatedTitle = titleResult.title;
     session.titleSource = titleResult.source;
 
-    // Detect session character
-    session.sessionCharacter = titleResult.character || detectSessionCharacter(session);
+    // Detect session character. If detection returns null and Cursor marked the session
+    // as agentic (unifiedMode === 'agent' / isAgentic === true), default to 'feature_build'
+    // as the closest character for autonomous multi-step agent sessions.
+    const detectedCharacter = titleResult.character || detectSessionCharacter(session);
+    session.sessionCharacter = detectedCharacter ?? (isAgentic ? 'feature_build' : null);
 
     return session;
   } catch {


### PR DESCRIPTION
## Summary

Fixes 7 accuracy bugs in Cursor session parsing found via direct SQLite inspection of real Cursor session files. Also fixes a \`messageCount\` inconsistency across all non-Claude-Code providers.

Closes #278

## Changes

### cursor.ts — P1 (critical bugs)
- **Timestamps**: Replace non-existent \`bubble.createdAt\` with \`timingInfo.clientRpcSendTime\` (Unix ms) on assistant bubbles. User bubbles have no timestamp and correctly fall back to epoch. Note: \`clientStartTime\` is a performance offset (e.g. \`926228.7ms\`), not a wall clock — ignored.
- **Session timestamp fallback**: Changed \`new Date()\` (misleading "now") to \`new Date(0)\` (epoch) when no real timestamps exist. \`composerData.createdAt\` / \`lastUpdatedAt\` still used as fallback when available.
- **Cost data**: Populate \`usage.estimatedCostUsd\` from \`composerData.usageData.default.costInCents / 100\`.
- **Token counts**: Sum \`tokenCount.inputTokens\` / \`tokenCount.outputTokens\` from assistant bubbles (user bubbles always report 0 — skipped).

### cursor.ts — P2 (missing features with available data)
- **gitBranch**: Extract from \`gitStatusRaw\` on the first user bubble using \`/^On branch (.+)/m\`. Previously hardcoded \`null\`.
- **unifiedMode/isAgentic**: When \`composerData.unifiedMode === 'agent'\` or \`composerData.isAgentic === true\` and the heuristic classifier returns \`null\`, default session character to \`'feature_build'\` (closest character for autonomous multi-step agent sessions).

### cursor.ts + copilot.ts + copilot-cli.ts — P3 (consistency)
- **messageCount**: Changed from \`messages.length\` to \`userMessages.length + assistantMessages.length\` across all 3 providers, consistent with Claude Code's \`jsonl.ts\`. System messages are excluded from the semantic count. (codex.ts was already correct.)

## Verification
- **Build**: \`pnpm build\` from repo root — PASS (zero errors)
- **Tests**: \`pnpm test\` from cli/ — PASS (563 tests, 27 test files)
- **API compatibility**: The \`SessionUsage\` structure populated for Cursor is identical to the existing interface (\`SessionUsage\` in \`types.ts\`). Dashboard reads \`total_input_tokens\` / \`estimated_cost_usd\` from the SQLite \`sessions\` table (written by the DB layer at sync time), not directly from \`session.usage\`. No breaking change.

## Test plan
- [ ] Cursor sessions now show accurate timestamps from \`timingInfo.clientRpcSendTime\` (not epoch for all messages)
- [ ] Cursor sessions show cost derived from \`usageData.default.costInCents\`
- [ ] Cursor sessions show token counts aggregated from assistant bubble \`tokenCount\`
- [ ] \`gitBranch\` populated on sessions where user bubbles contain \`gitStatusRaw\`
- [ ] Agent-mode sessions (\`unifiedMode === 'agent'\`) get \`sessionCharacter = 'feature_build'\` when heuristic returns null
- [ ] \`messageCount === userMessageCount + assistantMessageCount\` for all providers