### PR TITLE
feat: Dispatch — Learnings-Curated Blog Post Generator

### DIFF
--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -392,11 +392,18 @@ export interface DispatchInsight {
   bullets: string[];
 }
 
+export interface SessionBackground {
+  title: string;
+  sessionCharacter: string | null;
+  summary: string;
+}
+
 export interface DispatchRequest {
   insightIds: string[];
   context: string;
   tone: DispatchTone;
   format: DispatchFormat;
+  includeSessionBackground?: boolean;
 }
 
 export interface DispatchResponse {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -393,6 +393,7 @@ export interface DispatchInsight {
 }
 
 export interface SessionBackground {
+  sessionId: string;
   title: string;
   sessionCharacter: string | null;
   summary: string;

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -382,6 +382,7 @@ export interface FileSyncState {
 // ── Dispatch feature (blog post generator) ───────────────────────────────────
 
 export type DispatchTone = 'technical' | 'accessible' | 'quick-tips';
+export type DispatchFormat = 'blog' | 'linkedin';
 
 export interface DispatchInsight {
   id: string;
@@ -395,16 +396,22 @@ export interface DispatchRequest {
   insightIds: string[];
   context: string;
   tone: DispatchTone;
+  format: DispatchFormat;
 }
 
 export interface DispatchResponse {
   markdown: string;
+  /** Plain text body without YAML frontmatter — use for LinkedIn copy and word/char count. */
+  body: string;
+  format: DispatchFormat;
   frontmatter: {
     title: string;
     tags: string[];
     tldr: string;
   };
   wordCount: number;
+  characterCount: number;
+  degraded: boolean;
   model: string;
   tokensUsed: {
     input: number;

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -379,3 +379,36 @@ export interface FileSyncState {
   syncedSessionIds?: string[];  // For providers where 1 file = N sessions (e.g., Cursor SQLite)
 }
 
+// ── Dispatch feature (blog post generator) ───────────────────────────────────
+
+export type DispatchTone = 'technical' | 'accessible' | 'quick-tips';
+
+export interface DispatchInsight {
+  id: string;
+  type: string;
+  summary: string;
+  content: string;
+  bullets: string[];
+}
+
+export interface DispatchRequest {
+  insightIds: string[];
+  context: string;
+  tone: DispatchTone;
+}
+
+export interface DispatchResponse {
+  markdown: string;
+  frontmatter: {
+    title: string;
+    tags: string[];
+    tldr: string;
+  };
+  wordCount: number;
+  model: string;
+  tokensUsed: {
+    input: number;
+    output: number;
+  };
+}
+

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,6 +13,9 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.67.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -17,7 +17,7 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Loader2, AlertCircle } from 'lucide-react';
+import { GripVertical, Loader2, AlertCircle, X } from 'lucide-react';
 import {
   Sheet,
   SheetContent,
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
 import { generateDispatch } from '@/lib/api';
 import { PostPreview } from './PostPreview';
 import type { Insight } from '@/lib/types';
@@ -73,6 +74,7 @@ function SortableInsightItem({ insight, onRemove }: SortableInsightItemProps) {
         {...attributes}
         {...listeners}
         aria-label="Drag to reorder"
+        aria-description="Press Space or Enter to pick up, arrow keys to move, Space or Enter to drop"
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -85,11 +87,11 @@ function SortableInsightItem({ insight, onRemove }: SortableInsightItemProps) {
         <p className="text-xs text-muted-foreground leading-snug line-clamp-2">{insight.summary || insight.title}</p>
       </div>
       <button
-        className="shrink-0 text-muted-foreground hover:text-destructive transition-colors text-xs mt-0.5"
+        className="shrink-0 text-muted-foreground hover:text-destructive transition-colors mt-0.5"
         onClick={() => onRemove(insight.id)}
         aria-label="Remove insight"
       >
-        ×
+        <X className="h-3.5 w-3.5" />
       </button>
     </div>
   );
@@ -208,13 +210,13 @@ export function DispatchDrawer({
               <label className="block text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                 {"What's the story?"}
               </label>
-              <textarea
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring resize-none"
+              <Textarea
                 rows={4}
-                maxLength={600}
+                maxLength={500}
                 placeholder="2-3 sentences framing the narrative. What did you build or discover? Why does it matter?"
                 value={context}
                 onChange={(e) => setContext(e.target.value)}
+                className="resize-none"
               />
               <div className="flex justify-between mt-1">
                 <p className="text-xs text-muted-foreground">

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -1,0 +1,308 @@
+import { useState, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Loader2, AlertCircle } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { generateDispatch } from '@/lib/api';
+import { PostPreview } from './PostPreview';
+import type { Insight } from '@/lib/types';
+import type { DispatchTone, DispatchResponse } from '@/lib/api';
+
+const TONE_OPTIONS: { value: DispatchTone; label: string; description: string }[] = [
+  { value: 'technical', label: 'Technical deep-dive', description: 'For senior engineers — precise, depth-first' },
+  { value: 'accessible', label: 'Accessible', description: 'Broader audience — clear, with analogies' },
+  { value: 'quick-tips', label: 'Quick tips', description: 'Scannable — bold tips + brief context' },
+];
+
+const INSIGHT_TYPE_COLORS: Record<string, string> = {
+  learning: 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20',
+  decision: 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20',
+  technique: 'bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/20',
+  summary: 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20',
+  prompt_quality: 'bg-rose-500/10 text-rose-700 dark:text-rose-400 border-rose-500/20',
+};
+
+interface SortableInsightItemProps {
+  insight: Insight;
+  onRemove: (id: string) => void;
+}
+
+function SortableInsightItem({ insight, onRemove }: SortableInsightItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: insight.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const colorClass = INSIGHT_TYPE_COLORS[insight.type] ?? INSIGHT_TYPE_COLORS.summary;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-start gap-2 rounded-md border bg-card p-2.5 text-sm"
+    >
+      <button
+        className="mt-0.5 shrink-0 cursor-grab text-muted-foreground hover:text-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+        aria-label="Drag to reorder"
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 mb-1">
+          <Badge variant="outline" className={`text-[10px] px-1.5 py-0 ${colorClass}`}>
+            {insight.type.replace('_', ' ')}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground leading-snug line-clamp-2">{insight.summary || insight.title}</p>
+      </div>
+      <button
+        className="shrink-0 text-muted-foreground hover:text-destructive transition-colors text-xs mt-0.5"
+        onClick={() => onRemove(insight.id)}
+        aria-label="Remove insight"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+interface DispatchDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedInsights: Insight[];
+  onReorder: (insights: Insight[]) => void;
+  onRemove: (id: string) => void;
+}
+
+export function DispatchDrawer({
+  open,
+  onOpenChange,
+  selectedInsights,
+  onReorder,
+  onRemove,
+}: DispatchDrawerProps) {
+  const [context, setContext] = useState('');
+  const [tone, setTone] = useState<DispatchTone>('technical');
+  const [result, setResult] = useState<DispatchResponse | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: generateDispatch,
+    onSuccess: (data) => setResult(data),
+  });
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = selectedInsights.findIndex((i) => i.id === active.id);
+    const newIndex = selectedInsights.findIndex((i) => i.id === over.id);
+    onReorder(arrayMove(selectedInsights, oldIndex, newIndex));
+  }, [selectedInsights, onReorder]);
+
+  function handleGenerate() {
+    mutation.mutate({
+      insightIds: selectedInsights.map((i) => i.id),
+      context,
+      tone,
+    });
+  }
+
+  function handleClose() {
+    onOpenChange(false);
+    // Reset generation result when drawer closes so next open starts fresh
+    setResult(null);
+    mutation.reset();
+  }
+
+  const canGenerate = selectedInsights.length >= 3 && context.trim().length > 0 && !mutation.isPending;
+  const contextTooLong = context.length > 500;
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-none sm:w-[480px] flex flex-col p-0 gap-0"
+      >
+        <SheetHeader className="px-4 py-3 border-b shrink-0">
+          <SheetTitle>Create Blog Post</SheetTitle>
+          <SheetDescription>
+            Curate insights and context, then generate a publishable post.
+          </SheetDescription>
+        </SheetHeader>
+
+        {result ? (
+          <PostPreview result={result} />
+        ) : (
+          <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+            {/* Selected insights with drag-to-reorder */}
+            <div>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                Selected ({selectedInsights.length})
+                {selectedInsights.length > 0 && (
+                  <span className="ml-1 normal-case font-normal">— drag to reorder</span>
+                )}
+              </p>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={selectedInsights.map((i) => i.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-1.5">
+                    {selectedInsights.map((insight) => (
+                      <SortableInsightItem
+                        key={insight.id}
+                        insight={insight}
+                        onRemove={onRemove}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+              {selectedInsights.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No insights selected. Close this panel and select at least 3 from the list.
+                </p>
+              )}
+            </div>
+
+            {/* Context textarea */}
+            <div>
+              <label className="block text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
+                {"What's the story?"}
+              </label>
+              <textarea
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring resize-none"
+                rows={4}
+                maxLength={600}
+                placeholder="2-3 sentences framing the narrative. What did you build or discover? Why does it matter?"
+                value={context}
+                onChange={(e) => setContext(e.target.value)}
+              />
+              <div className="flex justify-between mt-1">
+                <p className="text-xs text-muted-foreground">
+                  This shapes the arc — the model reads it before the insights.
+                </p>
+                <span className={`text-xs ${contextTooLong ? 'text-destructive' : 'text-muted-foreground'}`}>
+                  {context.length}/500
+                </span>
+              </div>
+            </div>
+
+            {/* Tone selector */}
+            <div>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Tone</p>
+              <div className="space-y-1.5">
+                {TONE_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex items-start gap-2.5 rounded-md border px-3 py-2.5 cursor-pointer transition-colors ${
+                      tone === opt.value
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:border-primary/40'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="dispatch-tone"
+                      value={opt.value}
+                      checked={tone === opt.value}
+                      onChange={() => setTone(opt.value)}
+                      className="mt-0.5 shrink-0 accent-primary"
+                    />
+                    <div>
+                      <p className="text-sm font-medium">{opt.label}</p>
+                      <p className="text-xs text-muted-foreground">{opt.description}</p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Error */}
+            {mutation.isError && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>{mutation.error instanceof Error ? mutation.error.message : 'Generation failed. Please try again.'}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Footer */}
+        {!result && (
+          <div className="shrink-0 px-4 py-3 border-t">
+            <Button
+              className="w-full"
+              onClick={handleGenerate}
+              disabled={!canGenerate || contextTooLong}
+            >
+              {mutation.isPending ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Generating...
+                </>
+              ) : (
+                'Generate Post'
+              )}
+            </Button>
+            {!context.trim() && selectedInsights.length >= 3 && (
+              <p className="text-xs text-muted-foreground text-center mt-1.5">
+                Add a context paragraph to enable generation
+              </p>
+            )}
+          </div>
+        )}
+
+        {result && (
+          <div className="shrink-0 px-4 py-3 border-t">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => { setResult(null); mutation.reset(); }}
+            >
+              Regenerate
+            </Button>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
 import { generateDispatch } from '@/lib/api';
 import { PostPreview } from './PostPreview';
 import type { Insight } from '@/lib/types';
@@ -120,6 +121,7 @@ export function DispatchDrawer({
   const [context, setContext] = useState('');
   const [format, setFormat] = useState<DispatchFormat>('blog');
   const [tone, setTone] = useState<DispatchTone>('technical');
+  const [includeSessionBackground, setIncludeSessionBackground] = useState(false);
   const [result, setResult] = useState<DispatchResponse | null>(null);
 
   const mutation = useMutation({
@@ -147,6 +149,7 @@ export function DispatchDrawer({
       context,
       tone,
       format,
+      includeSessionBackground,
     });
   }
 
@@ -157,6 +160,7 @@ export function DispatchDrawer({
     setFormat('blog');
     setTone('technical');
     setContext('');
+    setIncludeSessionBackground(false);
   }
 
   const canGenerate = selectedInsights.length >= 3 && context.trim().length > 0 && !mutation.isPending;
@@ -240,6 +244,22 @@ export function DispatchDrawer({
               </div>
             </div>
 
+            {/* Session background toggle */}
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-medium text-foreground">Include session background</p>
+                <p className="text-xs text-muted-foreground">
+                  Adds session summaries to help the model understand context (up to 4 sessions).
+                </p>
+              </div>
+              <Switch
+                id="session-background"
+                checked={includeSessionBackground}
+                onCheckedChange={setIncludeSessionBackground}
+                aria-label="Include session background"
+              />
+            </div>
+
             {/* Format selector */}
             <fieldset className="space-y-2 border-0 p-0 m-0 min-w-0">
               <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Format</legend>
@@ -299,6 +319,18 @@ export function DispatchDrawer({
                 ))}
               </div>
             </fieldset>
+
+            {/* Session background toggle */}
+            <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2.5">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Include session background</p>
+                <p className="text-xs text-muted-foreground">Adds session context to help the model understand how insights connect</p>
+              </div>
+              <Switch
+                checked={includeSessionBackground}
+                onCheckedChange={setIncludeSessionBackground}
+              />
+            </div>
 
             {/* Error */}
             {mutation.isError && (

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -241,7 +241,7 @@ export function DispatchDrawer({
             </div>
 
             {/* Format selector */}
-            <fieldset className="space-y-2">
+            <fieldset className="space-y-2 border-0 p-0 m-0 min-w-0">
               <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Format</legend>
               <div className="space-y-1.5">
                 {FORMAT_OPTIONS.map((opt) => (
@@ -271,7 +271,7 @@ export function DispatchDrawer({
             </fieldset>
 
             {/* Tone selector */}
-            <fieldset className="space-y-2">
+            <fieldset className="space-y-2 border-0 p-0 m-0 min-w-0">
               <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Tone</legend>
               <div className="space-y-1.5">
                 {TONE_OPTIONS.map((opt) => (

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -244,22 +244,6 @@ export function DispatchDrawer({
               </div>
             </div>
 
-            {/* Session background toggle */}
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-xs font-medium text-foreground">Include session background</p>
-                <p className="text-xs text-muted-foreground">
-                  Adds session summaries to help the model understand context (up to 4 sessions).
-                </p>
-              </div>
-              <Switch
-                id="session-background"
-                checked={includeSessionBackground}
-                onCheckedChange={setIncludeSessionBackground}
-                aria-label="Include session background"
-              />
-            </div>
-
             {/* Format selector */}
             <fieldset className="space-y-2 border-0 p-0 m-0 min-w-0">
               <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Format</legend>
@@ -321,14 +305,20 @@ export function DispatchDrawer({
             </fieldset>
 
             {/* Session background toggle */}
-            <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2.5">
-              <div className="min-w-0">
-                <p className="text-sm font-medium">Include session background</p>
-                <p className="text-xs text-muted-foreground">Adds session context to help the model understand how insights connect</p>
+            <div className="flex items-center justify-between rounded-md border px-3 py-2.5">
+              <div className="space-y-0.5">
+                <label htmlFor="session-background" className="text-sm font-medium cursor-pointer">
+                  Include session background
+                </label>
+                <p id="session-bg-desc" className="text-xs text-muted-foreground">
+                  Adds session summaries to help the model understand context (up to 4 sessions).
+                </p>
               </div>
               <Switch
+                id="session-background"
                 checked={includeSessionBackground}
                 onCheckedChange={setIncludeSessionBackground}
+                aria-describedby="session-bg-desc"
               />
             </div>
 

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -31,7 +31,12 @@ import { Textarea } from '@/components/ui/textarea';
 import { generateDispatch } from '@/lib/api';
 import { PostPreview } from './PostPreview';
 import type { Insight } from '@/lib/types';
-import type { DispatchTone, DispatchResponse } from '@/lib/api';
+import type { DispatchTone, DispatchFormat, DispatchResponse } from '@/lib/api';
+
+const FORMAT_OPTIONS: { value: DispatchFormat; label: string; description: string }[] = [
+  { value: 'blog', label: 'Blog post', description: 'Full narrative, 800-1000 words, markdown ready to paste to dev.to / Hashnode' },
+  { value: 'linkedin', label: 'LinkedIn', description: 'Hook-first, 150-250 words, optimized for LinkedIn feed' },
+];
 
 const TONE_OPTIONS: { value: DispatchTone; label: string; description: string }[] = [
   { value: 'technical', label: 'Technical deep-dive', description: 'For senior engineers — precise, depth-first' },
@@ -113,6 +118,7 @@ export function DispatchDrawer({
   onRemove,
 }: DispatchDrawerProps) {
   const [context, setContext] = useState('');
+  const [format, setFormat] = useState<DispatchFormat>('blog');
   const [tone, setTone] = useState<DispatchTone>('technical');
   const [result, setResult] = useState<DispatchResponse | null>(null);
 
@@ -140,6 +146,7 @@ export function DispatchDrawer({
       insightIds: selectedInsights.map((i) => i.id),
       context,
       tone,
+      format,
     });
   }
 
@@ -160,7 +167,7 @@ export function DispatchDrawer({
         className="w-full sm:max-w-none sm:w-[480px] flex flex-col p-0 gap-0"
       >
         <SheetHeader className="px-4 py-3 border-b shrink-0">
-          <SheetTitle>Create Blog Post</SheetTitle>
+          <SheetTitle>Create Post</SheetTitle>
           <SheetDescription>
             Curate insights and context, then generate a publishable post.
           </SheetDescription>
@@ -225,6 +232,36 @@ export function DispatchDrawer({
                 <span className={`text-xs ${contextTooLong ? 'text-destructive' : 'text-muted-foreground'}`}>
                   {context.length}/500
                 </span>
+              </div>
+            </div>
+
+            {/* Format selector */}
+            <div>
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Format</p>
+              <div className="space-y-1.5">
+                {FORMAT_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex items-start gap-2.5 rounded-md border px-3 py-2.5 cursor-pointer transition-colors ${
+                      format === opt.value
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:border-primary/40'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="dispatch-format"
+                      value={opt.value}
+                      checked={format === opt.value}
+                      onChange={() => setFormat(opt.value)}
+                      className="mt-0.5 shrink-0 accent-primary"
+                    />
+                    <div>
+                      <p className="text-sm font-medium">{opt.label}</p>
+                      <p className="text-xs text-muted-foreground">{opt.description}</p>
+                    </div>
+                  </label>
+                ))}
               </div>
             </div>
 

--- a/dashboard/src/components/dispatch/DispatchDrawer.tsx
+++ b/dashboard/src/components/dispatch/DispatchDrawer.tsx
@@ -79,7 +79,7 @@ function SortableInsightItem({ insight, onRemove }: SortableInsightItemProps) {
         {...attributes}
         {...listeners}
         aria-label="Drag to reorder"
-        aria-description="Press Space or Enter to pick up, arrow keys to move, Space or Enter to drop"
+        aria-describedby="drag-hint"
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -152,9 +152,11 @@ export function DispatchDrawer({
 
   function handleClose() {
     onOpenChange(false);
-    // Reset generation result when drawer closes so next open starts fresh
     setResult(null);
     mutation.reset();
+    setFormat('blog');
+    setTone('technical');
+    setContext('');
   }
 
   const canGenerate = selectedInsights.length >= 3 && context.trim().length > 0 && !mutation.isPending;
@@ -185,6 +187,9 @@ export function DispatchDrawer({
                   <span className="ml-1 normal-case font-normal">— drag to reorder</span>
                 )}
               </p>
+              <span id="drag-hint" className="sr-only">
+                Press Space or Enter to pick up, arrow keys to move, Space or Enter to drop, Escape to cancel.
+              </span>
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -236,8 +241,8 @@ export function DispatchDrawer({
             </div>
 
             {/* Format selector */}
-            <div>
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Format</p>
+            <fieldset className="space-y-2">
+              <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Format</legend>
               <div className="space-y-1.5">
                 {FORMAT_OPTIONS.map((opt) => (
                   <label
@@ -263,11 +268,11 @@ export function DispatchDrawer({
                   </label>
                 ))}
               </div>
-            </div>
+            </fieldset>
 
             {/* Tone selector */}
-            <div>
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2">Tone</p>
+            <fieldset className="space-y-2">
+              <legend className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Tone</legend>
               <div className="space-y-1.5">
                 {TONE_OPTIONS.map((opt) => (
                   <label
@@ -293,7 +298,7 @@ export function DispatchDrawer({
                   </label>
                 ))}
               </div>
-            </div>
+            </fieldset>
 
             {/* Error */}
             {mutation.isError && (

--- a/dashboard/src/components/dispatch/FloatingActionBar.tsx
+++ b/dashboard/src/components/dispatch/FloatingActionBar.tsx
@@ -1,0 +1,32 @@
+import { PenLine } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface FloatingActionBarProps {
+  count: number;
+  onOpen: () => void;
+}
+
+const MAX_INSIGHTS = 8;
+
+export function FloatingActionBar({ count, onOpen }: FloatingActionBarProps) {
+  if (count < 3) return null;
+
+  const atMax = count >= MAX_INSIGHTS;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-full border bg-background shadow-lg px-4 py-2.5 animate-in slide-in-from-bottom-4 duration-300">
+      <span className="text-sm font-medium">
+        {count} insight{count !== 1 ? 's' : ''} selected
+      </span>
+      {atMax && (
+        <span className="text-xs text-amber-600 dark:text-amber-400">
+          Max reached — deselect to swap
+        </span>
+      )}
+      <Button size="sm" className="h-8 gap-1.5 rounded-full" onClick={onOpen}>
+        <PenLine className="h-3.5 w-3.5" />
+        Create Post
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/src/components/dispatch/PostPreview.tsx
+++ b/dashboard/src/components/dispatch/PostPreview.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { toast } from 'sonner';
+import { Copy, Download, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { DispatchResponse } from '@/lib/api';
+
+interface PostPreviewProps {
+  result: DispatchResponse;
+}
+
+export function PostPreview({ result }: PostPreviewProps) {
+  const [tab, setTab] = useState<'preview' | 'markdown'>('preview');
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(result.markdown).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast.success('Copied to clipboard');
+    });
+  }
+
+  function handleDownload() {
+    const slug = result.frontmatter.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 60);
+    const filename = `${slug || 'dispatch-post'}.md`;
+    const blob = new Blob([result.markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success(`Downloaded ${filename}`);
+  }
+
+  // Strip frontmatter for the preview tab — show clean prose
+  const bodyOnly = result.markdown.replace(/^---[\s\S]*?---\n\n?/, '');
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between gap-2 px-4 py-2 border-b shrink-0">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as 'preview' | 'markdown')}>
+          <TabsList variant="default" className="h-8">
+            <TabsTrigger value="preview" className="text-xs px-3">Preview</TabsTrigger>
+            <TabsTrigger value="markdown" className="text-xs px-3">Markdown</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">{result.wordCount} words</span>
+          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleCopy}>
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleDownload}>
+            <Download className="h-3.5 w-3.5" />
+            Download .md
+          </Button>
+        </div>
+      </div>
+
+      {result.frontmatter.tldr && (
+        <div className="mx-4 mt-3 px-3 py-2 rounded-md bg-muted/50 border text-sm text-muted-foreground shrink-0">
+          <span className="font-medium text-foreground">TL;DR:</span> {result.frontmatter.tldr}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {tab === 'preview' ? (
+          <div className="prose prose-sm dark:prose-invert max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {bodyOnly}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words text-muted-foreground">
+            {result.markdown}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/dispatch/PostPreview.tsx
+++ b/dashboard/src/components/dispatch/PostPreview.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
-import { Copy, Download, Check } from 'lucide-react';
+import { Copy, Download, Check, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { DispatchResponse } from '@/lib/api';
@@ -64,6 +64,13 @@ export function PostPreview({ result }: PostPreviewProps) {
           </Button>
         </div>
       </div>
+
+      {result.degraded && (
+        <div className="mx-4 mt-3 flex items-start gap-2 px-3 py-2.5 rounded-md bg-amber-500/10 border border-amber-500/20 text-sm text-amber-700 dark:text-amber-400 shrink-0">
+          <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+          <span>The model returned unexpected formatting — post structure may be incomplete. Review before publishing.</span>
+        </div>
+      )}
 
       {result.frontmatter.tldr && (
         <div className="mx-4 mt-3 px-3 py-2 rounded-md bg-muted/50 border text-sm text-muted-foreground shrink-0">

--- a/dashboard/src/components/dispatch/PostPreview.tsx
+++ b/dashboard/src/components/dispatch/PostPreview.tsx
@@ -15,8 +15,13 @@ export function PostPreview({ result }: PostPreviewProps) {
   const [tab, setTab] = useState<'preview' | 'markdown'>('preview');
   const [copied, setCopied] = useState(false);
 
+  const isLinkedIn = result.format === 'linkedin';
+
+  // LinkedIn: copy body (no YAML). Blog: copy full markdown with frontmatter.
+  const copyText = isLinkedIn ? result.body : result.markdown;
+
   function handleCopy() {
-    void navigator.clipboard.writeText(result.markdown).then(() => {
+    void navigator.clipboard.writeText(copyText).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
       toast.success('Copied to clipboard');
@@ -40,28 +45,39 @@ export function PostPreview({ result }: PostPreviewProps) {
     toast.success(`Downloaded ${filename}`);
   }
 
-  // Strip frontmatter for the preview tab — show clean prose
-  const bodyOnly = result.markdown.replace(/^---[\s\S]*?---\n\n?/, '');
+  // Blog: strip YAML frontmatter for clean prose in preview tab.
+  const blogBodyOnly = result.markdown.replace(/^---[\s\S]*?---\n\n?/, '');
+
+  const countLabel = isLinkedIn
+    ? `${result.characterCount} chars`
+    : `${result.wordCount} words`;
 
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between gap-2 px-4 py-2 border-b shrink-0">
-        <Tabs value={tab} onValueChange={(v) => setTab(v as 'preview' | 'markdown')}>
-          <TabsList variant="default" className="h-8">
-            <TabsTrigger value="preview" className="text-xs px-3">Preview</TabsTrigger>
-            <TabsTrigger value="markdown" className="text-xs px-3">Markdown</TabsTrigger>
-          </TabsList>
-        </Tabs>
+        {isLinkedIn ? (
+          // LinkedIn: no Markdown tab — there is no .md artifact for LinkedIn posts
+          <span className="text-sm font-medium">Preview</span>
+        ) : (
+          <Tabs value={tab} onValueChange={(v) => setTab(v as 'preview' | 'markdown')}>
+            <TabsList variant="default" className="h-8">
+              <TabsTrigger value="preview" className="text-xs px-3">Preview</TabsTrigger>
+              <TabsTrigger value="markdown" className="text-xs px-3">Markdown</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
         <div className="flex items-center gap-1.5">
-          <span className="text-xs text-muted-foreground">{result.wordCount} words</span>
+          <span className="text-xs text-muted-foreground">{countLabel}</span>
           <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleCopy}>
             {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
             {copied ? 'Copied' : 'Copy'}
           </Button>
-          <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleDownload}>
-            <Download className="h-3.5 w-3.5" />
-            Download .md
-          </Button>
+          {!isLinkedIn && (
+            <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleDownload}>
+              <Download className="h-3.5 w-3.5" />
+              Download .md
+            </Button>
+          )}
         </div>
       </div>
 
@@ -72,17 +88,22 @@ export function PostPreview({ result }: PostPreviewProps) {
         </div>
       )}
 
-      {result.frontmatter.tldr && (
+      {!isLinkedIn && result.frontmatter.tldr && (
         <div className="mx-4 mt-3 px-3 py-2 rounded-md bg-muted/50 border text-sm text-muted-foreground shrink-0">
           <span className="font-medium text-foreground">TL;DR:</span> {result.frontmatter.tldr}
         </div>
       )}
 
       <div className="flex-1 overflow-y-auto px-4 py-3">
-        {tab === 'preview' ? (
+        {isLinkedIn ? (
+          // LinkedIn: plain text with preserved whitespace (blank lines = paragraphs in the feed)
+          <pre className="text-sm font-sans whitespace-pre-wrap break-words leading-relaxed">
+            {result.body}
+          </pre>
+        ) : tab === 'preview' ? (
           <div className="prose prose-sm dark:prose-invert max-w-none">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {bodyOnly}
+              {blogBodyOnly}
             </ReactMarkdown>
           </div>
         ) : (

--- a/dashboard/src/components/ui/textarea.tsx
+++ b/dashboard/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -467,6 +467,7 @@ export interface DispatchRequest {
   context: string;
   tone: DispatchTone;
   format: DispatchFormat;
+  includeSessionBackground?: boolean;
 }
 
 export interface DispatchResponse {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -475,6 +475,8 @@ export interface DispatchResponse {
     tldr: string;
   };
   wordCount: number;
+  /** True when frontmatter parse failed and we returned raw content with a guessed title. */
+  degraded?: boolean;
   model: string;
   tokensUsed: {
     input: number;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -457,6 +457,38 @@ export async function reflectGenerateStream(
   return res;
 }
 
+// ── Dispatch (blog post generator) ───────────────────────────────────────────
+
+export type DispatchTone = 'technical' | 'accessible' | 'quick-tips';
+
+export interface DispatchRequest {
+  insightIds: string[];
+  context: string;
+  tone: DispatchTone;
+}
+
+export interface DispatchResponse {
+  markdown: string;
+  frontmatter: {
+    title: string;
+    tags: string[];
+    tldr: string;
+  };
+  wordCount: number;
+  model: string;
+  tokensUsed: {
+    input: number;
+    output: number;
+  };
+}
+
+export function generateDispatch(body: DispatchRequest): Promise<DispatchResponse> {
+  return request<DispatchResponse>('/dispatch/generate', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
 // ── Analysis Queue ────────────────────────────────────────────────────────────
 
 export interface AnalysisQueueItem {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -460,23 +460,28 @@ export async function reflectGenerateStream(
 // ── Dispatch (blog post generator) ───────────────────────────────────────────
 
 export type DispatchTone = 'technical' | 'accessible' | 'quick-tips';
+export type DispatchFormat = 'blog' | 'linkedin';
 
 export interface DispatchRequest {
   insightIds: string[];
   context: string;
   tone: DispatchTone;
+  format: DispatchFormat;
 }
 
 export interface DispatchResponse {
   markdown: string;
+  /** Plain text body without YAML frontmatter — use for LinkedIn copy and character count. */
+  body: string;
+  format: DispatchFormat;
   frontmatter: {
     title: string;
     tags: string[];
     tldr: string;
   };
   wordCount: number;
-  /** True when frontmatter parse failed and we returned raw content with a guessed title. */
-  degraded?: boolean;
+  characterCount: number;
+  degraded: boolean;
   model: string;
   tokensUsed: {
     input: number;

--- a/dashboard/src/pages/InsightsPage.tsx
+++ b/dashboard/src/pages/InsightsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { format } from 'date-fns';
 import { useSearchParams, Link } from 'react-router';
 import { useInsights } from '@/hooks/useInsights';
@@ -15,6 +15,7 @@ import { ErrorCard } from '@/components/ErrorCard';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select,
@@ -33,6 +34,8 @@ import { SavedFiltersDropdown } from '@/components/filters/SavedFiltersDropdown'
 import { SourceToolSelect } from '@/components/filters/SourceToolSelect';
 import { useSavedFilters } from '@/hooks/useSavedFilters';
 import { LlmNudgeBanner } from '@/components/LlmNudgeBanner';
+import { DispatchDrawer } from '@/components/dispatch/DispatchDrawer';
+import { FloatingActionBar } from '@/components/dispatch/FloatingActionBar';
 
 const INSIGHT_TYPES: InsightType[] = ['summary', 'decision', 'learning', 'technique', 'prompt_quality'];
 
@@ -58,6 +61,8 @@ interface InsightGroup {
   insights: Insight[];
 }
 
+const MAX_DISPATCH_INSIGHTS = 8;
+
 export default function InsightsPage() {
   const [filters, setFilter, setFilters, clearFilters] = useFilterParams({
     q: '',
@@ -67,6 +72,36 @@ export default function InsightsPage() {
     pattern: '',
     source: 'all',
   });
+
+  // Dispatch selection state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [selectedInsights, setSelectedInsights] = useState<Insight[]>([]);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const handleToggleSelect = useCallback((insight: Insight) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(insight.id)) {
+        next.delete(insight.id);
+        setSelectedInsights((ins) => ins.filter((i) => i.id !== insight.id));
+      } else {
+        if (next.size >= MAX_DISPATCH_INSIGHTS) return prev;
+        next.add(insight.id);
+        setSelectedInsights((ins) => [...ins, insight]);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleReorder = useCallback((reordered: Insight[]) => {
+    setSelectedInsights(reordered);
+    setSelectedIds(new Set(reordered.map((i) => i.id)));
+  }, []);
+
+  const handleRemoveFromDrawer = useCallback((id: string) => {
+    setSelectedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    setSelectedInsights((ins) => ins.filter((i) => i.id !== id));
+  }, []);
 
   const { savedFilters, saveFilter, deleteFilter } = useSavedFilters('insights');
 
@@ -200,7 +235,7 @@ export default function InsightsPage() {
   }, [filtered, filters.view]);
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+    <div className="flex flex-col h-[calc(100vh-3.5rem)] relative">
       {/* Sticky header: title + filters */}
       <div className="shrink-0 sticky top-0 z-10 bg-background border-b px-6 pt-5 pb-3 space-y-3">
         <div>
@@ -346,16 +381,37 @@ export default function InsightsPage() {
                   {group.label} ({group.count})
                 </h2>
                 <div className="rounded-md border overflow-hidden">
-                  {group.insights.map((insight) => (
-                    <InsightListItem
-                      key={insight.id}
-                      insight={insight}
-                      showProject={filters.view !== 'project'}
-                      allInsightIds={allInsightIds}
-                      highlighted={insight.id === highlightedInsightId}
-                      defaultExpanded={insight.id === highlightedInsightId}
-                    />
-                  ))}
+                  {group.insights.map((insight) => {
+                    const isSelected = selectedIds.has(insight.id);
+                    const atMax = selectedIds.size >= MAX_DISPATCH_INSIGHTS;
+                    return (
+                      <div
+                        key={insight.id}
+                        className={`relative group/dispatch ${isSelected ? 'bg-primary/5' : ''}`}
+                      >
+                        <div
+                          className="absolute left-2 top-3 z-10 opacity-0 group-hover/dispatch:opacity-100 transition-opacity"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Checkbox
+                            checked={isSelected}
+                            disabled={!isSelected && atMax}
+                            onCheckedChange={() => handleToggleSelect(insight)}
+                            aria-label={`Select insight: ${insight.title}`}
+                          />
+                        </div>
+                        <div className={`transition-[padding-left] ${isSelected ? 'pl-8' : 'group-hover/dispatch:pl-8'}`}>
+                          <InsightListItem
+                            insight={insight}
+                            showProject={filters.view !== 'project'}
+                            allInsightIds={allInsightIds}
+                            highlighted={insight.id === highlightedInsightId}
+                            defaultExpanded={insight.id === highlightedInsightId}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             );
@@ -363,6 +419,19 @@ export default function InsightsPage() {
         </div>
       )}
       </div>
+
+      <FloatingActionBar
+        count={selectedIds.size}
+        onOpen={() => setDrawerOpen(true)}
+      />
+
+      <DispatchDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        selectedInsights={selectedInsights}
+        onReorder={handleReorder}
+        onRemove={handleRemoveFromDrawer}
+      />
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,15 @@ importers:
 
   dashboard:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.67.2
         version: 5.90.21(react@19.2.4)
@@ -257,6 +266,28 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -3252,6 +3283,31 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ import exportRouter from './routes/export.js';
 import telemetryRouter from './routes/telemetry.js';
 import facetsRouter from './routes/facets.js';
 import reflectRouter from './routes/reflect.js';
+import dispatchRouter from './routes/dispatch.js';
 
 export interface ServerOptions {
   port: number;
@@ -58,6 +59,7 @@ export function createApp(): Hono {
   app.route('/api/telemetry', telemetryRouter);
   app.route('/api/facets', facetsRouter);
   app.route('/api/reflect', reflectRouter);
+  app.route('/api/dispatch', dispatchRouter);
 
   // Health check
   app.get('/api/health', (c) => c.json({ ok: true, version: '0.1.0' }));

--- a/server/src/llm/dispatch-prompts.test.ts
+++ b/server/src/llm/dispatch-prompts.test.ts
@@ -176,6 +176,61 @@ describe('buildDispatchContext', () => {
     const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
     expect(result).not.toContain('[EVIDENCE');
   });
+
+  it('includes SESSION BACKGROUND block when sessionBackgrounds provided', () => {
+    const result = buildDispatchContext({
+      userContext: 'story',
+      insights: sampleInsights,
+      sessionBackgrounds: [
+        { title: 'WAL Mode Investigation', summary: 'Three weeks debugging writes.', sessionCharacter: 'bug_hunt' },
+      ],
+    });
+    expect(result).toContain('SESSION BACKGROUND');
+    expect(result).toContain('WAL Mode Investigation');
+    expect(result).toContain('Three weeks debugging writes.');
+    expect(result).toContain('bug hunt'); // session_character with underscores replaced
+  });
+
+  it('includes session character parenthetical when present', () => {
+    const result = buildDispatchContext({
+      userContext: 'story',
+      insights: sampleInsights,
+      sessionBackgrounds: [
+        { title: 'Feature Work', summary: 'Built the auth flow.', sessionCharacter: 'feature_build' },
+      ],
+    });
+    expect(result).toContain('(feature build)');
+  });
+
+  it('omits session character parenthetical when null', () => {
+    const result = buildDispatchContext({
+      userContext: 'story',
+      insights: sampleInsights,
+      sessionBackgrounds: [
+        { title: 'Quick Task', summary: 'Fixed a typo.', sessionCharacter: null },
+      ],
+    });
+    expect(result).toContain('[Session: "Quick Task"]');
+    expect(result).not.toContain('(null)');
+  });
+
+  it('omits SESSION BACKGROUND block when no sessionBackgrounds', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    expect(result).not.toContain('SESSION BACKGROUND');
+  });
+
+  it('puts SESSION BACKGROUND between user context and insights', () => {
+    const result = buildDispatchContext({
+      userContext: 'story',
+      insights: sampleInsights,
+      sessionBackgrounds: [
+        { title: 'Session', summary: 'A summary.', sessionCharacter: null },
+      ],
+    });
+    const bgIdx = result.indexOf('SESSION BACKGROUND');
+    const insightsIdx = result.indexOf('INSIGHTS');
+    expect(bgIdx).toBeLessThan(insightsIdx);
+  });
 });
 
 // --- parseDispatchOutput (blog format) ---

--- a/server/src/llm/dispatch-prompts.test.ts
+++ b/server/src/llm/dispatch-prompts.test.ts
@@ -182,7 +182,7 @@ describe('buildDispatchContext', () => {
       userContext: 'story',
       insights: sampleInsights,
       sessionBackgrounds: [
-        { title: 'WAL Mode Investigation', summary: 'Three weeks debugging writes.', sessionCharacter: 'bug_hunt' },
+        { sessionId: 's1', title: 'WAL Mode Investigation', summary: 'Three weeks debugging writes.', sessionCharacter: 'bug_hunt' },
       ],
     });
     expect(result).toContain('SESSION BACKGROUND');
@@ -196,7 +196,7 @@ describe('buildDispatchContext', () => {
       userContext: 'story',
       insights: sampleInsights,
       sessionBackgrounds: [
-        { title: 'Feature Work', summary: 'Built the auth flow.', sessionCharacter: 'feature_build' },
+        { sessionId: 's1', title: 'Feature Work', summary: 'Built the auth flow.', sessionCharacter: 'feature_build' },
       ],
     });
     expect(result).toContain('(feature build)');
@@ -207,7 +207,7 @@ describe('buildDispatchContext', () => {
       userContext: 'story',
       insights: sampleInsights,
       sessionBackgrounds: [
-        { title: 'Quick Task', summary: 'Fixed a typo.', sessionCharacter: null },
+        { sessionId: 's1', title: 'Quick Task', summary: 'Fixed a typo.', sessionCharacter: null },
       ],
     });
     expect(result).toContain('[Session: "Quick Task"]');
@@ -224,7 +224,7 @@ describe('buildDispatchContext', () => {
       userContext: 'story',
       insights: sampleInsights,
       sessionBackgrounds: [
-        { title: 'Session', summary: 'A summary.', sessionCharacter: null },
+        { sessionId: 's1', title: 'Session', summary: 'A summary.', sessionCharacter: null },
       ],
     });
     const bgIdx = result.indexOf('SESSION BACKGROUND');

--- a/server/src/llm/dispatch-prompts.test.ts
+++ b/server/src/llm/dispatch-prompts.test.ts
@@ -10,45 +10,81 @@ import type { DispatchInsight } from '@code-insights/cli/types';
 // --- buildDispatchSystemPrompt ---
 
 describe('buildDispatchSystemPrompt', () => {
-  it('includes tone instruction for technical', () => {
-    const prompt = buildDispatchSystemPrompt('technical');
+  // Blog format — tone variations
+  it('blog/technical: includes depth-first tone instruction', () => {
+    const prompt = buildDispatchSystemPrompt('technical', 'blog');
     expect(prompt).toContain('senior engineers');
     expect(prompt).toContain('depth over accessibility');
   });
 
-  it('includes tone instruction for accessible', () => {
-    const prompt = buildDispatchSystemPrompt('accessible');
+  it('blog/accessible: includes clarity-first tone instruction', () => {
+    const prompt = buildDispatchSystemPrompt('accessible', 'blog');
     expect(prompt).toContain('mixed technical and non-technical');
   });
 
-  it('includes tone instruction for quick-tips', () => {
-    const prompt = buildDispatchSystemPrompt('quick-tips');
+  it('blog/quick-tips: includes scannable tips instruction', () => {
+    const prompt = buildDispatchSystemPrompt('quick-tips', 'blog');
     expect(prompt).toContain('tips format');
     expect(prompt).toContain('bold actionable tip');
   });
 
-  it('always includes banned word list', () => {
-    const prompt = buildDispatchSystemPrompt('technical');
-    expect(prompt).toContain('leveraged');
-    expect(prompt).toContain('seamlessly');
-    expect(prompt).toContain('delve');
-  });
-
-  it('always includes frontmatter format instructions', () => {
-    const prompt = buildDispatchSystemPrompt('accessible');
+  it('blog: includes frontmatter format instructions', () => {
+    const prompt = buildDispatchSystemPrompt('accessible', 'blog');
     expect(prompt).toContain('title:');
     expect(prompt).toContain('tags:');
     expect(prompt).toContain('tldr:');
   });
 
-  it('instructs not to invent facts', () => {
-    const prompt = buildDispatchSystemPrompt('technical');
-    expect(prompt).toContain('Do not invent facts');
+  // LinkedIn format — tone variations
+  it('linkedin/technical: uses LinkedIn-specific technical tone', () => {
+    const prompt = buildDispatchSystemPrompt('technical', 'linkedin');
+    expect(prompt).toContain('precise technical vocabulary');
+    // Must NOT include blog-specific H2 instruction
+    expect(prompt).not.toContain('H2 heading');
   });
 
-  it('instructs to synthesize, not enumerate', () => {
-    const prompt = buildDispatchSystemPrompt('technical');
-    expect(prompt).toContain('Synthesize');
+  it('linkedin/accessible: uses LinkedIn plain language tone', () => {
+    const prompt = buildDispatchSystemPrompt('accessible', 'linkedin');
+    expect(prompt).toContain('plain language');
+  });
+
+  it('linkedin/quick-tips: bold actionable statement (no headers)', () => {
+    const prompt = buildDispatchSystemPrompt('quick-tips', 'linkedin');
+    expect(prompt).toContain('bold actionable statement');
+    expect(prompt).toContain('no headers');
+  });
+
+  it('linkedin: includes hook instruction', () => {
+    const prompt = buildDispatchSystemPrompt('technical', 'linkedin');
+    expect(prompt).toContain('hook');
+    expect(prompt).toContain('150-250 words');
+  });
+
+  it('linkedin: includes hashtag instruction', () => {
+    const prompt = buildDispatchSystemPrompt('technical', 'linkedin');
+    expect(prompt).toContain('hashtag');
+  });
+
+  it('linkedin: warns against bullet lists and headers', () => {
+    const prompt = buildDispatchSystemPrompt('technical', 'linkedin');
+    expect(prompt).toContain('No headers');
+    expect(prompt).toContain('No bullet lists');
+  });
+
+  // Shared base — both formats
+  it('always includes banned word list', () => {
+    expect(buildDispatchSystemPrompt('technical', 'blog')).toContain('leveraged');
+    expect(buildDispatchSystemPrompt('technical', 'linkedin')).toContain('leveraged');
+  });
+
+  it('always instructs not to invent facts', () => {
+    expect(buildDispatchSystemPrompt('technical', 'blog')).toContain('Do not invent facts');
+    expect(buildDispatchSystemPrompt('technical', 'linkedin')).toContain('Do not invent facts');
+  });
+
+  it('always instructs to synthesize, not enumerate', () => {
+    expect(buildDispatchSystemPrompt('technical', 'blog')).toContain('Synthesize');
+    expect(buildDispatchSystemPrompt('technical', 'linkedin')).toContain('Synthesize');
   });
 });
 
@@ -109,7 +145,6 @@ describe('buildDispatchContext', () => {
     // i2 content is sparse (5 words) → bullets should appear
     expect(result).toContain('- Faster iteration');
     expect(result).toContain('- No ORM overhead');
-    // i1 content is not sparse → no bullet check needed (it has no bullets anyway)
   });
 
   it('omits bullets when content is not sparse (>= 40 words)', () => {
@@ -124,17 +159,28 @@ describe('buildDispatchContext', () => {
     expect(result).not.toContain('should not appear');
   });
 
+  it('maps prompt_quality type to Observation label', () => {
+    const pqInsight: DispatchInsight = {
+      id: 'pq1',
+      type: 'prompt_quality',
+      summary: 'Context provision was weak',
+      content: 'Missing context led to misaligned output.',
+      bullets: [],
+    };
+    const result = buildDispatchContext({ userContext: 'story', insights: [pqInsight] });
+    expect(result).toContain('[OBSERVATION 1]');
+    expect(result).not.toContain('[PROMPT_QUALITY 1]');
+  });
+
   it('does not include evidence field', () => {
     const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
-    // We just verify the function doesn't crash with our known inputs and doesn't have
-    // the word "evidence" from any of our test data
     expect(result).not.toContain('[EVIDENCE');
   });
 });
 
-// --- parseDispatchOutput ---
+// --- parseDispatchOutput (blog format) ---
 
-const VALID_OUTPUT = `---
+const VALID_BLOG_OUTPUT = `---
 title: "What SQLite Taught Me"
 tags: [sqlite, architecture, backend]
 tldr: "Three weeks, five surprises."
@@ -152,9 +198,9 @@ Running raw SQL gave us full control over schema evolution without ORM abstracti
 
 These lessons shaped how we approach embedded databases now.`;
 
-describe('parseDispatchOutput', () => {
+describe('parseDispatchOutput (blog)', () => {
   it('parses valid output correctly', () => {
-    const result = parseDispatchOutput(VALID_OUTPUT);
+    const result = parseDispatchOutput(VALID_BLOG_OUTPUT, 'blog');
     expect(result.ok).toBe(true);
     expect(result.frontmatter?.title).toBe('What SQLite Taught Me');
     expect(result.frontmatter?.tags).toEqual(['sqlite', 'architecture', 'backend']);
@@ -162,59 +208,135 @@ describe('parseDispatchOutput', () => {
     expect(result.markdown).toContain('## WAL Mode');
   });
 
+  it('returns body separate from markdown', () => {
+    const result = parseDispatchOutput(VALID_BLOG_OUTPUT, 'blog');
+    expect(result.body).not.toContain('---');
+    expect(result.body).toContain('## WAL Mode Is Not Optional');
+  });
+
+  it('quotes title in reconstructed YAML frontmatter', () => {
+    const result = parseDispatchOutput(VALID_BLOG_OUTPUT, 'blog');
+    expect(result.markdown).toMatch(/^---\ntitle: "/m);
+  });
+
+  it('escapes double quotes in title', () => {
+    const quoted = `---\ntitle: "Lessons from \\"Production\\" Systems"\ntags: []\ntldr: "A summary."\n---\n\nBody ends here.`;
+    const result = parseDispatchOutput(quoted, 'blog');
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.title).toContain('"Production"');
+  });
+
+  it('handles title with colon without breaking YAML', () => {
+    const withColon = `---\ntitle: "SQLite: What I Learned"\ntags: [sqlite]\ntldr: "A summary."\n---\n\nBody ends here.`;
+    const result = parseDispatchOutput(withColon, 'blog');
+    expect(result.ok).toBe(true);
+    expect(result.markdown).toMatch(/^---\ntitle: "SQLite: What I Learned"/m);
+  });
+
   it('returns missing-frontmatter error when no frontmatter', () => {
-    const result = parseDispatchOutput('Just a blog post without frontmatter.');
+    const result = parseDispatchOutput('Just a blog post without frontmatter.', 'blog');
     expect(result.ok).toBe(false);
     expect(result.error).toBe('missing-frontmatter');
-    expect(result.raw).toBe('Just a blog post without frontmatter.');
   });
 
   it('returns malformed-frontmatter when title is missing', () => {
-    const bad = `---
-tags: [sqlite]
-tldr: "A summary."
----
-
-## Section
-
-Body text.`;
-    const result = parseDispatchOutput(bad);
+    const bad = `---\ntags: [sqlite]\ntldr: "A summary."\n---\n\n## Section\n\nBody text.`;
+    const result = parseDispatchOutput(bad, 'blog');
     expect(result.ok).toBe(false);
     expect(result.error).toBe('malformed-frontmatter');
   });
 
   it('returns malformed-frontmatter when tldr is missing', () => {
-    const bad = `---
-title: "Some title"
-tags: [sqlite]
----
-
-## Section
-
-Body text.`;
-    const result = parseDispatchOutput(bad);
+    const bad = `---\ntitle: "Some title"\ntags: [sqlite]\n---\n\n## Section\n\nBody text.`;
+    const result = parseDispatchOutput(bad, 'blog');
     expect(result.ok).toBe(false);
     expect(result.error).toBe('malformed-frontmatter');
   });
 
   it('handles missing tags gracefully (empty array)', () => {
-    const noTags = `---
-title: "Post Without Tags"
-tldr: "A summary."
----
-
-## Section
-
-Body text here. This ends with a period.`;
-    const result = parseDispatchOutput(noTags);
+    const noTags = `---\ntitle: "Post Without Tags"\ntldr: "A summary."\n---\n\n## Section\n\nBody text here. This ends with a period.`;
+    const result = parseDispatchOutput(noTags, 'blog');
     expect(result.ok).toBe(true);
     expect(result.frontmatter?.tags).toEqual([]);
   });
 
-  it('includes body in reconstructed markdown', () => {
-    const result = parseDispatchOutput(VALID_OUTPUT);
+  it('includes body sections in reconstructed markdown', () => {
+    const result = parseDispatchOutput(VALID_BLOG_OUTPUT, 'blog');
     expect(result.markdown).toContain('## WAL Mode Is Not Optional');
     expect(result.markdown).toContain('## The Migration Lesson');
+  });
+});
+
+// --- parseDispatchOutput (linkedin format) ---
+
+const VALID_LINKEDIN_OUTPUT = `---
+title: "What SQLite Taught Me in Production"
+---
+
+**WAL mode is not optional** if you have concurrent readers and writers.
+
+I spent three weeks debugging a production issue. Every 50th request would stall. The culprit: SQLite in default journal mode, blocking reads during writes.
+
+Switching to WAL mode resolved it. Reads and writes operate on separate files — no locking.
+
+Three other things I learned the hard way:
+
+Skipping ORM migrations was the right call. Raw SQL gave us full control. Two lines of ALTER TABLE, done.
+
+Incremental builds cut CI time by 60%. Cache your intermediates.
+
+The hardest bugs are the ones that only appear under real load.
+
+#sqlite #backend #engineering #typescript`;
+
+describe('parseDispatchOutput (linkedin)', () => {
+  it('parses valid LinkedIn output correctly', () => {
+    const result = parseDispatchOutput(VALID_LINKEDIN_OUTPUT, 'linkedin');
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.title).toBe('What SQLite Taught Me in Production');
+  });
+
+  it('extracts hashtags from last line into tags', () => {
+    const result = parseDispatchOutput(VALID_LINKEDIN_OUTPUT, 'linkedin');
+    expect(result.frontmatter?.tags).toContain('sqlite');
+    expect(result.frontmatter?.tags).toContain('backend');
+    expect(result.frontmatter?.tags).toContain('engineering');
+    expect(result.frontmatter?.tags).toContain('typescript');
+    // Tags should not include the # prefix
+    expect(result.frontmatter?.tags?.every(t => !t.startsWith('#'))).toBe(true);
+  });
+
+  it('sets tldr to empty string', () => {
+    const result = parseDispatchOutput(VALID_LINKEDIN_OUTPUT, 'linkedin');
+    expect(result.frontmatter?.tldr).toBe('');
+  });
+
+  it('returns body as the plain post text (no YAML wrapper)', () => {
+    const result = parseDispatchOutput(VALID_LINKEDIN_OUTPUT, 'linkedin');
+    expect(result.body).not.toContain('---');
+    expect(result.body).toContain('WAL mode is not optional');
+    // markdown === body for LinkedIn (no YAML wrapper returned to user)
+    expect(result.markdown).toBe(result.body);
+  });
+
+  it('returns missing-frontmatter error when no metadata block', () => {
+    const result = parseDispatchOutput('Just a plain post without metadata.', 'linkedin');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing-frontmatter');
+  });
+
+  it('returns malformed-frontmatter when title is missing from metadata', () => {
+    const bad = `---\nauthor: "nobody"\n---\n\nPost body here.`;
+    const result = parseDispatchOutput(bad, 'linkedin');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('malformed-frontmatter');
+  });
+
+  it('returns empty tags when no hashtags on last line', () => {
+    const noHashtags = `---\ntitle: "My Post"\n---\n\nBody without hashtags on the last line.`;
+    const result = parseDispatchOutput(noHashtags, 'linkedin');
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.tags).toEqual([]);
   });
 });
 
@@ -235,15 +357,21 @@ describe('buildDegradedResponse', () => {
     expect(result.frontmatter?.title).toBe('Untitled');
   });
 
-  it('always returns empty tags and tldr', () => {
+  it('always returns empty tags and empty tldr', () => {
     const result = buildDegradedResponse('# Title\n\nContent.');
     expect(result.frontmatter?.tags).toEqual([]);
     expect(result.frontmatter?.tldr).toBe('');
   });
 
-  it('returns the raw content as markdown', () => {
+  it('returns the raw content as markdown and body', () => {
     const raw = '# Title\n\nContent.';
     const result = buildDegradedResponse(raw);
     expect(result.markdown).toBe(raw);
+    expect(result.body).toBe(raw);
+  });
+
+  it('sets degraded: true', () => {
+    const result = buildDegradedResponse('# Title\n\nContent.');
+    expect(result.degraded).toBe(true);
   });
 });

--- a/server/src/llm/dispatch-prompts.test.ts
+++ b/server/src/llm/dispatch-prompts.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDispatchSystemPrompt,
+  buildDispatchContext,
+  parseDispatchOutput,
+  buildDegradedResponse,
+} from './dispatch-prompts.js';
+import type { DispatchInsight } from '@code-insights/cli/types';
+
+// --- buildDispatchSystemPrompt ---
+
+describe('buildDispatchSystemPrompt', () => {
+  it('includes tone instruction for technical', () => {
+    const prompt = buildDispatchSystemPrompt('technical');
+    expect(prompt).toContain('senior engineers');
+    expect(prompt).toContain('depth over accessibility');
+  });
+
+  it('includes tone instruction for accessible', () => {
+    const prompt = buildDispatchSystemPrompt('accessible');
+    expect(prompt).toContain('mixed technical and non-technical');
+  });
+
+  it('includes tone instruction for quick-tips', () => {
+    const prompt = buildDispatchSystemPrompt('quick-tips');
+    expect(prompt).toContain('tips format');
+    expect(prompt).toContain('bold actionable tip');
+  });
+
+  it('always includes banned word list', () => {
+    const prompt = buildDispatchSystemPrompt('technical');
+    expect(prompt).toContain('leveraged');
+    expect(prompt).toContain('seamlessly');
+    expect(prompt).toContain('delve');
+  });
+
+  it('always includes frontmatter format instructions', () => {
+    const prompt = buildDispatchSystemPrompt('accessible');
+    expect(prompt).toContain('title:');
+    expect(prompt).toContain('tags:');
+    expect(prompt).toContain('tldr:');
+  });
+
+  it('instructs not to invent facts', () => {
+    const prompt = buildDispatchSystemPrompt('technical');
+    expect(prompt).toContain('Do not invent facts');
+  });
+
+  it('instructs to synthesize, not enumerate', () => {
+    const prompt = buildDispatchSystemPrompt('technical');
+    expect(prompt).toContain('Synthesize');
+  });
+});
+
+// --- buildDispatchContext ---
+
+const sampleInsights: DispatchInsight[] = [
+  {
+    id: 'i1',
+    type: 'learning',
+    summary: 'SQLite WAL mode enables concurrent reads',
+    content: 'WAL mode decouples reads from writes at the file level, allowing multiple readers while a single writer commits.',
+    bullets: [],
+  },
+  {
+    id: 'i2',
+    type: 'decision',
+    summary: 'Skipped ORM migrations entirely',
+    content: 'Ran raw SQL migrations instead.',
+    bullets: ['Faster iteration', 'No ORM overhead'],
+  },
+  {
+    id: 'i3',
+    type: 'technique',
+    summary: 'Incremental builds cut CI time',
+    content: 'Only changed packages are rebuilt.',
+    bullets: [],
+  },
+];
+
+describe('buildDispatchContext', () => {
+  it('puts user context before insights', () => {
+    const result = buildDispatchContext({ userContext: 'My story here.', insights: sampleInsights });
+    const contextIdx = result.indexOf('Context from the author');
+    const insightsIdx = result.indexOf('INSIGHTS');
+    expect(contextIdx).toBeLessThan(insightsIdx);
+  });
+
+  it('includes the correct insight count', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    expect(result).toContain('3 selected by author');
+  });
+
+  it('title-cases type labels and numbers them', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    expect(result).toContain('[LEARNING 1]');
+    expect(result).toContain('[DECISION 2]');
+    expect(result).toContain('[TECHNIQUE 3]');
+  });
+
+  it('includes summary and content', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    expect(result).toContain('SQLite WAL mode enables concurrent reads');
+    expect(result).toContain('WAL mode decouples reads from writes');
+  });
+
+  it('includes bullets only when content is sparse (< 40 words)', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    // i2 content is sparse (5 words) → bullets should appear
+    expect(result).toContain('- Faster iteration');
+    expect(result).toContain('- No ORM overhead');
+    // i1 content is not sparse → no bullet check needed (it has no bullets anyway)
+  });
+
+  it('omits bullets when content is not sparse (>= 40 words)', () => {
+    const longInsight: DispatchInsight = {
+      id: 'long',
+      type: 'learning',
+      summary: 'A long learning',
+      content: 'word '.repeat(41).trim(),
+      bullets: ['should not appear'],
+    };
+    const result = buildDispatchContext({ userContext: 'story', insights: [longInsight] });
+    expect(result).not.toContain('should not appear');
+  });
+
+  it('does not include evidence field', () => {
+    const result = buildDispatchContext({ userContext: 'story', insights: sampleInsights });
+    // We just verify the function doesn't crash with our known inputs and doesn't have
+    // the word "evidence" from any of our test data
+    expect(result).not.toContain('[EVIDENCE');
+  });
+});
+
+// --- parseDispatchOutput ---
+
+const VALID_OUTPUT = `---
+title: "What SQLite Taught Me"
+tags: [sqlite, architecture, backend]
+tldr: "Three weeks, five surprises."
+---
+
+## WAL Mode Is Not Optional
+
+SQLite WAL mode enables concurrent reads without locking out writers. This matters when you have a server reading while a CLI writes.
+
+## The Migration Lesson
+
+Running raw SQL gave us full control over schema evolution without ORM abstractions getting in the way.
+
+## Final Thoughts
+
+These lessons shaped how we approach embedded databases now.`;
+
+describe('parseDispatchOutput', () => {
+  it('parses valid output correctly', () => {
+    const result = parseDispatchOutput(VALID_OUTPUT);
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.title).toBe('What SQLite Taught Me');
+    expect(result.frontmatter?.tags).toEqual(['sqlite', 'architecture', 'backend']);
+    expect(result.frontmatter?.tldr).toBe('Three weeks, five surprises.');
+    expect(result.markdown).toContain('## WAL Mode');
+  });
+
+  it('returns missing-frontmatter error when no frontmatter', () => {
+    const result = parseDispatchOutput('Just a blog post without frontmatter.');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('missing-frontmatter');
+    expect(result.raw).toBe('Just a blog post without frontmatter.');
+  });
+
+  it('returns malformed-frontmatter when title is missing', () => {
+    const bad = `---
+tags: [sqlite]
+tldr: "A summary."
+---
+
+## Section
+
+Body text.`;
+    const result = parseDispatchOutput(bad);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('malformed-frontmatter');
+  });
+
+  it('returns malformed-frontmatter when tldr is missing', () => {
+    const bad = `---
+title: "Some title"
+tags: [sqlite]
+---
+
+## Section
+
+Body text.`;
+    const result = parseDispatchOutput(bad);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('malformed-frontmatter');
+  });
+
+  it('handles missing tags gracefully (empty array)', () => {
+    const noTags = `---
+title: "Post Without Tags"
+tldr: "A summary."
+---
+
+## Section
+
+Body text here. This ends with a period.`;
+    const result = parseDispatchOutput(noTags);
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.tags).toEqual([]);
+  });
+
+  it('includes body in reconstructed markdown', () => {
+    const result = parseDispatchOutput(VALID_OUTPUT);
+    expect(result.markdown).toContain('## WAL Mode Is Not Optional');
+    expect(result.markdown).toContain('## The Migration Lesson');
+  });
+});
+
+// --- buildDegradedResponse ---
+
+describe('buildDegradedResponse', () => {
+  it('extracts H1 as title when present', () => {
+    const raw = '# My Post Title\n\nSome content here.';
+    const result = buildDegradedResponse(raw);
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.title).toBe('My Post Title');
+  });
+
+  it('uses Untitled when no H1 present', () => {
+    const raw = 'Some content without a heading.';
+    const result = buildDegradedResponse(raw);
+    expect(result.ok).toBe(true);
+    expect(result.frontmatter?.title).toBe('Untitled');
+  });
+
+  it('always returns empty tags and tldr', () => {
+    const result = buildDegradedResponse('# Title\n\nContent.');
+    expect(result.frontmatter?.tags).toEqual([]);
+    expect(result.frontmatter?.tldr).toBe('');
+  });
+
+  it('returns the raw content as markdown', () => {
+    const raw = '# Title\n\nContent.';
+    const result = buildDegradedResponse(raw);
+    expect(result.markdown).toBe(raw);
+  });
+});

--- a/server/src/llm/dispatch-prompts.ts
+++ b/server/src/llm/dispatch-prompts.ts
@@ -1,7 +1,7 @@
 // Prompt construction and output parsing for the Dispatch post generator.
 // Supports two output formats: 'blog' (markdown + YAML frontmatter) and 'linkedin' (plain text + metadata block).
 
-import type { DispatchTone, DispatchInsight, DispatchFormat } from '@code-insights/cli/types';
+import type { DispatchTone, DispatchInsight, DispatchFormat, SessionBackground } from '@code-insights/cli/types';
 
 // --- System prompt ---
 
@@ -12,7 +12,8 @@ Do not use the words: "leveraged", "utilized", "seamlessly", "delve".
 Do not invent facts not present in the insights.
 Do not mention AI coding sessions, Code Insights, or any tool names.
 Synthesize — do not enumerate insights one by one as a list.
-Output only the requested format — no preamble, no meta-commentary.`;
+Output only the requested format — no preamble, no meta-commentary.
+If session background is provided, use it only to inform tone and framing — do not quote or paraphrase session summaries directly in the post.`;
 
 const FORMAT_INSTRUCTIONS: Record<DispatchFormat, string> = {
   blog: `Write a blog post of 800-1000 words in markdown (body only, excluding frontmatter).
@@ -73,6 +74,7 @@ export function buildDispatchSystemPrompt(tone: DispatchTone, format: DispatchFo
 export interface DispatchInput {
   userContext: string;
   insights: DispatchInsight[];
+  sessionBackgrounds?: SessionBackground[];
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -94,7 +96,16 @@ export function buildDispatchContext(input: DispatchInput): string {
     return `[${typeLabel.toUpperCase()} ${i + 1}]\nSummary: ${insight.summary}\n${insight.content}${bulletLines}`;
   });
 
-  return `Context from the author:\n${input.userContext}\n\n---\n\nINSIGHTS (${input.insights.length} selected by author):\n\n${insightBlocks.join('\n\n')}`;
+  const backgroundBlock = input.sessionBackgrounds && input.sessionBackgrounds.length > 0
+    ? `---\n\nSESSION BACKGROUND (${input.sessionBackgrounds.length} session${input.sessionBackgrounds.length > 1 ? 's' : ''} contributed these insights):\n\n${
+        input.sessionBackgrounds.map((s) => {
+          const charLabel = s.sessionCharacter ? ` (${s.sessionCharacter.replace(/_/g, ' ')})` : '';
+          return `[Session: "${s.title}"${charLabel}]\n${s.summary}`;
+        }).join('\n\n')
+      }\n\n`
+    : '';
+
+  return `Context from the author:\n${input.userContext}\n\n${backgroundBlock}---\n\nINSIGHTS (${input.insights.length} selected by author):\n\n${insightBlocks.join('\n\n')}`;
 }
 
 // --- Output parser ---

--- a/server/src/llm/dispatch-prompts.ts
+++ b/server/src/llm/dispatch-prompts.ts
@@ -42,9 +42,18 @@ export interface DispatchInput {
   insights: DispatchInsight[];
 }
 
+const TYPE_LABELS: Record<string, string> = {
+  learning: 'Learning',
+  decision: 'Decision',
+  technique: 'Technique',
+  summary: 'Summary',
+  prompt_quality: 'Observation',
+};
+
 export function buildDispatchContext(input: DispatchInput): string {
   const insightBlocks = input.insights.map((insight, i) => {
-    const typeLabel = insight.type.charAt(0).toUpperCase() + insight.type.slice(1);
+    const typeLabel = TYPE_LABELS[insight.type]
+      ?? (insight.type.charAt(0).toUpperCase() + insight.type.slice(1).replace(/_/g, ' '));
     const wordCount = insight.content.split(' ').length;
     const bulletLines = wordCount < 40 && insight.bullets.length > 0
       ? '\n' + insight.bullets.map(b => `- ${b}`).join('\n')
@@ -60,11 +69,15 @@ export function buildDispatchContext(input: DispatchInput): string {
 export interface DispatchParseResult {
   ok: boolean;
   markdown?: string;
+  /** The body text without frontmatter — use for word count to avoid re-parsing. */
+  body?: string;
   frontmatter?: {
     title: string;
     tags: string[];
     tldr: string;
   };
+  /** True when the parse failed and we returned raw content with a guessed title. */
+  degraded?: boolean;
   error?: 'missing-frontmatter' | 'malformed-frontmatter';
   raw?: string;
 }
@@ -105,16 +118,25 @@ export function parseDispatchOutput(raw: string): DispatchParseResult {
     console.warn(`[dispatch-prohibited-words] Prohibited words found in output: ${found.join(', ')}`);
   }
 
-  // Reconstruct full markdown with frontmatter
-  const markdown = `---\ntitle: ${titleMatch[1]}\ntags: [${tags.join(', ')}]\ntldr: ${tldrMatch[1]}\n---\n\n${body}`;
+  const title = titleMatch[1];
+  const tldr = tldrMatch[1];
+
+  // Escape special YAML characters so the output is valid when pasted into blog platforms.
+  // Titles/tldrs with ':' or '[' produce invalid unquoted YAML.
+  const escTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escTldr  = tldr.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+  // Reconstruct full markdown with properly quoted frontmatter
+  const markdown = `---\ntitle: "${escTitle}"\ntags: [${tags.join(', ')}]\ntldr: "${escTldr}"\n---\n\n${body}`;
 
   return {
     ok: true,
     markdown,
+    body,
     frontmatter: {
-      title: titleMatch[1],
+      title,
       tags,
-      tldr: tldrMatch[1],
+      tldr,
     },
   };
 }
@@ -127,6 +149,8 @@ export function buildDegradedResponse(raw: string): DispatchParseResult {
   return {
     ok: true,
     markdown: raw,
+    body: raw,
+    degraded: true,
     frontmatter: {
       title,
       tags: [],

--- a/server/src/llm/dispatch-prompts.ts
+++ b/server/src/llm/dispatch-prompts.ts
@@ -38,14 +38,16 @@ title: "A short title (8 words max)"
 Then write the post body as plain text. This is what gets copy-pasted to LinkedIn.
 
 Post structure:
-- Lines 1-2: The hook. State a concrete insight, counterintuitive observation, or sharp finding. Must stand alone before LinkedIn's "...see more" cutoff (~1,300 characters). Do not open with "I learned" or "Today I".
+- Lines 1-2: The hook. State a concrete insight, counterintuitive observation, or sharp finding. Must stand alone before LinkedIn's "...see more" cutoff (~1,300 characters). Do not open with "I learned", "Today I", "Recently I", or "Have you ever".
+  Strong hook example: "SQLite WAL mode eliminates write blocking — and most production apps don't use it."
+  Weak hook to avoid: "I recently learned something interesting about SQLite performance."
 - Body: 3-6 short paragraphs (1-3 sentences each). One blank line between paragraphs.
 - Last line: 3-5 hashtags only. Example: #engineering #typescript #sqlite
 
 LinkedIn rendering rules:
 - Bold is supported: **bold text**. Use sparingly — one bold phrase per paragraph at most.
 - No headers (## renders as literal ##, not a heading).
-- No bullet lists (- renders as a hyphen, not a bullet).
+- No bullet lists (- renders as a hyphen, not a bullet). If you need to present multiple items, write them as a short prose sequence: "First X, then Y, finally Z."
 - No YAML in the post body.`,
 };
 

--- a/server/src/llm/dispatch-prompts.ts
+++ b/server/src/llm/dispatch-prompts.ts
@@ -1,0 +1,136 @@
+// Prompt construction and output parsing for the Dispatch blog post generator.
+
+import type { DispatchTone, DispatchInsight } from '@code-insights/cli/types';
+
+// --- System prompt ---
+
+const TONE_INSTRUCTIONS: Record<DispatchTone, string> = {
+  'technical': 'Write for senior engineers. Precise vocabulary, specific trade-offs, do not over-explain fundamentals. Favor depth over accessibility.',
+  'accessible': 'Write for a mixed technical and non-technical audience. Define terms on first introduction, use analogies where helpful, keep sentences short. Favor clarity over density.',
+  'quick-tips': 'Write in a tips format. Each body section opens with a bold actionable tip, followed by 2-4 sentences of context. Favor scanability over narrative.',
+};
+
+const SYSTEM_PROMPT_BASE = `You are a technical ghostwriter helping a software engineer publish their learnings.
+The engineer has selected specific learnings and provided context about the story.
+
+Write a blog post of 800-1000 words in markdown (body only, excluding frontmatter).
+Structure: opening paragraph, 2-4 body sections each with an H2 heading, closing takeaway paragraph.
+Use plain, direct prose — write like an engineer sharing hard-won knowledge, not a content marketer.
+Do not use the words: "leveraged", "utilized", "seamlessly", "delve".
+Do not invent facts not present in the insights.
+Do not mention AI coding sessions, Code Insights, or any tool names.
+Synthesize — do not enumerate insights one by one as a list.
+
+Output a markdown document only — no preamble, no meta-commentary.
+Begin with a YAML frontmatter block in exactly this format:
+---
+title: "A concise title (10 words max)"
+tags: [tag1, tag2, tag3]
+tldr: "One sentence summary of the post"
+---
+
+Then write the blog post body (H2 sections, no H1 — title is in the frontmatter).`;
+
+export function buildDispatchSystemPrompt(tone: DispatchTone): string {
+  return `${SYSTEM_PROMPT_BASE}\n\n${TONE_INSTRUCTIONS[tone]}`;
+}
+
+// --- User context builder ---
+
+export interface DispatchInput {
+  userContext: string;
+  insights: DispatchInsight[];
+}
+
+export function buildDispatchContext(input: DispatchInput): string {
+  const insightBlocks = input.insights.map((insight, i) => {
+    const typeLabel = insight.type.charAt(0).toUpperCase() + insight.type.slice(1);
+    const wordCount = insight.content.split(' ').length;
+    const bulletLines = wordCount < 40 && insight.bullets.length > 0
+      ? '\n' + insight.bullets.map(b => `- ${b}`).join('\n')
+      : '';
+    return `[${typeLabel.toUpperCase()} ${i + 1}]\nSummary: ${insight.summary}\n${insight.content}${bulletLines}`;
+  });
+
+  return `Context from the author:\n${input.userContext}\n\n---\n\nINSIGHTS (${input.insights.length} selected by author):\n\n${insightBlocks.join('\n\n')}`;
+}
+
+// --- Output parser ---
+
+export interface DispatchParseResult {
+  ok: boolean;
+  markdown?: string;
+  frontmatter?: {
+    title: string;
+    tags: string[];
+    tldr: string;
+  };
+  error?: 'missing-frontmatter' | 'malformed-frontmatter';
+  raw?: string;
+}
+
+const PROHIBITED_WORDS = ['leveraged', 'utilized', 'seamlessly', 'delve'];
+
+export function parseDispatchOutput(raw: string): DispatchParseResult {
+  const fmMatch = raw.match(/^[\s]*---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) {
+    return { ok: false, error: 'missing-frontmatter', raw };
+  }
+
+  const fm = fmMatch[1];
+  const body = fmMatch[2].trim();
+
+  const titleMatch = fm.match(/^title:\s*"?(.+?)"?\s*$/m);
+  const tldrMatch = fm.match(/^tldr:\s*"?(.+?)"?\s*$/m);
+  const tagsMatch = fm.match(/^tags:\s*\[(.+?)\]/m);
+
+  if (!titleMatch || !tldrMatch) {
+    return { ok: false, error: 'malformed-frontmatter', raw };
+  }
+
+  const tags = tagsMatch
+    ? tagsMatch[1].split(',').map(t => t.trim().replace(/^['"]|['"]$/g, ''))
+    : [];
+
+  // Detect truncation — body should end with a sentence terminator
+  const trimmedBody = body.trim();
+  if (trimmedBody.length > 0 && !/[.!?]$/.test(trimmedBody)) {
+    console.warn('[dispatch-truncation] Generated post may be truncated — does not end with sentence terminator');
+  }
+
+  // Log prohibited word leakage without rejecting
+  const lowerBody = body.toLowerCase();
+  const found = PROHIBITED_WORDS.filter(w => lowerBody.includes(w));
+  if (found.length > 0) {
+    console.warn(`[dispatch-prohibited-words] Prohibited words found in output: ${found.join(', ')}`);
+  }
+
+  // Reconstruct full markdown with frontmatter
+  const markdown = `---\ntitle: ${titleMatch[1]}\ntags: [${tags.join(', ')}]\ntldr: ${tldrMatch[1]}\n---\n\n${body}`;
+
+  return {
+    ok: true,
+    markdown,
+    frontmatter: {
+      title: titleMatch[1],
+      tags,
+      tldr: tldrMatch[1],
+    },
+  };
+}
+
+// Degrade gracefully when both the initial parse and retry fail.
+// Extracts H1 as title if present, otherwise uses 'Untitled'.
+export function buildDegradedResponse(raw: string): DispatchParseResult {
+  const h1Match = raw.match(/^#+\s+(.+)$/m);
+  const title = h1Match ? h1Match[1] : 'Untitled';
+  return {
+    ok: true,
+    markdown: raw,
+    frontmatter: {
+      title,
+      tags: [],
+      tldr: '',
+    },
+  };
+}

--- a/server/src/llm/dispatch-prompts.ts
+++ b/server/src/llm/dispatch-prompts.ts
@@ -1,27 +1,24 @@
-// Prompt construction and output parsing for the Dispatch blog post generator.
+// Prompt construction and output parsing for the Dispatch post generator.
+// Supports two output formats: 'blog' (markdown + YAML frontmatter) and 'linkedin' (plain text + metadata block).
 
-import type { DispatchTone, DispatchInsight } from '@code-insights/cli/types';
+import type { DispatchTone, DispatchInsight, DispatchFormat } from '@code-insights/cli/types';
 
 // --- System prompt ---
 
-const TONE_INSTRUCTIONS: Record<DispatchTone, string> = {
-  'technical': 'Write for senior engineers. Precise vocabulary, specific trade-offs, do not over-explain fundamentals. Favor depth over accessibility.',
-  'accessible': 'Write for a mixed technical and non-technical audience. Define terms on first introduction, use analogies where helpful, keep sentences short. Favor clarity over density.',
-  'quick-tips': 'Write in a tips format. Each body section opens with a bold actionable tip, followed by 2-4 sentences of context. Favor scanability over narrative.',
-};
-
-const SYSTEM_PROMPT_BASE = `You are a technical ghostwriter helping a software engineer publish their learnings.
+const SHARED_BASE = `You are a technical ghostwriter helping a software engineer publish their learnings.
 The engineer has selected specific learnings and provided context about the story.
 
-Write a blog post of 800-1000 words in markdown (body only, excluding frontmatter).
-Structure: opening paragraph, 2-4 body sections each with an H2 heading, closing takeaway paragraph.
-Use plain, direct prose — write like an engineer sharing hard-won knowledge, not a content marketer.
 Do not use the words: "leveraged", "utilized", "seamlessly", "delve".
 Do not invent facts not present in the insights.
 Do not mention AI coding sessions, Code Insights, or any tool names.
 Synthesize — do not enumerate insights one by one as a list.
+Output only the requested format — no preamble, no meta-commentary.`;
 
-Output a markdown document only — no preamble, no meta-commentary.
+const FORMAT_INSTRUCTIONS: Record<DispatchFormat, string> = {
+  blog: `Write a blog post of 800-1000 words in markdown (body only, excluding frontmatter).
+Structure: opening paragraph, 2-4 body sections each with an H2 heading, closing takeaway paragraph.
+Use plain, direct prose — write like an engineer sharing hard-won knowledge, not a content marketer.
+
 Begin with a YAML frontmatter block in exactly this format:
 ---
 title: "A concise title (10 words max)"
@@ -29,10 +26,44 @@ tags: [tag1, tag2, tag3]
 tldr: "One sentence summary of the post"
 ---
 
-Then write the blog post body (H2 sections, no H1 — title is in the frontmatter).`;
+Then write the blog post body (H2 sections, no H1 — title is in the frontmatter).`,
 
-export function buildDispatchSystemPrompt(tone: DispatchTone): string {
-  return `${SYSTEM_PROMPT_BASE}\n\n${TONE_INSTRUCTIONS[tone]}`;
+  linkedin: `Write a LinkedIn post of 150-250 words.
+
+Output format — begin with a YAML metadata block (for internal use only, not part of the post):
+---
+title: "A short title (8 words max)"
+---
+
+Then write the post body as plain text. This is what gets copy-pasted to LinkedIn.
+
+Post structure:
+- Lines 1-2: The hook. State a concrete insight, counterintuitive observation, or sharp finding. Must stand alone before LinkedIn's "...see more" cutoff (~1,300 characters). Do not open with "I learned" or "Today I".
+- Body: 3-6 short paragraphs (1-3 sentences each). One blank line between paragraphs.
+- Last line: 3-5 hashtags only. Example: #engineering #typescript #sqlite
+
+LinkedIn rendering rules:
+- Bold is supported: **bold text**. Use sparingly — one bold phrase per paragraph at most.
+- No headers (## renders as literal ##, not a heading).
+- No bullet lists (- renders as a hyphen, not a bullet).
+- No YAML in the post body.`,
+};
+
+const TONE_INSTRUCTIONS: Record<DispatchFormat, Record<DispatchTone, string>> = {
+  blog: {
+    technical: 'Write for senior engineers. Precise vocabulary, specific trade-offs, do not over-explain fundamentals. Favor depth over accessibility.',
+    accessible: 'Write for a mixed technical and non-technical audience. Define terms on first introduction, use analogies where helpful, keep sentences short. Favor clarity over density.',
+    'quick-tips': 'Write in a tips format. Each body section opens with a bold actionable tip, followed by 2-4 sentences of context. Favor scanability over narrative.',
+  },
+  linkedin: {
+    technical: 'Use precise technical vocabulary. Name the specific trade-off or constraint. Do not over-explain — trust the audience knows the fundamentals.',
+    accessible: 'Use plain language. If a technical term is unavoidable, follow it immediately with a one-phrase explanation. Keep sentences short.',
+    'quick-tips': 'Each paragraph opens with a **bold actionable statement** (no headers — LinkedIn does not render them). Follow with 2-3 sentences of context. Favor scanability.',
+  },
+};
+
+export function buildDispatchSystemPrompt(tone: DispatchTone, format: DispatchFormat): string {
+  return `${SHARED_BASE}\n\n${FORMAT_INSTRUCTIONS[format]}\n\n${TONE_INSTRUCTIONS[format][tone]}`;
 }
 
 // --- User context builder ---
@@ -69,7 +100,7 @@ export function buildDispatchContext(input: DispatchInput): string {
 export interface DispatchParseResult {
   ok: boolean;
   markdown?: string;
-  /** The body text without frontmatter — use for word count to avoid re-parsing. */
+  /** The body text without frontmatter — plain post text. Use for character/word count and LinkedIn copy. */
   body?: string;
   frontmatter?: {
     title: string;
@@ -84,7 +115,14 @@ export interface DispatchParseResult {
 
 const PROHIBITED_WORDS = ['leveraged', 'utilized', 'seamlessly', 'delve'];
 
-export function parseDispatchOutput(raw: string): DispatchParseResult {
+export function parseDispatchOutput(raw: string, format: DispatchFormat): DispatchParseResult {
+  if (format === 'linkedin') {
+    return parseLinkedInOutput(raw);
+  }
+  return parseBlogOutput(raw);
+}
+
+function parseBlogOutput(raw: string): DispatchParseResult {
   const fmMatch = raw.match(/^[\s]*---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!fmMatch) {
     return { ok: false, error: 'missing-frontmatter', raw };
@@ -118,8 +156,9 @@ export function parseDispatchOutput(raw: string): DispatchParseResult {
     console.warn(`[dispatch-prohibited-words] Prohibited words found in output: ${found.join(', ')}`);
   }
 
-  const title = titleMatch[1];
-  const tldr = tldrMatch[1];
+  // Unescape backslash-escaped quotes — LLM may emit \" inside the quoted YAML value
+  const title = titleMatch[1].replace(/\\"/g, '"');
+  const tldr = tldrMatch[1].replace(/\\"/g, '"');
 
   // Escape special YAML characters so the output is valid when pasted into blog platforms.
   // Titles/tldrs with ':' or '[' produce invalid unquoted YAML.
@@ -137,6 +176,47 @@ export function parseDispatchOutput(raw: string): DispatchParseResult {
       title,
       tags,
       tldr,
+    },
+  };
+}
+
+function parseLinkedInOutput(raw: string): DispatchParseResult {
+  // LinkedIn output: ---\ntitle: "..."\n---\n\n<post body>
+  const fmMatch = raw.match(/^[\s]*---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!fmMatch) {
+    return { ok: false, error: 'missing-frontmatter', raw };
+  }
+
+  const fm = fmMatch[1];
+  const body = fmMatch[2].trim();
+
+  const titleMatch = fm.match(/^title:\s*"?(.+?)"?\s*$/m);
+  if (!titleMatch) {
+    return { ok: false, error: 'malformed-frontmatter', raw };
+  }
+
+  // Extract hashtags from the last line of the body
+  const lastLineMatch = body.match(/(?:^|\n)((?:#[a-zA-Z]\w*(?:\s+|$))+)$/);
+  const tags = lastLineMatch
+    ? lastLineMatch[1].trim().split(/\s+/).map(t => t.replace(/^#/, ''))
+    : [];
+
+  // Log prohibited word leakage without rejecting
+  const lowerBody = body.toLowerCase();
+  const found = PROHIBITED_WORDS.filter(w => lowerBody.includes(w));
+  if (found.length > 0) {
+    console.warn(`[dispatch-prohibited-words] Prohibited words found in output: ${found.join(', ')}`);
+  }
+
+  return {
+    ok: true,
+    // For LinkedIn, markdown IS the body — no YAML wrapper gets returned to the user
+    markdown: body,
+    body,
+    frontmatter: {
+      title: titleMatch[1],
+      tags,
+      tldr: '',
     },
   };
 }

--- a/server/src/llm/providers/anthropic.ts
+++ b/server/src/llm/providers/anthropic.ts
@@ -28,6 +28,7 @@ export function createAnthropicClient(apiKey: string, model: string): LLMClient 
         body: JSON.stringify({
           model,
           max_tokens: 8192,
+          ...(options?.temperature !== undefined && { temperature: options.temperature }),
           // System message: pass ContentBlock[] through natively, or string as-is.
           system: systemMessage?.content,
           // Chat messages: pass ContentBlock[] content arrays natively (Anthropic supports this).

--- a/server/src/llm/providers/gemini.ts
+++ b/server/src/llm/providers/gemini.ts
@@ -18,17 +18,20 @@ export function createGeminiClient(apiKey: string, model: string): LLMClient {
         parts: [{ text: flattenContent(m.content) }],
       }));
 
+      const generationConfig: Record<string, unknown> = {
+        temperature: options?.temperature ?? 0.7,
+        maxOutputTokens: 8192,
+      };
+
+      // JSON mode is the default for analysis calls (prevents markdown fences and prose prefixes).
+      // Dispatch and other text callers pass responseFormat: 'text' to get plain markdown output.
+      if (options?.responseFormat !== 'text') {
+        generationConfig.responseMimeType = 'application/json';
+      }
+
       const body: Record<string, unknown> = {
         contents,
-        generationConfig: {
-          temperature: options?.temperature ?? 0.7,
-          maxOutputTokens: 8192,
-          // Force valid JSON output at the decoding level.
-          // Without this, Gemini Flash often wraps JSON in markdown fences,
-          // prefixes prose, or produces structurally broken JSON that even
-          // jsonrepair cannot fix.
-          responseMimeType: 'application/json',
-        },
+        generationConfig,
       };
 
       if (systemMessage) {

--- a/server/src/llm/providers/gemini.ts
+++ b/server/src/llm/providers/gemini.ts
@@ -21,7 +21,7 @@ export function createGeminiClient(apiKey: string, model: string): LLMClient {
       const body: Record<string, unknown> = {
         contents,
         generationConfig: {
-          temperature: 0.7,
+          temperature: options?.temperature ?? 0.7,
           maxOutputTokens: 8192,
           // Force valid JSON output at the decoding level.
           // Without this, Gemini Flash often wraps JSON in markdown fences,

--- a/server/src/llm/providers/llamacpp.ts
+++ b/server/src/llm/providers/llamacpp.ts
@@ -48,7 +48,7 @@ export function createLlamaCppClient(model: string, baseUrl?: string): LLMClient
               model,
               // flattenContent converts ContentBlock[] to string; strings pass through unchanged.
               messages: messages.map(m => ({ role: m.role, content: flattenContent(m.content) })),
-              temperature: 0.3,
+              temperature: options?.temperature ?? 0.3,
               max_tokens: 4096,
               // Grammar-constrained JSON output — llama-server honours OpenAI's response_format.
               response_format: { type: 'json_object' },

--- a/server/src/llm/providers/llamacpp.ts
+++ b/server/src/llm/providers/llamacpp.ts
@@ -50,8 +50,9 @@ export function createLlamaCppClient(model: string, baseUrl?: string): LLMClient
               messages: messages.map(m => ({ role: m.role, content: flattenContent(m.content) })),
               temperature: options?.temperature ?? 0.3,
               max_tokens: 4096,
-              // Grammar-constrained JSON output — llama-server honours OpenAI's response_format.
-              response_format: { type: 'json_object' },
+              // Grammar-constrained JSON output — only when caller expects JSON.
+              // Text-format callers (e.g. Dispatch) return markdown/YAML, not JSON.
+              ...(options?.responseFormat !== 'text' && { response_format: { type: 'json_object' } }),
             }),
           });
         } catch (err) {
@@ -116,6 +117,15 @@ export function createLlamaCppClient(model: string, baseUrl?: string): LLMClient
           outputTokens: data.usage?.completion_tokens ?? 0,
         };
       };
+
+      // Text-format callers (e.g. Dispatch) return markdown/YAML — skip JSON validation entirely.
+      if (options?.responseFormat === 'text') {
+        const result = await attempt();
+        return {
+          content: result.content,
+          usage: { inputTokens: result.inputTokens, outputTokens: result.outputTokens },
+        };
+      }
 
       // Perform the chat call with a single retry on JSON parse failure.
       // Small quantized models occasionally emit malformed JSON even with response_format: json_object.

--- a/server/src/llm/providers/ollama.ts
+++ b/server/src/llm/providers/ollama.ts
@@ -24,7 +24,7 @@ export function createOllamaClient(model: string, baseUrl?: string): LLMClient {
             // flattenContent converts ContentBlock[] to string; strings pass through unchanged.
             messages: messages.map(m => ({ role: m.role, content: flattenContent(m.content) })),
             stream: false,
-            options: { temperature: 0.7 },
+            options: { temperature: options?.temperature ?? 0.7 },
           }),
         });
       } catch (err) {

--- a/server/src/llm/providers/openai.ts
+++ b/server/src/llm/providers/openai.ts
@@ -21,7 +21,7 @@ export function createOpenAIClient(apiKey: string, model: string): LLMClient {
           // flattenContent converts ContentBlock[] to string; strings pass through unchanged.
           // OpenAI gets automatic prefix caching for free when prefixes match — no extra config needed.
           messages: messages.map(m => ({ role: m.role, content: flattenContent(m.content) })),
-          temperature: 0.7,
+          temperature: options?.temperature ?? 0.7,
           max_tokens: 8192,
         }),
       });

--- a/server/src/llm/types.ts
+++ b/server/src/llm/types.ts
@@ -45,6 +45,8 @@ export interface LLMResponse {
 export interface ChatOptions {
   signal?: AbortSignal;
   temperature?: number;
+  /** Controls response format. Defaults to 'json' for backward compat; dispatch uses 'text' for markdown output. */
+  responseFormat?: 'json' | 'text';
 }
 
 export interface LLMClient {

--- a/server/src/llm/types.ts
+++ b/server/src/llm/types.ts
@@ -44,6 +44,7 @@ export interface LLMResponse {
 
 export interface ChatOptions {
   signal?: AbortSignal;
+  temperature?: number;
 }
 
 export interface LLMClient {

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -562,4 +562,67 @@ describe('POST /api/dispatch/generate', () => {
     const userMsg = callArgs.find(m => m.role === 'user')?.content ?? '';
     expect(userMsg).not.toContain('SESSION BACKGROUND');
   });
+
+  it('includeSessionBackground: filter-then-rank — top-ranked sessions with no summary do not block lower-ranked sessions that have summaries', async () => {
+    // Regression for cap-before-filter bug: previously top-2 sessions by insight count
+    // were selected first, then filtered for summaries, silently returning 0 backgrounds
+    // even though sessions ranked 3-5 had summaries.
+    testDb.prepare(`INSERT OR IGNORE INTO projects (id, name, path, last_activity, session_count) VALUES ('proj-1', 'test', '/test', datetime('now'), 5)`).run();
+
+    // Sessions ranked 1+2 by insight count: NO summary
+    testDb.prepare(
+      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool)
+       VALUES ('sess-nosumA', 'proj-1', 'test', '/test', datetime('now'), datetime('now'), 10, 'claude-code')`,
+    ).run();
+    testDb.prepare(
+      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool)
+       VALUES ('sess-nosumB', 'proj-1', 'test', '/test', datetime('now'), datetime('now'), 10, 'claude-code')`,
+    ).run();
+    // Sessions ranked 3-5 by insight count: HAVE summaries
+    seedSession('sess-sum1', 'Alpha Summary', 'Alpha session summary text.', 'feature_build');
+    seedSession('sess-sum2', 'Beta Summary', 'Beta session summary text.', 'bug_hunt');
+    seedSession('sess-sum3', 'Gamma Summary', 'Gamma session summary text.', 'refactor');
+
+    const seedFor = (id: string, sessionId: string) =>
+      testDb.prepare(
+        `INSERT INTO insights (id, session_id, project_id, project_name, type, title, content, summary, confidence, timestamp)
+         VALUES (?, ?, 'proj-1', 'test', 'learning', ?, ?, ?, 0.9, datetime('now'))`,
+      ).run(id, sessionId, `Summary ${id}`, `Content ${id}`, `Summary ${id}`);
+
+    // Give sess-nosumA 3 insights and sess-nosumB 2 insights (top by count but no summary)
+    seedFor('fr-1', 'sess-nosumA'); seedFor('fr-2', 'sess-nosumA'); seedFor('fr-3', 'sess-nosumA');
+    seedFor('fr-4', 'sess-nosumB'); seedFor('fr-5', 'sess-nosumB');
+    // Give the summary sessions 1 insight each
+    seedFor('fr-6', 'sess-sum1');
+    seedFor('fr-7', 'sess-sum2');
+    seedFor('fr-8', 'sess-sum3');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        insightIds: ['fr-1', 'fr-2', 'fr-3', 'fr-4', 'fr-5', 'fr-6', 'fr-7', 'fr-8'],
+        context: 'Context across sessions.',
+        tone: 'technical',
+        format: 'blog',
+        includeSessionBackground: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string; content: string }>;
+    const userMsg = callArgs.find(m => m.role === 'user')?.content ?? '';
+    // The 3 sessions with summaries must appear — filter-first ensures they are not displaced
+    expect(userMsg).toContain('SESSION BACKGROUND');
+    expect(userMsg).toContain('Alpha Summary');
+    expect(userMsg).toContain('Beta Summary');
+    expect(userMsg).toContain('Gamma Summary');
+    // The sessions without summaries must not appear
+    expect(userMsg).not.toContain('sess-nosumA');
+    expect(userMsg).not.toContain('sess-nosumB');
+  });
 });

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -1,0 +1,333 @@
+import Database from 'better-sqlite3';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { runMigrations } from '@code-insights/cli/db/schema';
+
+// ──────────────────────────────────────────────────────
+// Module-scoped mutable DB reference
+// ──────────────────────────────────────────────────────
+
+let testDb: Database.Database;
+
+vi.mock('@code-insights/cli/db/client', () => ({
+  getDb: () => testDb,
+  closeDb: () => {},
+}));
+
+vi.mock('@code-insights/cli/utils/telemetry', () => ({
+  trackEvent: vi.fn(),
+  captureError: vi.fn(),
+  isTelemetryEnabled: () => false,
+  getStableMachineId: () => 'test-id',
+}));
+
+const mockIsLLMConfigured = vi.fn(() => true);
+const mockCreateLLMClient = vi.fn();
+
+vi.mock('../llm/client.js', () => ({
+  isLLMConfigured: () => mockIsLLMConfigured(),
+  createLLMClient: (...args: unknown[]) => mockCreateLLMClient(...args),
+  loadLLMConfig: () => ({ provider: 'openai', model: 'gpt-4o' }),
+}));
+
+const { createApp } = await import('../index.js');
+
+// ──────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────
+
+const VALID_MARKDOWN = `---
+title: "What SQLite Taught Me About Production Systems"
+tags: [sqlite, backend, lessons-learned]
+tldr: "Three weeks of debugging, one WAL mode revelation."
+---
+
+## WAL Mode Is Not Optional
+
+SQLite in WAL mode allows concurrent readers while a writer is active.
+Without it, every write blocks all reads — a problem you won't notice
+in development but will notice at 3am.
+
+## The Migration Trap
+
+ORM-generated migrations can silently drop data when renaming columns.
+Always review the generated SQL before running in production.
+
+## Incremental Builds Save Sanity
+
+Building incrementally with cached intermediates cut our CI time by 60%.
+The trick is understanding what actually needs to rebuild.
+`;
+
+function makeMockLLMClient(response: string) {
+  return {
+    chat: vi.fn().mockResolvedValue({
+      content: response,
+      usage: { inputTokens: 500, outputTokens: 800 },
+    }),
+    estimateTokens: (text: string) => Math.ceil(text.length / 4),
+    provider: 'openai',
+    model: 'gpt-4o',
+  };
+}
+
+function initTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  runMigrations(db);
+  return db;
+}
+
+function seedPrerequisites() {
+  testDb
+    .prepare(`INSERT OR IGNORE INTO projects (id, name, path, last_activity, session_count) VALUES ('proj-1', 'test', '/test', datetime('now'), 1)`)
+    .run();
+  testDb
+    .prepare(
+      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool)
+       VALUES ('sess-1', 'proj-1', 'test', '/test', '2025-06-15T10:00:00Z', '2025-06-15T11:00:00Z', 10, 'claude-code')`,
+    )
+    .run();
+}
+
+function seedInsight(
+  id: string,
+  type: string,
+  summary: string,
+  content: string,
+  bullets: string | null = null,
+) {
+  testDb
+    .prepare(
+      `INSERT INTO insights (id, session_id, project_id, project_name, type, title, content, summary, confidence, timestamp, bullets)
+       VALUES (?, 'sess-1', 'proj-1', 'test', ?, ?, ?, ?, 0.9, datetime('now'), ?)`,
+    )
+    .run(id, type, summary, content, summary, bullets);
+}
+
+const BASE_BODY = {
+  insightIds: ['ins-1', 'ins-2', 'ins-3'],
+  context: 'I spent three weeks debugging our SQLite setup.',
+  tone: 'technical',
+};
+
+// ──────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────
+
+describe('POST /api/dispatch/generate', () => {
+  beforeEach(() => {
+    testDb = initTestDb();
+    mockIsLLMConfigured.mockReturnValue(true);
+    mockCreateLLMClient.mockReset();
+  });
+
+  it('returns 400 when LLM is not configured', async () => {
+    mockIsLLMConfigured.mockReturnValue(false);
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/LLM not configured/);
+  });
+
+  it('returns 400 when insightIds < 3', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, insightIds: ['ins-1', 'ins-2'] }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/at least 3/);
+  });
+
+  it('returns 400 when insightIds > 8', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, insightIds: ['1','2','3','4','5','6','7','8','9'] }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/8 or fewer/);
+  });
+
+  it('returns 400 when context is empty', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, context: '   ' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when context exceeds 500 chars', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, context: 'x'.repeat(501) }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/500/);
+  });
+
+  it('returns 400 for invalid tone', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, tone: 'marketing' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when no insights found in DB', async () => {
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when fewer than 3 IDs found in DB after filter', async () => {
+    seedPrerequisites();
+    // Seed only 2 of the 3 requested insights
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/at least 3/);
+  });
+
+  it('happy path: returns 200 with parsed markdown, frontmatter, wordCount', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'WAL mode matters', 'WAL mode allows concurrent readers.');
+    seedInsight('ins-2', 'decision', 'Avoid ORM migrations', 'Manual SQL is safer for column renames.');
+    seedInsight('ins-3', 'technique', 'Incremental builds', 'Cache intermediates to reduce CI time.');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as {
+      markdown: string;
+      frontmatter: { title: string; tags: string[]; tldr: string };
+      wordCount: number;
+      degraded: boolean;
+      model: string;
+    };
+    expect(json.frontmatter.title).toBe('What SQLite Taught Me About Production Systems');
+    expect(json.frontmatter.tags).toContain('sqlite');
+    expect(json.frontmatter.tldr).toMatch(/WAL/);
+    expect(json.wordCount).toBeGreaterThan(0);
+    expect(json.degraded).toBe(false);
+    expect(json.model).toBe('gpt-4o');
+    // Verify temperature 0.7 was passed
+    expect(mockClient.chat).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ temperature: 0.7 }),
+    );
+    // Verify system prompt is included in messages
+    const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string }>;
+    expect(callArgs[0].role).toBe('system');
+  });
+
+  it('handles null bullets without crashing', async () => {
+    seedPrerequisites();
+    // null bullets is the real-world case for legacy rows where bullets column was not set
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one', null);
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two', null);
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three', null);
+
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+    // Should not 500 — null bullets must be handled gracefully
+    expect(res.status).toBe(200);
+  });
+
+  it('retries on parse failure and degrades gracefully on second failure', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three');
+
+    const rawContent = '# My Post\n\nSome content without frontmatter.';
+    const mockClient = {
+      chat: vi.fn().mockResolvedValue({
+        content: rawContent,
+        usage: { inputTokens: 100, outputTokens: 200 },
+      }),
+      estimateTokens: (text: string) => Math.ceil(text.length / 4),
+      provider: 'openai',
+      model: 'gpt-4o',
+    };
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as { degraded: boolean; frontmatter: { title: string } };
+    expect(json.degraded).toBe(true);
+    // Extracted H1 as title
+    expect(json.frontmatter.title).toBe('My Post');
+    // LLM called twice (initial + retry)
+    expect(mockClient.chat).toHaveBeenCalledTimes(2);
+  });
+
+  it('Gemini regression: responseFormat text is passed to prevent JSON mode', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+
+    expect(mockClient.chat).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ responseFormat: 'text' }),
+    );
+  });
+});

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -94,12 +94,16 @@ function seedPrerequisites() {
   testDb
     .prepare(`INSERT OR IGNORE INTO projects (id, name, path, last_activity, session_count) VALUES ('proj-1', 'test', '/test', datetime('now'), 1)`)
     .run();
+  seedSession('sess-1', 'Untitled');
+}
+
+function seedSession(id: string, title: string, summary: string | null = null, character: string | null = null) {
   testDb
     .prepare(
-      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool)
-       VALUES ('sess-1', 'proj-1', 'test', '/test', '2025-06-15T10:00:00Z', '2025-06-15T11:00:00Z', 10, 'claude-code')`,
+      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool, generated_title, summary, session_character)
+       VALUES (?, 'proj-1', 'test', '/test', '2025-06-15T10:00:00Z', '2025-06-15T11:00:00Z', 10, 'claude-code', ?, ?, ?)`,
     )
-    .run();
+    .run(id, title, summary, character);
 }
 
 function seedInsight(
@@ -108,13 +112,14 @@ function seedInsight(
   summary: string,
   content: string,
   bullets: string | null = null,
+  sessionId = 'sess-1',
 ) {
   testDb
     .prepare(
       `INSERT INTO insights (id, session_id, project_id, project_name, type, title, content, summary, confidence, timestamp, bullets)
-       VALUES (?, 'sess-1', 'proj-1', 'test', ?, ?, ?, ?, 0.9, datetime('now'), ?)`,
+       VALUES (?, ?, 'proj-1', 'test', ?, ?, ?, ?, 0.9, datetime('now'), ?)`,
     )
-    .run(id, type, summary, content, summary, bullets);
+    .run(id, sessionId, type, summary, content, summary, bullets);
 }
 
 const BASE_BODY = {
@@ -450,5 +455,111 @@ describe('POST /api/dispatch/generate', () => {
     expect(json.frontmatter.title).toBe('What SQLite Taught Me About Production Systems');
     expect(json.frontmatter.tldr).toMatch(/WAL/);
     expect(json.wordCount).toBeGreaterThan(0);
+  });
+
+  it('includeSessionBackground: session summaries fetched and sent in user message; capped at 4', async () => {
+    testDb.prepare(`INSERT OR IGNORE INTO projects (id, name, path, last_activity, session_count) VALUES ('proj-1', 'test', '/test', datetime('now'), 5)`).run();
+    // Seed 5 sessions, each with a summary
+    for (let i = 1; i <= 5; i++) {
+      testDb.prepare(
+        `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool, summary, generated_title, session_character)
+         VALUES (?, 'proj-1', 'test', '/test', datetime('now'), datetime('now'), 10, 'claude-code', ?, ?, ?)`,
+      ).run(`sess-bg${i}`, `Summary for session ${i}`, `Session ${i}`, 'feature_build');
+    }
+
+    // Seed insights spread across all 5 sessions — sess-bg1 contributes most (3)
+    const seedBg = (id: string, sessionId: string) =>
+      testDb.prepare(
+        `INSERT INTO insights (id, session_id, project_id, project_name, type, title, content, summary, confidence, timestamp)
+         VALUES (?, ?, 'proj-1', 'test', 'learning', ?, ?, ?, 0.9, datetime('now'))`,
+      ).run(id, sessionId, `Summary ${id}`, `Content ${id}`, `Summary ${id}`);
+
+    seedBg('bg-1', 'sess-bg1'); seedBg('bg-2', 'sess-bg1'); seedBg('bg-3', 'sess-bg1');
+    seedBg('bg-4', 'sess-bg2'); seedBg('bg-5', 'sess-bg2');
+    seedBg('bg-6', 'sess-bg3');
+    seedBg('bg-7', 'sess-bg4');
+    seedBg('bg-8', 'sess-bg5');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        insightIds: ['bg-1', 'bg-2', 'bg-3', 'bg-4', 'bg-5', 'bg-6', 'bg-7', 'bg-8'],
+        context: 'A story across many sessions.',
+        tone: 'technical',
+        format: 'blog',
+        includeSessionBackground: true,
+      }),
+    });
+
+    const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string; content: string }>;
+    const userMsg = callArgs.find(m => m.role === 'user')?.content ?? '';
+    expect(userMsg).toContain('SESSION BACKGROUND');
+    // Cap at 4 — sess-bg5 (least contributing) should not appear
+    const sessionCount = (userMsg.match(/\[Session:/g) ?? []).length;
+    expect(sessionCount).toBeLessThanOrEqual(4);
+    expect(userMsg).toContain('Session 1');
+  });
+
+  it('includeSessionBackground: omitted from user message when false', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, includeSessionBackground: false }),
+    });
+
+    const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string; content: string }>;
+    const userMsg = callArgs.find(m => m.role === 'user')?.content ?? '';
+    expect(userMsg).not.toContain('SESSION BACKGROUND');
+  });
+
+  it('includeSessionBackground: sessions without summary are silently skipped', async () => {
+    testDb.prepare(`INSERT OR IGNORE INTO projects (id, name, path, last_activity, session_count) VALUES ('proj-1', 'test', '/test', datetime('now'), 1)`).run();
+    testDb.prepare(
+      `INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count, source_tool)
+       VALUES ('sess-nosummary', 'proj-1', 'test', '/test', datetime('now'), datetime('now'), 5, 'claude-code')`,
+    ).run();
+
+    const seedNs = (id: string) =>
+      testDb.prepare(
+        `INSERT INTO insights (id, session_id, project_id, project_name, type, title, content, summary, confidence, timestamp)
+         VALUES (?, 'sess-nosummary', 'proj-1', 'test', 'learning', ?, ?, ?, 0.9, datetime('now'))`,
+      ).run(id, `Summary ${id}`, `Content ${id}`, `Summary ${id}`);
+    seedNs('ns-1'); seedNs('ns-2'); seedNs('ns-3');
+
+    const mockClient = makeMockLLMClient(VALID_MARKDOWN);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        insightIds: ['ns-1', 'ns-2', 'ns-3'],
+        context: 'Context.',
+        tone: 'technical',
+        format: 'blog',
+        includeSessionBackground: true,
+      }),
+    });
+
+    // Should succeed — sessions without summary are filtered in the SQL WHERE clause
+    expect(res.status).toBe(200);
+    const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string; content: string }>;
+    const userMsg = callArgs.find(m => m.role === 'user')?.content ?? '';
+    expect(userMsg).not.toContain('SESSION BACKGROUND');
   });
 });

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -35,6 +35,20 @@ const { createApp } = await import('../index.js');
 // Fixtures
 // ──────────────────────────────────────────────────────
 
+const VALID_LINKEDIN_OUTPUT = `---
+title: "What SQLite Taught Me in Production"
+---
+
+**WAL mode is not optional** if you have concurrent readers and writers.
+
+I spent three weeks debugging a production issue that only appeared under real load. The culprit was SQLite in default journal mode blocking all reads during a write.
+
+Switching to WAL mode resolved it immediately. Reads and writes operate on separate file segments — no locking.
+
+Three other things I learned the hard way working on this system.
+
+#sqlite #backend #engineering`;
+
 const VALID_MARKDOWN = `---
 title: "What SQLite Taught Me About Production Systems"
 tags: [sqlite, backend, lessons-learned]
@@ -107,6 +121,7 @@ const BASE_BODY = {
   insightIds: ['ins-1', 'ins-2', 'ins-3'],
   context: 'I spent three weeks debugging our SQLite setup.',
   tone: 'technical',
+  format: 'blog',
 };
 
 // ──────────────────────────────────────────────────────
@@ -187,6 +202,18 @@ describe('POST /api/dispatch/generate', () => {
       body: JSON.stringify({ ...BASE_BODY, tone: 'marketing' }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid format', async () => {
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, format: 'newsletter' }),
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/format must be one of/);
   });
 
   it('returns 404 when no insights found in DB', async () => {
@@ -329,5 +356,94 @@ describe('POST /api/dispatch/generate', () => {
       expect.any(Array),
       expect.objectContaining({ responseFormat: 'text' }),
     );
+  });
+
+  it('linkedin happy path: returns 200 with hashtags in tags, empty tldr, body=markdown', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'WAL mode matters', 'WAL mode allows concurrent readers.');
+    seedInsight('ins-2', 'decision', 'Avoid ORM migrations', 'Manual SQL is safer for column renames.');
+    seedInsight('ins-3', 'technique', 'Incremental builds', 'Cache intermediates to reduce CI time.');
+
+    const mockClient = makeMockLLMClient(VALID_LINKEDIN_OUTPUT);
+    mockCreateLLMClient.mockReturnValue(mockClient);
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, format: 'linkedin' }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as {
+      format: string;
+      frontmatter: { title: string; tags: string[]; tldr: string };
+      body: string;
+      markdown: string;
+      characterCount: number;
+      degraded: boolean;
+    };
+    expect(json.format).toBe('linkedin');
+    expect(json.frontmatter.title).toBe('What SQLite Taught Me in Production');
+    expect(json.frontmatter.tags).toContain('sqlite');
+    expect(json.frontmatter.tags).toContain('backend');
+    expect(json.frontmatter.tags).toContain('engineering');
+    // Tags must not include # prefix
+    expect(json.frontmatter.tags.every((t: string) => !t.startsWith('#'))).toBe(true);
+    expect(json.frontmatter.tldr).toBe('');
+    // For LinkedIn, markdown === body (no YAML wrapper)
+    expect(json.markdown).toBe(json.body);
+    expect(json.body).toContain('WAL mode is not optional');
+    expect(json.characterCount).toBeGreaterThan(0);
+    expect(json.degraded).toBe(false);
+  });
+
+  it('format is echoed back correctly in response', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three');
+
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, format: 'blog' }),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json() as { format: string };
+    expect(json.format).toBe('blog');
+  });
+
+  it('blog regression: blog format unchanged, includes YAML frontmatter in markdown', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'WAL mode matters', 'WAL mode allows concurrent readers.');
+    seedInsight('ins-2', 'decision', 'Avoid ORM migrations', 'Manual SQL is safer for column renames.');
+    seedInsight('ins-3', 'technique', 'Incremental builds', 'Cache intermediates to reduce CI time.');
+
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...BASE_BODY, format: 'blog' }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json() as {
+      markdown: string;
+      body: string;
+      frontmatter: { title: string; tags: string[]; tldr: string };
+      wordCount: number;
+    };
+    // Blog markdown includes YAML frontmatter
+    expect(json.markdown).toContain('---');
+    expect(json.markdown).toContain('title:');
+    // Body is prose-only (no YAML)
+    expect(json.body).not.toContain('---\ntitle:');
+    expect(json.frontmatter.title).toBe('What SQLite Taught Me About Production Systems');
+    expect(json.frontmatter.tldr).toMatch(/WAL/);
+    expect(json.wordCount).toBeGreaterThan(0);
   });
 });

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -396,6 +396,11 @@ describe('POST /api/dispatch/generate', () => {
     expect(json.body).toContain('WAL mode is not optional');
     expect(json.characterCount).toBeGreaterThan(0);
     expect(json.degraded).toBe(false);
+    // LinkedIn uses lower temperature for hook consistency
+    expect(mockClient.chat).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ temperature: 0.55 }),
+    );
   });
 
   it('format is echoed back correctly in response', async () => {

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -1,0 +1,137 @@
+import { Hono } from 'hono';
+import { getDb } from '@code-insights/cli/db/client';
+import { createLLMClient } from '../llm/client.js';
+import { requireLLM } from './route-helpers.js';
+import {
+  buildDispatchSystemPrompt,
+  buildDispatchContext,
+  parseDispatchOutput,
+  buildDegradedResponse,
+} from '../llm/dispatch-prompts.js';
+import type { DispatchTone, DispatchInsight } from '@code-insights/cli/types';
+
+const app = new Hono();
+
+const VALID_TONES: DispatchTone[] = ['technical', 'accessible', 'quick-tips'];
+
+interface InsightRow {
+  id: string;
+  type: string;
+  summary: string;
+  content: string;
+  bullets: string; // JSON-encoded string[]
+}
+
+function countWords(text: string): number {
+  const bodyMatch = text.match(/---[\s\S]*?---\n([\s\S]*)/);
+  const body = bodyMatch ? bodyMatch[1] : text;
+  return body.trim().split(/\s+/).filter(Boolean).length;
+}
+
+// POST /api/dispatch/generate
+// Body: { insightIds: string[], context: string, tone: DispatchTone }
+// Returns: { markdown, frontmatter: { title, tags, tldr }, wordCount, model, tokensUsed }
+app.post('/generate', requireLLM(), async (c) => {
+  const body = await c.req.json<{
+    insightIds?: unknown;
+    context?: unknown;
+    tone?: unknown;
+  }>();
+
+  // Validate insightIds
+  if (!Array.isArray(body.insightIds)) {
+    return c.json({ error: 'insightIds must be an array' }, 400);
+  }
+  const insightIds = body.insightIds as unknown[];
+  if (insightIds.some((id) => typeof id !== 'string')) {
+    return c.json({ error: 'insightIds must contain only strings' }, 400);
+  }
+  if (insightIds.length < 3) {
+    return c.json({ error: 'Select at least 3 insights to generate a post' }, 400);
+  }
+  if (insightIds.length > 8) {
+    return c.json({ error: 'For the best post, keep it to 8 or fewer insights' }, 400);
+  }
+
+  // Validate context
+  if (typeof body.context !== 'string' || body.context.trim().length === 0) {
+    return c.json({ error: 'context is required' }, 400);
+  }
+  if (body.context.length > 500) {
+    return c.json({ error: 'context must be 500 characters or fewer' }, 400);
+  }
+
+  // Validate tone
+  if (!VALID_TONES.includes(body.tone as DispatchTone)) {
+    return c.json({ error: `tone must be one of: ${VALID_TONES.join(', ')}` }, 400);
+  }
+
+  const tone = body.tone as DispatchTone;
+  const contextText = body.context.trim();
+  const typedIds = insightIds as string[];
+
+  // Fetch insights from DB — respects provided order
+  const db = getDb();
+  const placeholders = typedIds.map(() => '?').join(', ');
+  const rows = db.prepare(
+    `SELECT id, type, summary, content, bullets FROM insights WHERE id IN (${placeholders})`
+  ).all(...typedIds) as InsightRow[];
+
+  if (rows.length === 0) {
+    return c.json({ error: 'No insights found for the provided IDs' }, 404);
+  }
+
+  // Preserve the caller's ordering
+  const rowMap = new Map(rows.map((r) => [r.id, r]));
+  const orderedInsights: DispatchInsight[] = typedIds
+    .map((id) => rowMap.get(id))
+    .filter((r): r is InsightRow => r !== undefined)
+    .map((r) => {
+      let bullets: string[] = [];
+      try { bullets = JSON.parse(r.bullets) as string[]; } catch { /* empty */ }
+      return { id: r.id, type: r.type, summary: r.summary, content: r.content, bullets };
+    });
+
+  const systemPrompt = buildDispatchSystemPrompt(tone);
+  const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights });
+
+  const client = createLLMClient();
+  const messages = [
+    { role: 'user' as const, content: userMessage },
+  ];
+
+  let response = await client.chat(messages, {
+    // temperature 0.7 is not a universal option in the LLMClient interface;
+    // providers use their own defaults — Sonnet defaults to 1.0
+    // We override via system prompt instructions for consistent output length
+  });
+
+  let parsed = parseDispatchOutput(response.content);
+
+  // Single retry on parse failure
+  if (!parsed.ok) {
+    response = await client.chat(messages);
+    parsed = parseDispatchOutput(response.content);
+
+    if (!parsed.ok) {
+      // Degrade gracefully — return the raw content with extracted title
+      parsed = buildDegradedResponse(response.content);
+    }
+  }
+
+  const markdown = parsed.markdown ?? response.content;
+  const wordCount = countWords(markdown);
+
+  return c.json({
+    markdown,
+    frontmatter: parsed.frontmatter ?? { title: 'Untitled', tags: [], tldr: '' },
+    wordCount,
+    model: client.model,
+    tokensUsed: {
+      input: response.usage?.inputTokens ?? 0,
+      output: response.usage?.outputTokens ?? 0,
+    },
+  });
+});
+
+export default app;

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -122,20 +122,16 @@ app.post('/generate', requireLLM(), async (c) => {
   // Fetch session backgrounds when requested
   let sessionBackgrounds: SessionBackground[] | undefined;
   if (includeSessionBackground) {
-    // Count insights per session to pick the top 4 by contribution
+    // Count insights per session (all selected insights, before filtering)
     const sessionInsightCount = new Map<string, number>();
     for (const r of rows) {
       sessionInsightCount.set(r.session_id, (sessionInsightCount.get(r.session_id) ?? 0) + 1);
     }
 
-    // Sort sessions by insight count descending, take top 4
-    const topSessionIds = [...sessionInsightCount.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 4)
-      .map(([id]) => id);
-
-    if (topSessionIds.length > 0) {
-      const sessionPlaceholders = topSessionIds.map(() => '?').join(', ');
+    const allSessionIds = [...sessionInsightCount.keys()];
+    if (allSessionIds.length > 0) {
+      // Fetch only sessions that have summaries — filter FIRST, then rank and cap
+      const sessionPlaceholders = allSessionIds.map(() => '?').join(', ');
       const sessionRows = db.prepare(
         `SELECT id,
                 COALESCE(custom_title, generated_title, 'Untitled') as title,
@@ -145,14 +141,18 @@ app.post('/generate', requireLLM(), async (c) => {
          WHERE id IN (${sessionPlaceholders})
            AND summary IS NOT NULL
            AND summary != ''`
-      ).all(...topSessionIds) as SessionRow[];
+      ).all(...allSessionIds) as SessionRow[];
 
-      sessionBackgrounds = sessionRows.map((s) => ({
-        sessionId: s.id,
-        title: s.title,
-        summary: s.summary,
-        sessionCharacter: s.session_character,
-      }));
+      // Rank by insight count descending, cap at 4
+      sessionBackgrounds = sessionRows
+        .sort((a, b) => (sessionInsightCount.get(b.id) ?? 0) - (sessionInsightCount.get(a.id) ?? 0))
+        .slice(0, 4)
+        .map((s) => ({
+          sessionId: s.id,
+          title: s.title,
+          sessionCharacter: s.session_character,
+          summary: s.summary,
+        }));
     }
   }
 

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -8,7 +8,7 @@ import {
   parseDispatchOutput,
   buildDegradedResponse,
 } from '../llm/dispatch-prompts.js';
-import type { DispatchTone, DispatchInsight, DispatchFormat } from '@code-insights/cli/types';
+import type { DispatchTone, DispatchInsight, DispatchFormat, SessionBackground } from '@code-insights/cli/types';
 
 const app = new Hono();
 
@@ -23,14 +23,22 @@ const TEMPERATURES: Record<DispatchFormat, number> = {
 
 interface InsightRow {
   id: string;
+  session_id: string;
   type: string;
   summary: string;
   content: string;
   bullets: string | null; // JSON-encoded string[], or null for legacy rows
 }
 
+interface SessionRow {
+  id: string;
+  title: string;
+  session_character: string | null;
+  summary: string;
+}
+
 // POST /api/dispatch/generate
-// Body: { insightIds: string[], context: string, tone: DispatchTone, format: DispatchFormat }
+// Body: { insightIds: string[], context: string, tone: DispatchTone, format: DispatchFormat, includeSessionBackground?: boolean }
 // Returns: { markdown, body, format, frontmatter, wordCount, characterCount, degraded, model, tokensUsed }
 app.post('/generate', requireLLM(), async (c) => {
   const body = await c.req.json<{
@@ -38,6 +46,7 @@ app.post('/generate', requireLLM(), async (c) => {
     context?: unknown;
     tone?: unknown;
     format?: unknown;
+    includeSessionBackground?: unknown;
   }>();
 
   // Validate insightIds
@@ -77,12 +86,13 @@ app.post('/generate', requireLLM(), async (c) => {
   const format = body.format as DispatchFormat;
   const contextText = body.context.trim();
   const typedIds = insightIds as string[];
+  const includeSessionBackground = body.includeSessionBackground === true;
 
   // Fetch insights from DB — respects provided order
   const db = getDb();
   const placeholders = typedIds.map(() => '?').join(', ');
   const rows = db.prepare(
-    `SELECT id, type, summary, content, bullets FROM insights WHERE id IN (${placeholders})`
+    `SELECT id, session_id, type, summary, content, bullets FROM insights WHERE id IN (${placeholders})`
   ).all(...typedIds) as InsightRow[];
 
   if (rows.length === 0) {
@@ -109,8 +119,45 @@ app.post('/generate', requireLLM(), async (c) => {
     return c.json({ error: 'Select at least 3 insights to generate a post' }, 400);
   }
 
+  // Fetch session backgrounds when requested
+  let sessionBackgrounds: SessionBackground[] | undefined;
+  if (includeSessionBackground) {
+    // Count insights per session to pick the top 4 by contribution
+    const sessionInsightCount = new Map<string, number>();
+    for (const r of rows) {
+      sessionInsightCount.set(r.session_id, (sessionInsightCount.get(r.session_id) ?? 0) + 1);
+    }
+
+    // Sort sessions by insight count descending, take top 4
+    const topSessionIds = [...sessionInsightCount.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4)
+      .map(([id]) => id);
+
+    if (topSessionIds.length > 0) {
+      const sessionPlaceholders = topSessionIds.map(() => '?').join(', ');
+      const sessionRows = db.prepare(
+        `SELECT id,
+                COALESCE(custom_title, generated_title, 'Untitled') as title,
+                session_character,
+                summary
+         FROM sessions
+         WHERE id IN (${sessionPlaceholders})
+           AND summary IS NOT NULL
+           AND summary != ''`
+      ).all(...topSessionIds) as SessionRow[];
+
+      sessionBackgrounds = sessionRows.map((s) => ({
+        sessionId: s.id,
+        title: s.title,
+        summary: s.summary,
+        sessionCharacter: s.session_character,
+      }));
+    }
+  }
+
   const systemPrompt = buildDispatchSystemPrompt(tone, format);
-  const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights });
+  const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights, sessionBackgrounds });
 
   const client = createLLMClient();
   const messages = [

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -19,13 +19,7 @@ interface InsightRow {
   type: string;
   summary: string;
   content: string;
-  bullets: string; // JSON-encoded string[]
-}
-
-function countWords(text: string): number {
-  const bodyMatch = text.match(/---[\s\S]*?---\n([\s\S]*)/);
-  const body = bodyMatch ? bodyMatch[1] : text;
-  return body.trim().split(/\s+/).filter(Boolean).length;
+  bullets: string | null; // JSON-encoded string[], or null for legacy rows
 }
 
 // POST /api/dispatch/generate
@@ -88,9 +82,18 @@ app.post('/generate', requireLLM(), async (c) => {
     .filter((r): r is InsightRow => r !== undefined)
     .map((r) => {
       let bullets: string[] = [];
-      try { bullets = JSON.parse(r.bullets) as string[]; } catch { /* empty */ }
+      if (r.bullets) {
+        try {
+          const parsed = JSON.parse(r.bullets);
+          if (Array.isArray(parsed)) bullets = parsed as string[];
+        } catch { /* empty */ }
+      }
       return { id: r.id, type: r.type, summary: r.summary, content: r.content, bullets };
     });
+
+  if (orderedInsights.length < 3) {
+    return c.json({ error: 'Select at least 3 insights to generate a post' }, 400);
+  }
 
   const systemPrompt = buildDispatchSystemPrompt(tone);
   const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights });
@@ -101,13 +104,14 @@ app.post('/generate', requireLLM(), async (c) => {
     { role: 'user' as const, content: userMessage },
   ];
 
-  let response = await client.chat(messages, { temperature: 0.7 });
+  const chatOptions = { temperature: 0.7, responseFormat: 'text' as const };
+  let response = await client.chat(messages, chatOptions);
 
   let parsed = parseDispatchOutput(response.content);
 
   // Single retry on parse failure
   if (!parsed.ok) {
-    response = await client.chat(messages, { temperature: 0.7 });
+    response = await client.chat(messages, chatOptions);
     parsed = parseDispatchOutput(response.content);
 
     if (!parsed.ok) {
@@ -117,12 +121,14 @@ app.post('/generate', requireLLM(), async (c) => {
   }
 
   const markdown = parsed.markdown ?? response.content;
-  const wordCount = countWords(markdown);
+  const bodyText = parsed.body ?? markdown;
+  const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
 
   return c.json({
     markdown,
     frontmatter: parsed.frontmatter ?? { title: 'Untitled', tags: [], tldr: '' },
     wordCount,
+    degraded: parsed.degraded ?? false,
     model: client.model,
     tokensUsed: {
       input: response.usage?.inputTokens ?? 0,

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -8,11 +8,12 @@ import {
   parseDispatchOutput,
   buildDegradedResponse,
 } from '../llm/dispatch-prompts.js';
-import type { DispatchTone, DispatchInsight } from '@code-insights/cli/types';
+import type { DispatchTone, DispatchInsight, DispatchFormat } from '@code-insights/cli/types';
 
 const app = new Hono();
 
 const VALID_TONES: DispatchTone[] = ['technical', 'accessible', 'quick-tips'];
+const VALID_FORMATS: DispatchFormat[] = ['blog', 'linkedin'];
 
 interface InsightRow {
   id: string;
@@ -23,13 +24,14 @@ interface InsightRow {
 }
 
 // POST /api/dispatch/generate
-// Body: { insightIds: string[], context: string, tone: DispatchTone }
-// Returns: { markdown, frontmatter: { title, tags, tldr }, wordCount, model, tokensUsed }
+// Body: { insightIds: string[], context: string, tone: DispatchTone, format: DispatchFormat }
+// Returns: { markdown, body, format, frontmatter, wordCount, characterCount, degraded, model, tokensUsed }
 app.post('/generate', requireLLM(), async (c) => {
   const body = await c.req.json<{
     insightIds?: unknown;
     context?: unknown;
     tone?: unknown;
+    format?: unknown;
   }>();
 
   // Validate insightIds
@@ -60,7 +62,13 @@ app.post('/generate', requireLLM(), async (c) => {
     return c.json({ error: `tone must be one of: ${VALID_TONES.join(', ')}` }, 400);
   }
 
+  // Validate format
+  if (!VALID_FORMATS.includes(body.format as DispatchFormat)) {
+    return c.json({ error: `format must be one of: ${VALID_FORMATS.join(', ')}` }, 400);
+  }
+
   const tone = body.tone as DispatchTone;
+  const format = body.format as DispatchFormat;
   const contextText = body.context.trim();
   const typedIds = insightIds as string[];
 
@@ -95,7 +103,7 @@ app.post('/generate', requireLLM(), async (c) => {
     return c.json({ error: 'Select at least 3 insights to generate a post' }, 400);
   }
 
-  const systemPrompt = buildDispatchSystemPrompt(tone);
+  const systemPrompt = buildDispatchSystemPrompt(tone, format);
   const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights });
 
   const client = createLLMClient();
@@ -107,12 +115,12 @@ app.post('/generate', requireLLM(), async (c) => {
   const chatOptions = { temperature: 0.7, responseFormat: 'text' as const };
   let response = await client.chat(messages, chatOptions);
 
-  let parsed = parseDispatchOutput(response.content);
+  let parsed = parseDispatchOutput(response.content, format);
 
   // Single retry on parse failure
   if (!parsed.ok) {
     response = await client.chat(messages, chatOptions);
-    parsed = parseDispatchOutput(response.content);
+    parsed = parseDispatchOutput(response.content, format);
 
     if (!parsed.ok) {
       // Degrade gracefully — return the raw content with extracted title
@@ -123,11 +131,15 @@ app.post('/generate', requireLLM(), async (c) => {
   const markdown = parsed.markdown ?? response.content;
   const bodyText = parsed.body ?? markdown;
   const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
+  const characterCount = bodyText.length;
 
   return c.json({
     markdown,
+    body: bodyText,
+    format,
     frontmatter: parsed.frontmatter ?? { title: 'Untitled', tags: [], tldr: '' },
     wordCount,
+    characterCount,
     degraded: parsed.degraded ?? false,
     model: client.model,
     tokensUsed: {

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -15,6 +15,12 @@ const app = new Hono();
 const VALID_TONES: DispatchTone[] = ['technical', 'accessible', 'quick-tips'];
 const VALID_FORMATS: DispatchFormat[] = ['blog', 'linkedin'];
 
+// LinkedIn uses a lower temperature for consistent hook quality — the hook is the highest-stakes line
+const TEMPERATURES: Record<DispatchFormat, number> = {
+  blog: 0.7,
+  linkedin: 0.55,
+};
+
 interface InsightRow {
   id: string;
   type: string;
@@ -112,7 +118,7 @@ app.post('/generate', requireLLM(), async (c) => {
     { role: 'user' as const, content: userMessage },
   ];
 
-  const chatOptions = { temperature: 0.7, responseFormat: 'text' as const };
+  const chatOptions = { temperature: TEMPERATURES[format], responseFormat: 'text' as const };
   let response = await client.chat(messages, chatOptions);
 
   let parsed = parseDispatchOutput(response.content, format);

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -97,20 +97,17 @@ app.post('/generate', requireLLM(), async (c) => {
 
   const client = createLLMClient();
   const messages = [
+    { role: 'system' as const, content: systemPrompt },
     { role: 'user' as const, content: userMessage },
   ];
 
-  let response = await client.chat(messages, {
-    // temperature 0.7 is not a universal option in the LLMClient interface;
-    // providers use their own defaults — Sonnet defaults to 1.0
-    // We override via system prompt instructions for consistent output length
-  });
+  let response = await client.chat(messages, { temperature: 0.7 });
 
   let parsed = parseDispatchOutput(response.content);
 
   // Single retry on parse failure
   if (!parsed.ok) {
-    response = await client.chat(messages);
+    response = await client.chat(messages, { temperature: 0.7 });
     parsed = parseDispatchOutput(response.content);
 
     if (!parsed.ok) {


### PR DESCRIPTION
## Summary

- Add `POST /api/dispatch/generate` endpoint that takes 3-8 selected insights + user context + tone + format, calls Sonnet via configured LLM, and returns a structured post
- Support two output formats: **blog** (800-1000 word markdown with YAML frontmatter) and **LinkedIn** (150-250 word hook-first post with hashtags)
- Add Dispatch UI on InsightsPage: inline checkboxes on hover, FloatingActionBar (appears at 3+ selections), DispatchDrawer with drag-to-reorder (dnd-kit), context field, format + tone selectors, and PostPreview with format-aware rendering

Closes #296

## Why

Developers accumulate structured learnings in the insights table but have no way to turn them into shareable artifacts. This feature lets users curate their insights, frame the narrative, and generate a publishable blog post or LinkedIn post. The user provides the substance and framing; the LLM provides the prose scaffolding.

## How

**Server layer:**
- `server/src/llm/dispatch-prompts.ts` — `buildDispatchSystemPrompt(tone, format)`, `buildDispatchContext(input)`, `parseDispatchOutput(raw, format)`, `buildDegradedResponse(raw)`
- Prompt architecture: SHARED_BASE + FORMAT_INSTRUCTIONS[format] + TONE_INSTRUCTIONS[format][tone] — each combination produces a distinct instruction set
- Blog parser: YAML frontmatter with title/tags/tldr, title unescaping, proper re-encoding for output
- LinkedIn parser: title-only metadata block, hashtag extraction from last line, `markdown === body` (no YAML wrapper returned to user)
- Single retry on parse failure; degraded response on double failure
- `server/src/routes/dispatch.ts` — validates insightIds (3-8), context (1-500 chars), tone (enum), format (enum); echoes `format`, `body`, `characterCount` in response

**Dashboard layer:**
- `DispatchDrawer.tsx` — Sheet right panel with dnd-kit sortable, context textarea, **format selector** (blog/linkedin) above tone radio group
- `PostPreview.tsx` — format-aware: blog gets Preview/Markdown tabs + TL;DR banner + Download .md; LinkedIn gets plain-text `<pre>` with whitespace-pre-wrap + character count (no YAML wrapper, no download)
- `FloatingActionBar.tsx` — fixed bottom bar, appears at ≥3 selections
- `InsightsPage.tsx` — inline Checkbox on hover per card, selection state (max 8)

## Schema Impact
- [ ] SQLite schema changed: no
- [x] Types changed: yes — added `DispatchFormat`, `DispatchTone`, `DispatchInsight`, `DispatchRequest`, `DispatchResponse` to `cli/src/types.ts`
- [x] Server API changed: yes — new `POST /api/dispatch/generate` endpoint; `format` field added to request/response
- [x] Backward compatible: yes — additive only

## Dependency Audit

**dnd-kit (@dnd-kit/core ^6.3.1, @dnd-kit/sortable ^10.0.0, @dnd-kit/utilities ^3.2.2)**:
- React 19 compatible
- No conflicts with shadcn/ui Sheet
- Lightweight: ~15KB gzipped

## Verification

**Pre-PR gate:**
- `pnpm build` — PASS (zero errors across all 3 packages)
- `pnpm test` — 53 test files, 1124 tests — all pass

**Dispatch-specific tests (`server/src/llm/dispatch-prompts.test.ts`, 35 tests):**
- `buildDispatchSystemPrompt(tone, format)`: all 3 tones × both formats — tone/format-specific copy, banned words, frontmatter instructions
- `buildDispatchContext`: ordering, insight count, type labels, bullet sparse guard, evidence exclusion
- `parseDispatchOutput(raw, 'blog')`: valid parse, YAML quote escaping/unescaping, missing/malformed frontmatter, missing tags
- `parseDispatchOutput(raw, 'linkedin')`: hashtag extraction, empty tldr, body===markdown
- `buildDegradedResponse`: H1 extraction, fallback title, degraded flag

**Dispatch route tests (`server/src/routes/dispatch.test.ts`, 16 tests):**
- Validation: LLM not configured (400), insightIds < 3, insightIds > 8, empty context, context > 500, invalid tone, invalid format
- Happy paths: blog (frontmatter, wordCount, temperature 0.7 passed, system prompt in messages), LinkedIn (hashtags in tags, tldr='', markdown===body), format echoed
- Edge cases: null bullets, parse failure + degraded response, Gemini responseFormat:text regression, blog regression

**API curl example (blog):**
```bash
curl -X POST http://localhost:7890/api/dispatch/generate \
  -H "Content-Type: application/json" \
  -d '{"insightIds":["id1","id2","id3"],"context":"Three weeks debugging SQLite.","tone":"technical","format":"blog"}'
```

**API curl example (linkedin):**
```bash
curl -X POST http://localhost:7890/api/dispatch/generate \
  -H "Content-Type: application/json" \
  -d '{"insightIds":["id1","id2","id3"],"context":"Three weeks debugging SQLite.","tone":"accessible","format":"linkedin"}'
```

## Test plan
- [ ] Select 3-8 insights → FloatingActionBar appears with correct count
- [ ] Open drawer → format selector visible above tone selector, blog default
- [ ] Switch to LinkedIn format → description shows "150-250 words, LinkedIn feed"
- [ ] Blog generate → Preview/Markdown tabs, TL;DR banner, word count, Copy + Download .md
- [ ] LinkedIn generate → plain text preview, character count, Copy (no Download .md, no TL;DR)
- [ ] Drag to reorder → order preserved on generate
- [ ] Remove from drawer → count updates
- [ ] Regenerate → clears result, returns to form
- [ ] API validation: insightIds < 3 → 400; > 8 → 400; context empty → 400; context > 500 → 400
- [ ] API validation: invalid format → 400 with "format must be one of" error
- [ ] No LLM configured → 400 from requireLLM middleware