### PR TITLE
chore: add GitHub repo hygiene (.github templates + topics)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: melagiri

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the fields below so we can reproduce and fix it quickly.
+
+  - type: input
+    id: version
+    attributes:
+      label: Code Insights version
+      description: Run `code-insights --version` to find out
+      placeholder: "e.g. 1.2.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: Source tool (provider)
+      description: Which AI coding tool are you syncing sessions from?
+      options:
+        - Claude Code
+        - Cursor
+        - Codex CLI
+        - Copilot CLI
+        - VS Code Copilot Chat
+        - Not applicable / unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: Run `node --version`
+      placeholder: "e.g. v22.4.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `code-insights sync`
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any error messages or terminal output here
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,6 +51,13 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: pnpm
+    attributes:
+      label: pnpm version (if applicable)
+      description: Run `pnpm --version` — helpful for installation issues with native bindings
+      placeholder: "e.g. 9.1.0"
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://code-insights.app/docs
+    about: Check the docs first — installation, providers, and common issues are all covered.
+  - name: Discussions
+    url: https://github.com/melagiri/code-insights/discussions
+    about: For questions, ideas, or sharing how you use Code Insights.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got an idea that would make Code Insights better? Describe it below.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this affect?
+      options:
+        - CLI commands
+        - Session sync / parsing
+        - Provider support (new or existing)
+        - Dashboard — charts & stats
+        - Dashboard — conversation replay
+        - LLM analysis / insights
+        - SQLite schema / data model
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or pain point. "As a developer who uses Cursor + Claude Code, I want to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Rough sketches, CLI examples, or mockups are all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other approaches you thought about, or workarounds you're currently using
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to implement this myself and open a PR

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or improvement
-labels: ["enhancement"]
+labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What does this PR do?
+
+<!-- Brief description of the change and why it's needed -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Provider support (new source tool)
+- [ ] Documentation
+- [ ] Refactor / internal improvement
+
+## Related issue
+
+<!-- Closes #123 -->
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+- [ ] Ran `pnpm test` — all tests pass
+- [ ] Ran `pnpm build` — no build errors
+- [ ] Manually tested with real session data
+
+## Notes for reviewer
+
+<!-- Anything unusual, trade-offs made, or areas you'd like a second eye on -->


### PR DESCRIPTION
## Summary

- Add structured YAML issue templates: bug report (with provider dropdown, version, OS fields) and feature request (with area dropdown, contribution checkbox)
- Add `ISSUE_TEMPLATE/config.yml` to disable blank issues and link to docs/discussions
- Add `PULL_REQUEST_TEMPLATE.md` with type checklist, related issue field, and test plan
- Add `FUNDING.yml` to surface the GitHub Sponsors button on the repo page
- Set 8 GitHub topics via API: `ai-coding-analytics`, `claude-code`, `cursor`, `developer-tools`, `sqlite`, `llm`, `local-first`, `codex`

## Test plan

- [ ] Visit the repo Issues tab — should show "Bug Report" and "Feature Request" templates, no blank issue option
- [ ] Open a new PR — should pre-fill with the PR template
- [ ] Check repo page — Sponsor button should appear, topics visible below repo description

🤖 Generated with [Claude Code](https://claude.com/claude-code)