### PR TITLE
design: codebase knowledge redesign — brainstorm + team tier exploration

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -99,10 +99,50 @@ Zero-config first run: `code-insights` with no args auto-syncs and opens the das
 
 ## Non-Goals
 
-- **Not a business** — No monetization, no paywall, no premium tier
+- **Not a business** — No monetization, no paywall, no premium tier ⚠ *see discussion below*
 - **Not a central platform** — No central database for user session data
 - **Not a dependency** — Users can stop using it anytime, data remains theirs
-- **Not a team tool** — This is a personal learning tool; no org/team features
+- **Not a team tool** — This is a personal learning tool; no org/team features ⚠ *see discussion below*
+
+---
+
+## Under Active Discussion — May Override Non-Goals
+
+> **Status:** Brainstorming phase. No implementation decisions made. This section documents a direction being explored before any code changes are committed. The founder must make an explicit decision before Phase 3 of the roadmap below begins.
+>
+> Branch: `feature/codebase-knowledge-redesign`  
+> Full brainstorm notes: `docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md`
+
+### Team Knowledge Sync — Optional Team Tier
+
+A brainstorming session (2026-04-22) explored adding an optional **team tier** that would allow multiple developers on the same codebase to pool their extracted knowledge — without ever sharing raw session transcripts.
+
+**The core insight:** The LLM synthesis step is a natural privacy boundary. Raw sessions stay local forever. Only the already-processed, already-scrubbed extracted knowledge (decisions, learnings, patterns, friction) would sync to a team-owned database.
+
+**What this would look like:**
+
+- **Free tier**: unchanged — fully local SQLite, personal only, everything as it is today
+- **Team tier**: Bring-Your-Own Supabase PostgreSQL — teams configure their own Supabase project; Code Insights never runs the infrastructure
+- **Privacy-preserving sync**: only LLM-extracted structured knowledge syncs; raw transcripts never leave the machine
+- **`code-insights context <topic>`**: a new retrieval command that queries both your local DB and the team's shared knowledge base, with attribution per entry (`@alice · Jan 14, 2026`)
+- **`.code-insights.md`**: generated from the full team's knowledge (not just one person's sessions) — solving the single-author blindspot
+
+**What this would require overriding:**
+
+| Current non-goal | Proposed override |
+|-----------------|-------------------|
+| Not a team tool | Optional team tier — free personal tier unchanged |
+| Not a business | Possible seat-based pricing for team tier (BYOS means no hosted infra cost) |
+| No Supabase | BYOS model — teams own their Supabase instance, not us |
+
+**What stays unchanged regardless:**
+
+- Free personal tier is identical to today — no degradation, no feature gating
+- Raw session data never leaves the machine under any tier
+- MIT-licensed open source codebase
+- No Code Insights central server — team data lives in the team's own Supabase
+
+**Decision required:** Before Phase 3 implementation begins, this file must be explicitly updated to either (a) accept the team tier direction and revise the non-goals, or (b) reject it and keep the current non-goals intact. The brainstorm notes document records all design decisions, TA review, and UX review for reference.
 
 ## Success Looks Like
 

