### PR TITLE
fix(cursor): extract plain text from Lexical JSON stored in text field

### DIFF
--- a/cli/src/providers/__tests__/cursor.test.ts
+++ b/cli/src/providers/__tests__/cursor.test.ts
@@ -214,6 +214,46 @@ describe('CursorProvider — parsing accuracy fixes', () => {
     expect(session!.gitBranch).toBeNull();
   });
 
+  // ── Lexical JSON in text field ────────────────────────────────────────────
+
+  it('extracts plain text from Lexical JSON stored in the text field', async () => {
+    const lexicalJson = JSON.stringify({
+      root: {
+        children: [
+          {
+            type: 'paragraph',
+            children: [{ text: 'Go through the codebase and understand the project.' }],
+          },
+        ],
+      },
+    });
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ text: lexicalJson }),
+        assistantBubble(),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const userMsg = session!.messages.find(m => m.type === 'user');
+    expect(userMsg).toBeDefined();
+    expect(userMsg!.content).toBe('Go through the codebase and understand the project.');
+    expect(userMsg!.content).not.toContain('{"root"');
+  });
+
+  it('leaves non-Lexical text field unchanged', async () => {
+    const dbPath = makeCursorDb(tempDir, {
+      conversation: [
+        userBubble({ text: 'How do I fix this bug?' }),
+        assistantBubble(),
+      ],
+    });
+    const session = await provider.parse(virtualPath(dbPath));
+    expect(session).not.toBeNull();
+    const userMsg = session!.messages.find(m => m.type === 'user');
+    expect(userMsg!.content).toBe('How do I fix this bug?');
+  });
+
   // ── messageCount consistency ──────────────────────────────────────────────
 
   it('messageCount equals userMessageCount + assistantMessageCount', async () => {

--- a/cli/src/providers/cursor.ts
+++ b/cli/src/providers/cursor.ts
@@ -745,7 +745,10 @@ function parseBubbles(conversation: Array<Record<string, unknown>>, sessionId: s
     const contentField = (bubble.content as string | undefined) || '';
 
     if (textField) {
-      content = textField;
+      // Some Cursor versions store the Lexical editor JSON in `text` rather than `richText`.
+      // Detect and extract plain text from it so we don't display raw JSON to the user.
+      const lexicalFromText = textField.startsWith('{"root"') ? extractLexicalText(textField) : null;
+      content = lexicalFromText !== null ? lexicalFromText : textField;
     } else if (bubble.richText) {
       // richText may be a Lexical JSON object (user bubbles) or a plain string (older formats).
       // Try Lexical extraction first; fall back to coercing whatever value we have to a string.


### PR DESCRIPTION
## Summary

- Newer Cursor versions store the Lexical editor JSON (`{"root":...}`) directly in the `text` bubble field rather than `richText`
- Previously, raw JSON was displayed in the Conversation view instead of the user's actual message
- Fix applies the existing `extractLexicalText()` helper to `text` when it starts with `{"root"`, with no performance cost for plain-text messages (fast prefix check)

## Test plan

- [ ] All 16 existing cursor provider tests pass
- [ ] New test: `extracts plain text from Lexical JSON stored in the text field` — verifies Lexical JSON in `text` is unwrapped correctly
- [ ] New test: `leaves non-Lexical text field unchanged` — verifies normal messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)