### PR TITLE
feat(dashboard): filter conversations by source tool across all pages

### DIFF
--- a/dashboard/src/components/filters/SourceToolSelect.tsx
+++ b/dashboard/src/components/filters/SourceToolSelect.tsx
@@ -1,0 +1,53 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SOURCE_TOOL_COLORS } from '@/lib/constants/colors';
+
+export const SOURCE_TOOLS = [
+  { value: 'claude-code', label: 'Claude Code' },
+  { value: 'cursor', label: 'Cursor' },
+  { value: 'codex-cli', label: 'Codex CLI' },
+  { value: 'copilot-cli', label: 'Copilot CLI' },
+  { value: 'copilot', label: 'Copilot' },
+] as const;
+
+// Extract the dot color class from SOURCE_TOOL_COLORS badge string (e.g. "bg-orange-500/10 text-orange-600 ...")
+// We only need the text color for the dot background — use the bg-*-500/10 converted to bg-*-500
+const DOT_COLORS: Record<string, string> = {
+  'claude-code': 'bg-orange-500',
+  'cursor': 'bg-blue-500',
+  'codex-cli': 'bg-green-500',
+  'copilot-cli': 'bg-cyan-500',
+  'copilot': 'bg-violet-500',
+};
+
+interface SourceToolSelectProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  className?: string;
+}
+
+export function SourceToolSelect({ value, onValueChange, className }: SourceToolSelectProps) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger className={className}>
+        <SelectValue placeholder="All Sources" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All Sources</SelectItem>
+        {SOURCE_TOOLS.map((tool) => (
+          <SelectItem key={tool.value} value={tool.value}>
+            <span className="flex items-center gap-1.5">
+              <span className={`h-2 w-2 rounded-full shrink-0 ${DOT_COLORS[tool.value]}`} />
+              {tool.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/dashboard/src/components/sessions/ProjectNav.tsx
+++ b/dashboard/src/components/sessions/ProjectNav.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
+import { SOURCE_TOOLS } from '@/components/filters/SourceToolSelect';
 import type { Project } from '@/lib/types';
 
 interface ProjectNavProps {
@@ -106,11 +107,9 @@ export function ProjectNav({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">All Sources</SelectItem>
-            <SelectItem value="claude-code">Claude Code</SelectItem>
-            <SelectItem value="cursor">Cursor</SelectItem>
-            <SelectItem value="codex-cli">Codex CLI</SelectItem>
-            <SelectItem value="copilot-cli">Copilot CLI</SelectItem>
-            <SelectItem value="copilot">Copilot</SelectItem>
+            {SOURCE_TOOLS.map((tool) => (
+              <SelectItem key={tool.value} value={tool.value}>{tool.label}</SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/dashboard/src/components/sessions/SessionListPanel.tsx
+++ b/dashboard/src/components/sessions/SessionListPanel.tsx
@@ -23,6 +23,7 @@ import { useDeletedSessionCount } from '@/hooks/useSessions';
 import { useQueuedSessionIds } from '@/hooks/useAnalysisQueue';
 import { SaveFilterPopover } from '@/components/filters/SaveFilterPopover';
 import { SavedFiltersDropdown } from '@/components/filters/SavedFiltersDropdown';
+import { SourceToolSelect } from '@/components/filters/SourceToolSelect';
 import { useSavedFilters } from '@/hooks/useSavedFilters';
 import { subDays, startOfDay, formatISO } from 'date-fns';
 
@@ -66,9 +67,10 @@ interface SessionListPanelProps {
     dateFrom: string;
     dateTo: string;
     outcome: string;
+    source: string;
   };
   onFilterChange: (
-    key: 'q' | 'character' | 'status' | 'dateRange' | 'dateFrom' | 'dateTo' | 'outcome',
+    key: 'q' | 'character' | 'status' | 'dateRange' | 'dateFrom' | 'dateTo' | 'outcome' | 'source',
     value: string
   ) => void;
   onSetFilters: (updates: Record<string, string>) => void;
@@ -197,7 +199,7 @@ export function SessionListPanel({
 
   const allFiltersForSave = { ...filters } as Record<string, string>;
   const defaultFilterValues: Record<string, string> = {
-    q: '', character: 'all', status: 'all', dateRange: 'all', dateFrom: '', dateTo: '', outcome: 'all',
+    q: '', character: 'all', status: 'all', dateRange: 'all', dateFrom: '', dateTo: '', outcome: 'all', source: 'all',
   };
 
   const dateRangeLabel = useMemo(() => {
@@ -338,6 +340,12 @@ export function SessionListPanel({
               ))}
             </SelectContent>
           </Select>
+
+          <SourceToolSelect
+            value={filters.source || 'all'}
+            onValueChange={(v) => onFilterChange('source', v)}
+            className="h-7 text-xs flex-1"
+          />
 
           <SaveFilterPopover
             activeFilters={allFiltersForSave}

--- a/dashboard/src/components/sessions/SessionListPanel.tsx
+++ b/dashboard/src/components/sessions/SessionListPanel.tsx
@@ -195,7 +195,8 @@ export function SessionListPanel({
     filters.status !== 'all' ||
     !!filters.q ||
     (!!filters.dateRange && filters.dateRange !== 'all') ||
-    (!!filters.outcome && filters.outcome !== 'all');
+    (!!filters.outcome && filters.outcome !== 'all') ||
+    filters.source !== 'all';
 
   const allFiltersForSave = { ...filters } as Record<string, string>;
   const defaultFilterValues: Record<string, string> = {

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -10,6 +10,7 @@ import { ErrorCard } from '@/components/ErrorCard';
 import { formatTokenCount, formatModelName } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { CHART_COLORS } from '@/lib/constants/colors';
+import { SourceToolSelect } from '@/components/filters/SourceToolSelect';
 import {
   BarChart,
   Bar,
@@ -32,7 +33,11 @@ const rangeOptions: { value: AnalyticsRange; label: string }[] = [
 
 export default function AnalyticsPage() {
   const [range, setRange] = useState<AnalyticsRange>('7d');
-  const { data: sessions = [], isLoading: sessionsLoading, isError: sessionsError, refetch: refetchSessions } = useSessions({ limit: 500 });
+  const [source, setSource] = useState<string>('all');
+  const { data: sessions = [], isLoading: sessionsLoading, isError: sessionsError, refetch: refetchSessions } = useSessions({
+    limit: 500,
+    ...(source !== 'all' && { sourceTool: source }),
+  });
   const { data: insights = [], isLoading: insightsLoading, isError: insightsError, refetch: refetchInsights } = useInsights();
   const { data: projects = [], isLoading: projectsLoading, isError: projectsError, refetch: refetchProjects } = useProjects();
   const { tooltipBg, tooltipBorder } = useThemeColors();
@@ -50,10 +55,16 @@ export default function AnalyticsPage() {
     () => cutoff === 0 ? sessions : sessions.filter((s) => new Date(s.started_at).getTime() >= cutoff),
     [sessions, cutoff]
   );
-  const filteredInsights = useMemo(
-    () => cutoff === 0 ? insights : insights.filter((i) => new Date(i.timestamp).getTime() >= cutoff),
-    [insights, cutoff]
+  // When source filter is active, insights are scoped to session IDs in filteredSessions
+  const filteredSessionIds = useMemo(
+    () => new Set(filteredSessions.map((s) => s.id)),
+    [filteredSessions]
   );
+  const filteredInsights = useMemo(() => {
+    const byDate = cutoff === 0 ? insights : insights.filter((i) => new Date(i.timestamp).getTime() >= cutoff);
+    if (source === 'all') return byDate;
+    return byDate.filter((i) => filteredSessionIds.has(i.session_id));
+  }, [insights, cutoff, source, filteredSessionIds]);
 
   // Build daily stats from filtered sessions
   const dailyStats: DailyStats[] = useMemo(() => {
@@ -213,18 +224,25 @@ export default function AnalyticsPage() {
           <h1 className="text-2xl font-bold">Analytics</h1>
           <p className="text-muted-foreground">Visualize your AI coding usage patterns</p>
         </div>
-        <div className="flex gap-1">
-          {rangeOptions.map(({ value, label }) => (
-            <Button
-              key={value}
-              variant={range === value ? 'default' : 'ghost'}
-              size="sm"
-              className="h-7 px-2.5 text-xs"
-              onClick={() => setRange(value)}
-            >
-              {label}
-            </Button>
-          ))}
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex gap-1">
+            {rangeOptions.map(({ value, label }) => (
+              <Button
+                key={value}
+                variant={range === value ? 'default' : 'ghost'}
+                size="sm"
+                className="h-7 px-2.5 text-xs"
+                onClick={() => setRange(value)}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+          <SourceToolSelect
+            value={source}
+            onValueChange={setSource}
+            className="w-[140px] h-7 text-xs"
+          />
         </div>
       </div>
 

--- a/dashboard/src/pages/InsightsPage.tsx
+++ b/dashboard/src/pages/InsightsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { format } from 'date-fns';
 import { useSearchParams, Link } from 'react-router';
 import { useInsights } from '@/hooks/useInsights';
+import { useSessions } from '@/hooks/useSessions';
 import { useFilterParams } from '@/hooks/useFilterParams';
 import { useProjects } from '@/hooks/useProjects';
 import { buildPatternGroups } from '@/lib/pattern-grouping';
@@ -29,6 +30,7 @@ import type { Insight, InsightType } from '@/lib/types';
 import { InsightTypePills } from '@/components/filters/InsightTypePills';
 import { SaveFilterPopover } from '@/components/filters/SaveFilterPopover';
 import { SavedFiltersDropdown } from '@/components/filters/SavedFiltersDropdown';
+import { SourceToolSelect } from '@/components/filters/SourceToolSelect';
 import { useSavedFilters } from '@/hooks/useSavedFilters';
 import { LlmNudgeBanner } from '@/components/LlmNudgeBanner';
 
@@ -63,6 +65,7 @@ export default function InsightsPage() {
     type: 'all',
     view: 'timeline',
     pattern: '',
+    source: 'all',
   });
 
   const { savedFilters, saveFilter, deleteFilter } = useSavedFilters('insights');
@@ -84,8 +87,19 @@ export default function InsightsPage() {
   const { data: insights = [], isLoading, isError, refetch } = useInsights(
     filters.project !== 'all' ? { projectId: filters.project } : undefined
   );
+  // Fetch sessions for source tool mapping — Insight type lacks source_tool, so we join client-side
+  const { data: allSessions = [] } = useSessions();
 
   const allInsightIds = useMemo(() => new Set(insights.map((i) => i.id)), [insights]);
+
+  // Map session_id → source_tool for client-side source filtering on Insights
+  const sessionSourceMap = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const s of allSessions) {
+      map.set(s.id, s.source_tool);
+    }
+    return map;
+  }, [allSessions]);
 
   const patternGroups = useMemo(() => buildPatternGroups(insights), [insights]);
 
@@ -105,11 +119,15 @@ export default function InsightsPage() {
           return false;
         }
       }
+      if (filters.source !== 'all') {
+        const sourceTool = sessionSourceMap.get(i.session_id);
+        if (sourceTool !== filters.source) return false;
+      }
       return true;
     });
-  }, [insights, activeTypes, filters.q, patternInsightIds]);
+  }, [insights, activeTypes, filters.q, filters.source, patternInsightIds, sessionSourceMap]);
 
-  const hasFilters = !!filters.q || filters.type !== 'all' || filters.project !== 'all' || !!filters.pattern;
+  const hasFilters = !!filters.q || filters.type !== 'all' || filters.project !== 'all' || !!filters.pattern || filters.source !== 'all';
 
   const grouped = useMemo((): InsightGroup[] => {
     const view = filters.view;
@@ -243,6 +261,12 @@ export default function InsightsPage() {
             </SelectContent>
           </Select>
 
+          <SourceToolSelect
+            value={filters.source}
+            onValueChange={(v) => setFilter('source', v)}
+            className="w-[140px]"
+          />
+
           <Tabs
             value={filters.view}
             onValueChange={(v) => setFilter('view', v)}
@@ -262,8 +286,8 @@ export default function InsightsPage() {
         <div className="flex flex-wrap items-center gap-2">
           <InsightTypePills activeTypes={activeTypes} onChange={handleTypePillChange} />
           <SaveFilterPopover
-            activeFilters={{ q: filters.q, project: filters.project, type: filters.type }}
-            defaultFilterValues={{ q: '', project: 'all', type: 'all' }}
+            activeFilters={{ q: filters.q, project: filters.project, type: filters.type, source: filters.source }}
+            defaultFilterValues={{ q: '', project: 'all', type: 'all', source: 'all' }}
             onSave={saveFilter}
           />
         </div>

--- a/dashboard/src/pages/InsightsPage.tsx
+++ b/dashboard/src/pages/InsightsPage.tsx
@@ -87,8 +87,9 @@ export default function InsightsPage() {
   const { data: insights = [], isLoading, isError, refetch } = useInsights(
     filters.project !== 'all' ? { projectId: filters.project } : undefined
   );
-  // Fetch sessions for source tool mapping — Insight type lacks source_tool, so we join client-side
-  const { data: allSessions = [] } = useSessions();
+  // Fetch sessions for source tool mapping — Insight type lacks source_tool, so we join client-side.
+  // limit: 500 matches Analytics page pattern; server default is 50 which would silently miss sessions.
+  const { data: allSessions = [] } = useSessions({ limit: 500 });
 
   const allInsightIds = useMemo(() => new Set(insights.map((i) => i.id)), [insights]);
 

--- a/dashboard/src/pages/JournalPage.tsx
+++ b/dashboard/src/pages/JournalPage.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { format, startOfWeek, endOfWeek, subWeeks } from 'date-fns';
 import { useInsights } from '@/hooks/useInsights';
+import { useSessions } from '@/hooks/useSessions';
 import { useLlmConfig } from '@/hooks/useConfig';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -8,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Sparkles, Target, Lightbulb, GitBranch, Clock } from 'lucide-react';
 import { Link } from 'react-router';
 import { ErrorCard } from '@/components/ErrorCard';
+import { SourceToolSelect } from '@/components/filters/SourceToolSelect';
 import type { Insight } from '@/lib/types';
 
 function getWeekKey(dateStr: string): string {
@@ -33,16 +35,32 @@ function getWeekLabel(weekKey: string): string {
 }
 
 export default function JournalPage() {
+  const [source, setSource] = useState<string>('all');
   const { data: insights = [], isLoading, isError, refetch } = useInsights();
+  const { data: allSessions = [] } = useSessions();
   const { data: llmConfig } = useLlmConfig();
 
   const llmConfigured = !!(llmConfig?.provider && llmConfig?.model);
 
-  // Group learnings and decisions by week for the timeline
+  // Map session_id → source_tool for client-side source filtering
+  const sessionSourceMap = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const s of allSessions) {
+      map.set(s.id, s.source_tool);
+    }
+    return map;
+  }, [allSessions]);
+
+  // Group learnings and decisions by week, optionally filtered by source tool
   const insightsByWeek = useMemo(() => {
-    const relevant = insights.filter(
-      (i) => i.type === 'learning' || i.type === 'decision' || i.type === 'technique'
-    );
+    const relevant = insights.filter((i) => {
+      if (i.type !== 'learning' && i.type !== 'decision' && i.type !== 'technique') return false;
+      if (source !== 'all') {
+        const sourceTool = sessionSourceMap.get(i.session_id);
+        if (sourceTool !== source) return false;
+      }
+      return true;
+    });
     const grouped: Record<string, Insight[]> = {};
     relevant.forEach((insight) => {
       const weekKey = getWeekKey(insight.timestamp);
@@ -50,7 +68,7 @@ export default function JournalPage() {
       grouped[weekKey].push(insight);
     });
     return grouped;
-  }, [insights]);
+  }, [insights, source, sessionSourceMap]);
 
   const sortedWeeks = useMemo(
     () => Object.keys(insightsByWeek).sort((a, b) => b.localeCompare(a)),
@@ -59,11 +77,18 @@ export default function JournalPage() {
 
   return (
     <div className="p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Knowledge Journal</h1>
-        <p className="text-muted-foreground">
-          A chronological timeline of your learnings and decisions
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Knowledge Journal</h1>
+          <p className="text-muted-foreground">
+            A chronological timeline of your learnings and decisions
+          </p>
+        </div>
+        <SourceToolSelect
+          value={source}
+          onValueChange={setSource}
+          className="w-[140px] h-8 text-xs"
+        />
       </div>
 
       {isError && (

--- a/dashboard/src/pages/JournalPage.tsx
+++ b/dashboard/src/pages/JournalPage.tsx
@@ -37,7 +37,8 @@ function getWeekLabel(weekKey: string): string {
 export default function JournalPage() {
   const [source, setSource] = useState<string>('all');
   const { data: insights = [], isLoading, isError, refetch } = useInsights();
-  const { data: allSessions = [] } = useSessions();
+  // limit: 500 matches Analytics page pattern; server default is 50 which would silently miss sessions
+  const { data: allSessions = [] } = useSessions({ limit: 500 });
   const { data: llmConfig } = useLlmConfig();
 
   const llmConfigured = !!(llmConfig?.provider && llmConfig?.model);

--- a/dashboard/src/pages/SessionsPage.tsx
+++ b/dashboard/src/pages/SessionsPage.tsx
@@ -84,7 +84,7 @@ export default function SessionsPage() {
   );
 
   const handleFilterChange = useCallback(
-    (key: 'q' | 'character' | 'status' | 'dateRange' | 'dateFrom' | 'dateTo' | 'outcome', value: string) => {
+    (key: 'q' | 'character' | 'status' | 'dateRange' | 'dateFrom' | 'dateTo' | 'outcome' | 'source', value: string) => {
       setFilter(key, value);
     },
     [setFilter]
@@ -98,7 +98,7 @@ export default function SessionsPage() {
   );
 
   const handleClearFilters = useCallback(() => {
-    setFilters({ q: '', character: 'all', status: 'all', dateRange: 'all', dateFrom: '', dateTo: '', outcome: 'all' });
+    setFilters({ q: '', character: 'all', status: 'all', dateRange: 'all', dateFrom: '', dateTo: '', outcome: 'all', source: 'all' });
   }, [setFilters]);
 
   const selectedProjectName = useMemo(() => {
@@ -165,6 +165,7 @@ export default function SessionsPage() {
             dateFrom: filters.dateFrom,
             dateTo: filters.dateTo,
             outcome: filters.outcome,
+            source: filters.source,
           }}
           onFilterChange={handleFilterChange}
           onSetFilters={handleSetFilters}


### PR DESCRIPTION
## What

Adds source tool filtering to Sessions, Analytics, Insights, and Journal pages so users can scope any dashboard view to a single AI coding tool (Claude Code, Cursor, Codex CLI, Copilot CLI, or Copilot).

## Why

Users working across multiple AI coding tools had no consistent way to filter by tool across the dashboard. The source filter was buried in the ProjectNav sidebar (sessions only) and absent from Analytics, Insights, and Journal entirely.

## How

**New shared component:** `SourceToolSelect` at `dashboard/src/components/filters/SourceToolSelect.tsx` — wraps shadcn `Select` with colored dot indicators per tool, using `SOURCE_TOOL_COLORS` from the existing colors constants. Exports `SOURCE_TOOLS` constant consumed by `ProjectNav` to eliminate duplication.

**Sessions page:** Added `source` to `SessionListPanelProps.filters` and `onFilterChange` key union. `SourceToolSelect` added to filter Row 3. Wired to existing `useFilterParams` `source` key and server-side `sessionParams.sourceTool`. Added `source: 'all'` to `defaultFilterValues` and `handleClearFilters`. ProjectNav source Select unchanged (no regression).

**Analytics page:** `sourceTool` passed to `useSessions({ limit: 500, sourceTool })` for server-side filtering (existing indexed column). Insights filtered client-side via `Set<sessionId>` from filtered sessions. `SourceToolSelect` added below range buttons, right-aligned.

**Insights page:** `useSessions()` added (React Query cached). Session→sourceTool map built in `useMemo`. Source filter applied in existing `filtered` chain. `source: 'all'` added to `useFilterParams` defaults and `SaveFilterPopover`.

**Journal page:** Same session source map pattern as Insights. Source `useState`. `insightsByWeek` useMemo filters by source before grouping. `SourceToolSelect` right-aligned in page header.

## Schema Impact
- [ ] SQLite schema changed: no
- [ ] Types changed: no (`cli/src/types.ts` untouched)
- [ ] Server API changed: no (existing `/api/sessions?sourceTool=` used as-is)
- [ ] Backward compatible: yes — pure dashboard change

## Testing

**Pre-PR gate:**
- `pnpm build` — ✅ passes (zero errors, all 3 packages: cli, server, dashboard)
- `pnpm test` — ✅ passes (579 tests, 28 test files, zero failures)

**Functional verification checklist:**
- [ ] Sessions: Source Select appears in Row 3 between Outcome and Save; selecting filters session list; ProjectNav select still works; clearing resets source
- [ ] Sessions: URL `?source=cursor` persists on page reload
- [ ] Analytics: Source Select below range buttons; selecting scopes all charts and summary stats
- [ ] Insights: Source Select after Project Select; filters insight list; included in Save Filter
- [ ] Journal: Source Select right of title; filters timeline entries by week
- [ ] Dark mode: colored dots readable in both themes

Closes #281