### PR TITLE
fix(insights): use configured LLM provider in insights check --analyze

### DIFF
--- a/cli/src/commands/__tests__/insights.test.ts
+++ b/cli/src/commands/__tests__/insights.test.ts
@@ -518,6 +518,7 @@ describe('insightsCheckCommand — auto-analyze (1-2 sessions)', () => {
     runMigrations(mockDb);
     mockRunAnalysis.mockReset();
     mockValidate.mockReset();
+    mockFromConfig.mockReset();
     mockProviderRunAnalysis.mockReset();
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -533,29 +534,31 @@ describe('insightsCheckCommand — auto-analyze (1-2 sessions)', () => {
     db.exec(`INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count) VALUES ('${id}', 'pa1', 'proj', '/p', datetime('now'), datetime('now'), 10);`);
   }
 
-  it('auto-analyzes 1 unanalyzed session using native runner', async () => {
+  it('auto-analyzes 1 unanalyzed session using configured provider', async () => {
     seedOne(mockDb, 'auto-1');
-    mockRunAnalysis
-      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' });
+    mockProviderRunAnalysis
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' });
     const { insightsCheckCommand } = await import('../insights.js');
     await insightsCheckCommand({ days: 7, quiet: false });
-    expect(mockValidate).toHaveBeenCalledTimes(1);
-    expect(mockRunAnalysis).toHaveBeenCalledTimes(2);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockProviderRunAnalysis).toHaveBeenCalledTimes(2);
   });
 
-  it('auto-analyzes 2 unanalyzed sessions using native runner', async () => {
+  it('auto-analyzes 2 unanalyzed sessions using configured provider', async () => {
     seedOne(mockDb, 'auto-2a');
     seedOne(mockDb, 'auto-2b');
-    mockRunAnalysis
-      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' });
+    mockProviderRunAnalysis
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 500, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 400, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' });
     const { insightsCheckCommand } = await import('../insights.js');
     await insightsCheckCommand({ days: 7, quiet: false });
-    expect(mockValidate).toHaveBeenCalled();
-    expect(mockRunAnalysis).toHaveBeenCalledTimes(4);
+    expect(mockValidate).not.toHaveBeenCalled();
+    expect(mockFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockProviderRunAnalysis).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -591,9 +594,9 @@ describe('insightsCheckCommand — --analyze flag', () => {
   it('processes all sessions with --analyze and shows [N/total] progress', async () => {
     seedSessions(mockDb, 3);
     for (let i = 0; i < 3; i++) {
-      mockRunAnalysis
-        .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-        .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' });
+      mockProviderRunAnalysis
+        .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+        .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' });
     }
     const { insightsCheckCommand } = await import('../insights.js');
     await insightsCheckCommand({ days: 7, quiet: false, analyze: true });
@@ -609,12 +612,12 @@ describe('insightsCheckCommand — --analyze flag', () => {
 
   it('continues processing after one session fails', async () => {
     seedSessions(mockDb, 3);
-    mockRunAnalysis
+    mockProviderRunAnalysis
       .mockRejectedValueOnce(new Error('fail on session 0'))
-      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' })
-      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'claude-native', provider: 'claude-code-native' });
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 1000, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 800, inputTokens: 0, outputTokens: 0, model: 'anthropic', provider: 'anthropic' });
     const { insightsCheckCommand } = await import('../insights.js');
     await insightsCheckCommand({ days: 7, quiet: false, analyze: true });
     const stdoutOutput = (stdoutSpy.mock.calls as Array<[unknown]>).map(c => String(c[0])).join('');

--- a/cli/src/commands/__tests__/insights.test.ts
+++ b/cli/src/commands/__tests__/insights.test.ts
@@ -572,6 +572,7 @@ describe('insightsCheckCommand — --analyze flag', () => {
     runMigrations(mockDb);
     mockRunAnalysis.mockReset();
     mockValidate.mockReset();
+    mockFromConfig.mockReset();
     mockProviderRunAnalysis.mockReset();
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -346,8 +346,7 @@ export async function insightsCheckCommand(opts: {
 
     // --analyze: process all found sessions with progress output
     if (analyze) {
-      ClaudeNativeRunner.validate();
-      const runner = new ClaudeNativeRunner({ model: opts.model });
+      const runner = ProviderRunner.fromConfig();
       let successCount = 0;
 
       for (let i = 0; i < rows.length; i++) {
@@ -357,7 +356,7 @@ export async function insightsCheckCommand(opts: {
         process.stdout.write(`${position} ${label} ... `);
         const start = Date.now();
         try {
-          await runInsightsCommand({ sessionId: row.id, native: true, quiet: true, _runner: runner });
+          await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
           const elapsed = Math.round((Date.now() - start) / 1000);
           process.stdout.write(`done (${elapsed}s)\n`);
           successCount++;
@@ -371,15 +370,14 @@ export async function insightsCheckCommand(opts: {
       return;
     }
 
-    // Auto-analyze silently when 1-2 unanalyzed sessions
+    // Auto-analyse silently when 1-2 unanalysed sessions
     if (count <= 2) {
-      ClaudeNativeRunner.validate();
-      const runner = new ClaudeNativeRunner({ model: opts.model });
+      const runner = ProviderRunner.fromConfig();
       for (const row of rows) {
         try {
-          await runInsightsCommand({ sessionId: row.id, native: true, quiet: true, _runner: runner });
+          await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
         } catch {
-          // Silently ignore auto-analyze errors for 1-2 sessions
+          // Silently ignore auto-analyse errors for 1-2 sessions
         }
       }
       return;

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -311,7 +311,6 @@ export async function insightsCheckCommand(opts: {
   days?: number;
   quiet?: boolean;
   analyze?: boolean;
-  model?: string;
 }): Promise<void> {
   const days = opts.days ?? 7;
   const quiet = opts.quiet ?? false;
@@ -370,14 +369,14 @@ export async function insightsCheckCommand(opts: {
       return;
     }
 
-    // Auto-analyse silently when 1-2 unanalysed sessions
+    // Auto-analyze silently when 1-2 unanalyzed sessions
     if (count <= 2) {
       const runner = ProviderRunner.fromConfig();
       for (const row of rows) {
         try {
           await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
         } catch {
-          // Silently ignore auto-analyse errors for 1-2 sessions
+          // Silently ignore auto-analyze errors for 1-2 sessions
         }
       }
       return;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -166,13 +166,11 @@ insightsCmd
   .option('--days <n>', 'Lookback window in days', '7')
   .option('-q, --quiet', 'Machine-readable output (just count)')
   .option('--analyze', 'Process all found sessions sequentially')
-  .option('--model <model>', 'Model for native analysis (default: sonnet)')
   .action(async (opts) => {
     await insightsCheckCommand({
       days: opts.days ? parseInt(opts.days, 10) : 7,
       quiet: opts.quiet,
       analyze: opts.analyze,
-      model: opts.model,
     });
   });
 


### PR DESCRIPTION
## Problem

`insights check --analyze` (and the auto-analyse path for ≤2 unanalysed sessions) hardcoded `ClaudeNativeRunner` regardless of what is configured in `config.json`:

```ts
// insightsCheckCommand — both paths affected
ClaudeNativeRunner.validate();
const runner = new ClaudeNativeRunner({ model: opts.model });
await runInsightsCommand({ sessionId: row.id, native: true, ... });
```

This means users who have configured a provider under `insights.llm` (Gemini, OpenAI, Ollama, Anthropic) will still have `claude -p` invoked, producing an error or silently using the wrong model.

The per-session `insights <id>` command does this correctly already:
```ts
runner = ProviderRunner.fromConfig();
```

## Fix

Replace both hardcoded `ClaudeNativeRunner` instances in `insightsCheckCommand` with `ProviderRunner.fromConfig()` and set `native: false`, making the behaviour consistent with the direct `insights <id>` invocation.

Update tests to assert on `mockProviderRunAnalysis` (ProviderRunner) instead of `mockRunAnalysis` (ClaudeNativeRunner), and add `mockFromConfig.mockReset()` to the auto-analyze `beforeEach` (was missing, causing cross-test count bleed).

## Behaviour change

Users who had **no provider configured** and were relying on `insights check --analyze` silently falling through to Claude native will now receive a configuration error. They should either:
- Run `code-insights config llm` to configure a provider, or
- Use `code-insights insights <id> --native` for individual sessions

## Verification

```
pnpm test --run src/commands/__tests__/insights.test.ts
```

```
Test Files  1 passed (1)
Tests       26 passed (26)
```

Full suite:
```
Test Files  28 passed (28)
Tests       579 passed (579)
```

Closes #286 (original fix contributed by @Coopeh)