--- a/docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md
+++ b/docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md
@@ -1,0 +1,300 @@
+# Codebase Knowledge — Redesign Brainstorm Notes
+
+**Date:** 2026-04-22  
+**Branch:** feature/codebase-knowledge-redesign  
+**Status:** Brainstorming complete — pending TA + UX review, then implementation plan  
+**Context:** Continuation of the 2026-04-20 spec (`docs/superpowers/specs/2026-04-20-codebase-knowledge-design.md`)
+
+---
+
+## What Was Researched
+
+Two parallel agents ran before this brainstorm:
+
+1. **Spec analyst** — deep pros/cons of the 2026-04-20 `.code-insights.md` spec
+2. **entire.io browser researcher** — explored entire.io's product: checkpoint-based git-native session archiving, orphan branch storage, `entire explain` retrieval command, team-shared checkpoint branches
+
+### Key findings from entire.io
+
+- entire.io is a **commit-anchored, full-fidelity archive** (raw transcripts in git). Code Insights is a **synthesized knowledge layer** (LLM-extracted decisions/learnings). Complementary, not competing.
+- entire.io's `entire explain --commit <sha>` retrieval UX is as important as storage — retrieval interface matters.
+- entire.io stores checkpoints in an orphan branch; uses commit trailers (`Entire-Checkpoint: <id>`) that survive rebase/squash.
+- entire.io has no synthesis layer — it captures everything but analyzes nothing. Code Insights' LLM synthesis is the differentiator.
+
+### Key weaknesses found in the 2026-04-20 spec
+
+1. **Staleness is silent** — file goes stale with no signal. No `sessions_at_generation` counter, no dashboard warning.
+2. **Authorship blindspot** — file appears authoritative but reflects one developer's sessions only. No attribution.
+3. **CLAUDE.md relationship unresolved** — agents won't automatically find `.code-insights.md`; needs a CLAUDE.md reference.
+4. **LLM hallucination in Key Decisions** — system prompt doesn't prohibit inferring reasoning not present in session data.
+5. **Update cadence undefined** — "after more sessions" is not actionable.
+6. **No retrieval interface** — the file is the only interaction surface; no way to query by topic.
+
+---
+
+## Design Direction Chosen: **B — The Intent Layer (Extended)**
+
+Three options were presented; **B** was chosen by the user. The original B has been extended with a team knowledge sync model.
+
+### What B delivers
+
+1. **All fixes from the original spec** — attribution, staleness signal, CLAUDE.md bridge, LLM hallucination guard
+2. **`code-insights context` retrieval command** — live query interface over the knowledge base
+3. **Configurable auto-regeneration** — not just manual; session-count-delta or schedule triggers
+4. **`--inject-rules`** — formal CLAUDE.md injection, not deferred
+5. **Team knowledge sync via Supabase** — the major new direction (see below)
+
+---
+
+## The Major New Direction: Team Knowledge Sync
+
+### The problem being solved
+
+Each developer has their own `~/.code-insights/data.db`. Their extracted decisions and learnings are invisible to teammates. The committed `.code-insights.md` file is only one person's view. In a team of 4, three developers' AI session knowledge is lost.
+
+### The architecture
+
+**Two-tier model:**
+
+| Tier | Storage | Contents | Access |
+|------|---------|----------|--------|
+| Personal (free) | Local SQLite `~/.code-insights/data.db` | Everything — sessions, transcripts, insights, extracted knowledge | Local only, never leaves machine |
+| Team (paid) | Supabase PostgreSQL (bring-your-own) | Extracted knowledge only — decisions, learnings, patterns, friction | All team members read/write |
+
+**Privacy boundary (CRITICAL):**
+
+What **never** leaves your machine:
+- Raw session transcripts
+- Your prompts and messages
+- Tool call contents
+- File contents from sessions
+
+What **syncs to team DB** (already LLM-processed and scrubbed):
+- Extracted decisions (structured: choice, reasoning, category, confidence)
+- Extracted learnings (structured: insight, topic, takeaway)
+- Pattern categories + frequencies
+- Friction categories + severity + attribution
+- Reflect rules (already reviewed by user before syncing)
+
+**Why this privacy story works:** The LLM synthesis step is the privacy boundary. Raw transcripts → LLM → structured decisions/learnings. By the time knowledge hits the team DB, it's been through two scrub passes and an LLM abstraction layer. You're sharing conclusions, not conversations.
+
+### Team Supabase schema (proposed)
+
+```sql
+-- All tables are project-scoped and author-attributed
+
+team_decisions (
+  id, project_id, author_git_user, author_email,
+  topic_tags[], choice_text, reasoning, alternatives_rejected,
+  tradeoff, revisit_condition, confidence, context_note,
+  created_at, superseded_by_id (nullable)
+)
+
+team_learnings (
+  id, project_id, author_git_user, author_email,
+  topic_tags[], insight_text, root_cause, takeaway,
+  session_character, created_at
+)
+
+team_patterns (
+  id, project_id, author_git_user, author_email,
+  category, description, frequency, driver, created_at
+)
+
+team_friction (
+  id, project_id, author_git_user, author_email,
+  category, description, severity, frequency,
+  attribution, mitigation, created_at
+)
+
+team_conflict_alerts (
+  id, new_entry_id, new_entry_type,
+  conflicting_entry_id, conflicting_entry_type,
+  keyword_overlap[], resolved_as ('supersedes' | 'complements' | 'ignored'),
+  resolved_at, resolved_by
+)
+```
+
+### Sync trigger
+
+- **Default: automatic** — extracted knowledge syncs as part of `code-insights sync` after session analysis
+- **Configurable** — can be set to: `on-sync` (default) / `on-attach` / `manual`
+- User can always preview what will be pushed before it goes
+
+### BYOS (Bring Your Own Supabase)
+
+- Teams configure their own Supabase project — paste connection string into `code-insights config`
+- Code Insights never runs infra; never touches the data
+- Enterprise teams can self-host Supabase entirely on-premise
+- Row-level security isolates project data
+
+---
+
+## The Conflict Resolution Model
+
+**Decision:** Latest timestamp takes precedence (mirrors how ADRs work in practice — a newer ADR supersedes an older one).
+
+**But:** The system must surface potential conflicts at *write time* so the author is never blindsided.
+
+### Conflict detection flow
+
+1. Developer's session produces a new extracted decision (e.g., "use raw SQL for migrations")
+2. Before pushing to team DB, the system keyword-matches against existing team decisions in the same project
+3. If overlap detected: **conflict alert surfaced** — "⚠ This may relate to an existing decision by @alice (Jan 2026): 'Use ORM for migrations'"
+4. Author chooses:
+   - **Supersedes** — mark old decision as superseded, new one is canonical
+   - **Complements** — both decisions coexist under the topic (different aspect)
+   - **Ignore** — push without linking (not recommended but allowed)
+
+**Keyword matching strategy (TBD with TA):** Options are fuzzy text match, embedding similarity, or topic-tag overlap. Needs TA input on what's feasible without adding heavy infra.
+
+### Dashboard topic grouping
+
+The dashboard should show decisions **grouped by topic** with the evolution timeline visible:
+
+```
+Topic: database/migrations
+  ✓ [Jan 2026] @alice — Use ORM for migrations          [superseded]
+  ✓ [Mar 2026] @bob   — Use raw SQL in applyVN()        [current · supersedes above]
+
+Topic: database/connections
+  ✓ [Feb 2026] @alice — Use WAL mode for all SQLite     [current]
+  ✓ [Apr 2026] @bob   — WAL mode confirmed, add timeout [complements above]
+```
+
+This is a natural knowledge evolution UI — not just a flat list of rules, but a versioned decision history per topic.
+
+---
+
+## The `code-insights context` Command
+
+### `code-insights context --topics`
+
+Lists all topics where the team has decisions and learnings:
+
+```
+Topics with knowledge (project: code-insights)
+
+database/sqlite      12 decisions · 8 learnings · 3 authors
+auth                  5 decisions · 4 learnings · 2 authors
+packaging             4 decisions · 2 learnings · 1 author
+migrations            3 decisions · 6 learnings · 2 authors
+dashboard/build       2 decisions · 3 learnings · 1 author
+```
+
+### `code-insights context <topic>`
+
+Returns all knowledge for a topic, merged from local DB + team Supabase:
+
+```
+Context: database/sqlite   (3 sources · last updated Apr 2026)
+
+Decisions
+  [confidence: 95]  Use WAL mode for all SQLite connections
+                    @alice · Jan 2026 · "Prevents SQLITE_BUSY under concurrent reads"
+  [confidence: 92]  Write migrations as raw SQL in applyVN()
+                    @bob · Mar 2026 · "ORM failed silently on V6" · supersedes ORM decision
+
+Learnings
+  @alice · Feb 2026 · WAL mode must be set at connection open, not per-query
+  @bob   · Mar 2026 · ALTER TABLE in SQLite can't drop columns — use recreate pattern
+
+Active friction
+  stale-assumptions (high · 23 occurrences) — @team
+  Mitigation: grep for current schema version before touching migrations
+```
+
+**Attribution model:** Every entry shows git user + timestamp. Merged view: local DB entries (your sessions) + team Supabase entries (teammates).
+
+---
+
+## The `.code-insights.md` Evolution
+
+With team DB, the committed file becomes a **team artifact** rather than a personal one:
+
+- Generated from the team Supabase DB (all members' knowledge), not just the local DB
+- Attribution in the frontmatter: `authors: [alice, bob, srikanth]` instead of `author: srikanth`
+- YAML `rules[]` are ranked by confidence across all contributors
+- Key Decisions section represents the team's collective architectural history
+- Staleness solved: file generated from live team DB, always reflects current state
+
+---
+
+## Fixes Retained from Original Spec Analysis
+
+These fixes from the spec analyst were confirmed and remain in scope:
+
+1. **Author attribution** — `author` in YAML frontmatter, byline in markdown header (team version: `authors: [...]`)
+2. **CLAUDE.md bridge** — after first generation, CLI prompts: "Add to CLAUDE.md: `See .code-insights.md for AI-extracted codebase knowledge.`"
+3. **Staleness signal** — `sessions_at_generation` in frontmatter; passive dashboard warning when delta > 50 sessions
+4. **LLM hallucination guard** — add to system prompt: "Do not infer reasoning not explicitly present in the session data. Omit a decision if its reasoning is unclear."
+5. **`--no-llm` as CI mode** — reframe as first-class CI use case, not just a fallback
+
+---
+
+## Product Strategy Implications
+
+**Current VISION.md says:** "No team/org features. No cloud sync. No monetization."
+
+**This design adds all three** — but as an optional team tier:
+- Free tier: unchanged — local SQLite, fully personal, everything as today
+- Team tier: opt-in, bring-your-own Supabase, self-hosted-first, privacy-preserving
+
+**Key framing:** This is not a pivot away from local-first. It's adding a team sync layer where the privacy boundary is the LLM synthesis step. Raw data never leaves the machine; only structured conclusions sync.
+
+**Monetization model (to be decided):** Likely seat-based pricing for team tier, with free personal tier unchanged. BYOS means Code Insights doesn't run the database infra.
+
+---
+
+## Open Questions (for TA + UX inputs)
+
+**Technical:**
+- What keyword/semantic matching strategy for conflict detection? (fuzzy text, embeddings, topic-tag overlap?)
+- PostgreSQL schema design for multi-tenant team DB with row-level security
+- Sync protocol: how does the CLI authenticate to team Supabase? (connection string? Supabase anon key + JWT?)
+- Topic extraction: LLM tags topics at analysis time, or derived on-the-fly via keyword search?
+- How does `code-insights context` handle offline mode when team DB is unreachable?
+
+**UX:**
+- What does the conflict alert look like at the terminal (non-blocking? blocking with prompt)?
+- Dashboard topic grouping: flat list with headers, or expandable tree?
+- What's the visual treatment for superseded vs current decisions?
+- How does the dashboard show team member attribution? Avatars? Git usernames?
+- Where does the team DB config live in the dashboard settings flow?
+
+---
+
+## Implementation Sequence (Tentative, Pre-TA Review)
+
+The original spec's implementation sequence is no longer sufficient given the team DB scope. A new sequence is needed:
+
+**Phase 1: Personal tier (the original spec + fixes)**
+- `cli/src/utils/project-root.ts`, `cli/src/utils/scrub.ts`
+- `server/src/llm/repo-export-prompts.ts`
+- `server/src/routes/export.ts` + two new endpoints
+- `cli/src/commands/export.ts` + `attach` alias
+- Dashboard: Repo format card + Step 4 review UI
+
+**Phase 2: Retrieval command**
+- `code-insights context --topics` and `code-insights context <topic>` (local DB only first)
+
+**Phase 3: Team sync (Supabase)**
+- Team DB schema + Supabase auth config
+- Sync mechanism (`code-insights sync --push-knowledge`)
+- `code-insights context` extended to read from team DB
+- Conflict detection + alert flow
+- Dashboard topic grouping view
+
+**Phase 4: Team `.code-insights.md`**
+- `code-insights attach` generates from team DB when configured
+- Multi-author attribution in frontmatter
+
+---
+
+## Next Steps
+
+1. TA reviews technical architecture — schema, sync, conflict detection feasibility
+2. UX engineer reviews dashboard topic grouping + conflict alert UX
+3. Update VISION.md to reflect team tier direction (after founder decision)
+4. Write implementation plan starting with Phase 1 (original spec + fixes)
+5. Phase 2–4 get separate specs and plans

--- a/docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md
+++ b/docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-22  
 **Branch:** feature/codebase-knowledge-redesign  
-**Status:** Brainstorming complete — pending TA + UX review, then implementation plan  
+**Status:** TA + UX review complete — ready for implementation plan (Phase 1 first)  
 **Context:** Continuation of the 2026-04-20 spec (`docs/superpowers/specs/2026-04-20-codebase-knowledge-design.md`)
 
 ---
@@ -291,10 +291,157 @@ The original spec's implementation sequence is no longer sufficient given the te
 
 ---
 
+## TA Review Findings (2026-04-22)
+
+Reviewer: technical-architect agent. Full review in conversation history.
+
+### Schema revisions required before implementation
+
+- **Project identity**: Must be a stable UUID stored in `.code-insights/team-config.yml` (committed to repo). Never trust `project_name` across machines.
+- **`topic_tags TEXT[]`**: Correct. Use GIN index for `&&` overlap queries. No junction table in V1.
+- **`team_decision_links` table**: New — for "complements" relationship (many-to-many). `superseded_by_id` on main table handles "supersedes" (one-to-one linear).
+- **Missing fields** on every team table: `updated_at TIMESTAMPTZ`, `source_session_hash TEXT` (SHA-256 of local session_id — idempotency without leaking local IDs), `local_insight_id TEXT` (dedup on re-push), `deleted_at TIMESTAMPTZ` (soft delete).
+- **Drop `team_` prefix**: Supabase schema is the boundary. Tables named `decisions`, `learnings`, `patterns`, `friction`.
+- **RLS is mandatory**: Must ship with policies, not as a follow-up. Template policies specified by TA.
+- **Auth anchor table**: `team_members (user_id UUID, project_id UUID, role TEXT)` — RLS checks against this.
+
+### Conflict detection: topic-tag overlap + pg_trgm (no embeddings in V1)
+
+```sql
+-- GIN on topic_tags + pg_trgm on choice_text
+candidates = decisions
+  WHERE project_id = ?
+  AND topic_tags && new.topic_tags        -- GIN overlap (fast)
+  AND superseded_by_id IS NULL            -- current decisions only
+  AND similarity(choice_text, new.choice_text) > 0.25  -- pg_trgm gate
+ORDER BY cardinality(topic_tags & new.topic_tags) DESC,
+         similarity(choice_text, new.choice_text) DESC
+LIMIT 3
+```
+
+Pre-flight runs against **local SQLite first** (so offline conflict detection works for your own history), then remote call on push. Defer embeddings/pgvector to V2.
+
+### Auth: Supabase Auth + anon key + user JWT — NOT connection strings or service role keys
+
+- Service role keys bypass RLS — never used in CLI tools
+- `code-insights team login` → PKCE browser flow → tokens in `~/.code-insights/auth.json` (chmod 0600)
+- Team config (supabase URL + anon key) in `~/.code-insights/config.json` (safe to share)
+- `author_user_id UUID` is the RLS identity — `author_git_user` is display-only
+
+### Topic extraction: LLM tagging at analysis time — mandatory, not optional
+
+Keyword-search-at-query-time breaks conflict detection, the `--topics` index, and cross-author merging. LLM must extract `topic_tags: ["database/sqlite", "migrations"]` during session analysis. A `topic-normalize.ts` (mirrors `friction-normalize.ts`) prevents tag drift. Backfill via `reflect backfill --topics`.
+
+New schema change: `applyV10` adds `topic_tags TEXT` (JSON array) to local `insights` table.
+
+### Local `knowledge_sync` table (new — V10)
+
+Required for idempotent re-push:
+
+```sql
+CREATE TABLE IF NOT EXISTS knowledge_sync (
+  insight_id    TEXT PRIMARY KEY REFERENCES insights(id),
+  remote_id     TEXT NOT NULL,    -- UUID from team DB
+  pushed_at     TEXT NOT NULL,
+  last_status   TEXT NOT NULL     -- 'pushed' | 'conflict-pending' | 'ignored'
+);
+```
+
+### Offline mode: 2-second timeout, fail-fast, no local caching
+
+Team DB is augmentation — never required. `context <topic>` timeout = 2s. Fail to local-only with inline notice. No background sync, no local mirror of team data in V1.
+
+### Revised phase sequence (6 phases, not 4)
+
+| Phase | Scope |
+|-------|-------|
+| 1 | Original 2026-04-20 spec + 3 fixes + topic tag extraction (schema V10, normalizer, backfill) |
+| 2 | Local `code-insights context --topics` and `context <topic>` (no network) |
+| 3 | Team DB foundation — schema, RLS, `team login`, `team status`, Settings UI section |
+| 4 | Push + conflict detection (sync mechanism, idempotency, conflict alerts terminal) |
+| 5 | Team reads + `/knowledge` dashboard page + `attach` generates from team DB |
+| 6 | Polish, `team invite`, docs, `delete-my-data` for GDPR |
+
+### Critical escalation items (TA)
+
+1. **VISION.md update required before Phase 3** — current vision says "No team/org features. No cloud sync. No monetization." Founder must make this decision explicitly.
+2. **Scrubbing on push path** — reuse `scrub.ts` on every record before Supabase write. Must be in same commit as push endpoint.
+3. **Telemetry events** — `team_login_success`, `team_sync_push`, `team_conflict_detected`, `context_query` need adding.
+4. **GDPR** — `code-insights team delete-my-data` must be designed before first real team uses Phase 3.
+5. **`.code-insights/team-config.yml`** — needs its own mini-spec in Phase 3 (format, schema validation, git blame behavior).
+
+---
+
+## UX Review Findings (2026-04-22)
+
+Reviewer: ux-engineer agent. Full wireframes and component specs in conversation history.
+
+### `/knowledge` page: two-pane master/detail
+
+Not a flat list, not a tree. Two panels:
+- **Panel A (280px)**: topic index — searchable, contributor dot clusters on hover, type filter tabs (All / Decisions / Learnings), contributors section at bottom
+- **Panel B**: topic detail — decisions as evolution timeline with `●` (current, filled blue) and `◌` (superseded, outlined, collapsed by default, strikethrough title)
+
+URL: `/knowledge?topic=database/sqlite` — Panel A selection drives URL.
+
+Mobile: Panel A becomes `<Sheet side="left">` triggered by "Topics (N)" button in sticky header.
+
+**shadcn/ui components**: `<ScrollArea>`, `<Input>`, `<Tabs>`, `<Avatar>`, `<HoverCard>`, `<Collapsible>`, `<DropdownMenu>`, extend `InsightCard` conventions, reuse `InsightsPage` three-pane layout instinct.
+
+**Visual treatment for superseded**:
+1. Dot marker: filled `●` (current) vs outlined `◌` (superseded)
+2. `opacity-60` + `line-through` on title
+3. `<Collapsible>` closed by default — one-click expand
+
+### Conflict alert: non-blocking by default
+
+**Terminal**: Push always completes. Post-sync summary lists conflicts with `code-insights knowledge resolve` follow-up. Interactive mode via `--resolve-conflicts` flag.
+
+**Dashboard**: Three layers:
+- Page: amber `<Alert>` banner ("3 unresolved conflicts — [Review all]")
+- Topic row: amber dot in Panel A topic list
+- Entry card: inline `<Card>` resolution box (not modal/popover) with keyword overlap % + matched token chips + [Mark as supersedes] [Mark as complements] [Dismiss] buttons
+
+Resolution options: Supersedes (primary, `<Button variant="default">`), Complements (`<Button variant="outline">`), Dismiss (`<Button variant="ghost">`).
+
+**Threshold note**: Start conflict detection at ≥60% overlap OR (same topic tag + ≥40%). False positives kill trust faster than missed conflicts.
+
+### `code-insights context` terminal output design
+
+Unified marker system across both commands:
+- `●` filled green = decision
+- `◆` cyan diamond = learning
+- `⚠` yellow/red = friction (by severity)
+- `✓` green check = effective pattern
+
+Attribution: `@handle · Jan 14, 2026` in `chalk.dim()` — absolute date, not relative (output is often copy-pasted).
+
+Box header (`╭─╮`) shows topic + project + `[team sync]` / `[local only]` status tag.
+
+Superseded shown with inline arrow: `↑ supersedes @alice's Jan 14 decision on ORM migrations`.
+
+**Key flags**: `--all` (include superseded), `--type decisions/learnings`, `--since 30d`, `--author alice`, `--format md/json`, `--local` (skip team DB).
+
+**Pipe safety**: Auto-detect `!process.stdout.isTTY` and drop color (chalk handles this). Wrap at `min(process.stdout.columns, 100)` chars.
+
+### Cross-surface consistency (terminal ↔ dashboard)
+
+| Convention | Terminal | Dashboard |
+|-----------|----------|-----------|
+| Current decision | `●` green | filled dot, blue border |
+| Superseded decision | `◌` dim + strikethrough | outlined dot, opacity-60, collapsible |
+| Learning | `◆` cyan | separate section, no icon |
+| Friction | `⚠` yellow/red by severity | amber left border + AlertTriangle |
+| Pattern | `✓` green | emerald left border + Sparkles |
+| Attribution | `@handle · Jan 14, 2026` (dim) | avatar + `@handle · Jan 14, 2026` (dim) |
+| Team sync status | `[team sync]` tag in box header | "Scope: Team + Mine" selector |
+
+---
+
 ## Next Steps
 
-1. TA reviews technical architecture — schema, sync, conflict detection feasibility
-2. UX engineer reviews dashboard topic grouping + conflict alert UX
-3. Update VISION.md to reflect team tier direction (after founder decision)
-4. Write implementation plan starting with Phase 1 (original spec + fixes)
-5. Phase 2–4 get separate specs and plans
+1. **Founder decision**: Update VISION.md to reflect team tier direction — required before Phase 3 begins (escalated by TA)
+2. **Phase 1 implementation plan**: Write plan for original spec + 3 fixes + topic tag extraction. Invoke `superpowers:writing-plans` skill.
+3. **Phase 2 plan** (can follow Phase 1 immediately): Local `context` command
+4. **Phase 3 mini-spec**: `.code-insights/team-config.yml` format + Supabase schema + RLS policies
+5. Phases 3–6 get their own specs and plans once Phase 1–2 ship


### PR DESCRIPTION
## Summary

This PR captures the complete design brainstorming session for the codebase knowledge feature, including competitive research, spec analysis, TA + UX review, and a new team tier direction that requires a founder decision before implementation.

**No code changes.** Documentation only.

## What's in this PR

### 1. Brainstorm notes (`docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md`)

Full session notes from a parallel-agent brainstorm covering:

- **entire.io competitive research** — entire.io is a commit-anchored, full-fidelity session archive (raw transcripts in git orphan branches). Code Insights is a synthesized knowledge layer. Complementary, not competing. Key lesson: the retrieval UX (`entire explain`) matters as much as the storage.
- **Spec pros/cons analysis** — the 2026-04-20 spec is directionally right but has 5 real gaps: silent staleness, single-author blindspot, informal CLAUDE.md agent discovery, undefined update cadence, LLM hallucination risk in Key Decisions.
- **Design direction chosen: B — The Intent Layer** — original spec + 3 targeted fixes + `code-insights context <topic>` retrieval command + formal `--inject-rules` CLAUDE.md integration + configurable auto-regeneration.
- **Team knowledge sync model** — major new direction: Bring-Your-Own Supabase PostgreSQL for team tier; only LLM-extracted knowledge syncs (never raw transcripts); `code-insights context <topic>` merges local DB + team Supabase with attribution.
- **Conflict resolution model** — latest decision wins (like superseding ADRs); keyword overlap surfaces conflicts at push time; non-blocking; user resolves as "supersedes" or "complements"; dashboard shows topic evolution timeline.

### 2. TA review findings (appended to brainstorm doc)

- Schema revisions: project UUID (not name string), `team_decision_links` for complements, missing fields (`updated_at`, `source_session_hash`, `local_insight_id`, `deleted_at`), mandatory RLS policies
- Conflict detection: `pg_trgm` + topic-tag GIN overlap — no pgvector in V1
- Auth: Supabase Auth + anon key + user JWT — not connection strings or service role keys
- Topic extraction: LLM tagging at analysis time (mandatory — conflict detection depends on it); requires schema V10 + `topic-normalize.ts`
- Revised 6-phase implementation sequence (topic tags move into Phase 1)
- Critical escalation: VISION.md update required before Phase 3

### 3. UX review findings (appended to brainstorm doc)

- `/knowledge` page: two-pane master/detail (Panel A = topic index, Panel B = topic detail with evolution timeline)
- Conflict alert: non-blocking terminal post-sync summary + `code-insights knowledge resolve`; dashboard inline resolution box (no modals)
- Terminal output design: `●◆⚠✓` unified marker system, box header with team sync status tag, chalk.dim attribution
- Cross-surface consistency table covering terminal ↔ dashboard visual language

### 4. VISION.md update

Adds a clearly-marked "Under Active Discussion" section flagging that the "Not a team tool" and "Not a business" non-goals are being reconsidered. Includes a decision gate: the founder must explicitly update VISION.md before Phase 3 implementation begins.

## Decision Required Before Merging to Master

This PR documents a design direction. The VISION.md section makes the founder decision visible. **Merging this PR does not approve the team tier implementation** — it records the brainstorm and surfaces the decision.

The team tier (Phases 3–6) should not begin implementation until VISION.md is explicitly updated to accept or reject the direction.

## What's Not In This PR

- No code changes
- No schema changes
- No CLI or server changes
- Phase 1 implementation plan (original spec + fixes + topic tags) — that comes next

## Test plan

- [ ] Read `docs/superpowers/specs/2026-04-22-codebase-knowledge-redesign-brainstorm.md` and confirm it accurately captures the design session
- [ ] Read the "Under Active Discussion" section in `docs/VISION.md` and confirm the framing is accurate and honest
- [ ] Make the founder decision on team tier direction before Phase 3 begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)