### PR TITLE
fix: foreign key error on trivial sessions and unknown option --no-native

### DIFF
--- a/cli/src/commands/session-end.ts
+++ b/cli/src/commands/session-end.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'url';
 import { getConfigDir } from '../utils/config.js';
 import { syncSingleFile } from './sync.js';
 import { enqueue } from '../db/queue.js';
+import { sessionExists } from '../db/read.js';
 
 /** Resolve the CLI entry point for spawning child processes. */
 const CLI_ENTRY = resolve(fileURLToPath(import.meta.url), '../../index.js');
@@ -83,10 +84,15 @@ export async function sessionEndCommand(options: SessionEndOptions = {}): Promis
   }
 
   // Phase 2: Enqueue for async analysis
-  enqueue(sessionId, native ? 'native' : 'provider');
+  if (sessionExists(sessionId)) {
+    enqueue(sessionId, native ? 'native' : 'provider');
 
-  // Phase 3: Spawn detached worker to process the queue
-  spawnWorker(quiet, options.model);
+    // Phase 3: Spawn detached worker to process the queue
+    spawnWorker(quiet, options.model);
+  } else {
+    // Session was trivial (<= 2 messages) and thus skipped by syncSingleFile,
+    // or didn't sync for some other reason. Do not enqueue to avoid foreign key errors.
+  }
 }
 
 function spawnWorker(quiet: boolean, model?: string): void {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -136,6 +136,7 @@ program
   .command('session-end')
   .description('SessionEnd hook: sync session, enqueue for analysis, spawn background worker')
   .option('--native', 'Use claude -p for analysis worker (default: true)')
+  .option('--no-native', 'Disable native analysis worker')
   .option('-s, --source <tool>', 'Source tool identifier (default: claude-code)')
   .option('-q, --quiet', 'Suppress output')
   .option('--model <model>', 'Model for native analysis (default: sonnet)')


### PR DESCRIPTION
Fixes a SQLite foreign key constraint failure that occurs when short-lived sessions (like \`claude update\`) are sent to the \`session-end\` hook but are filtered out for being too trivial.\n\nAlso fixes an issue where the hook would throw an unknown option error for \`--no-native\` because Commander wasn't explicitly configured to accept the negative flag.