### PR TITLE
feat(dev): enforce vitest coverage thresholds per TDD domain

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "prepublishOnly": "cd .. && pnpm -r build && cp -r dashboard/dist cli/dashboard-dist && cp -r server/dist cli/server-dist",
     "postpublish": "rm -rf dashboard-dist server-dist"

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -5,4 +5,38 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: ['**/dist/**', '**/node_modules/**'],
   },
+  coverage: {
+    provider: 'v8',
+    include: ['src/**/*.ts'],
+    exclude: ['src/**/*.test.ts', '**/dist/**', '**/node_modules/**'],
+    // Thresholds enforced by `pnpm test:coverage` — not by `pnpm test`.
+    // Set at current actual baseline to prevent regression.
+    // Targets are from docs/QA.md MUST TDD domains (see issue #188 for gap plan).
+    thresholds: {
+      // Parsers — MUST TDD target: 90% | current: ~39% stmts / ~32% branch
+      // Gap plan: add provider unit tests (claude-code, codex, cursor parsing logic)
+      'src/providers/**': {
+        statements: 38,
+        branches: 32,
+        functions: 55,
+        lines: 39,
+      },
+      // Migrations / DB layer — MUST TDD target: 90% | current: ~82% stmts / ~70% branch
+      // Gap plan: add db/client.ts connection + write.ts transaction tests
+      'src/db/**': {
+        statements: 81,
+        branches: 69,
+        functions: 77,
+        lines: 81,
+      },
+      // Shared utilities — MUST TDD target: 85% | current: ~64% stmts / ~54% branch
+      // Gap plan: add utils/ollama-detect.ts and utils/hooks-utils.ts tests
+      'src/utils/**': {
+        statements: 63,
+        branches: 53,
+        functions: 72,
+        lines: 70,
+      },
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "pnpm --filter @code-insights/cli dev",
     "test": "pnpm -r test",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "pnpm --filter @code-insights/cli test:coverage && pnpm --filter @code-insights/server test:coverage"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "engines": {

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -5,4 +5,37 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: ['**/dist/**', '**/node_modules/**'],
   },
+  coverage: {
+    provider: 'v8',
+    include: ['src/**/*.ts'],
+    exclude: ['src/**/*.test.ts', '**/dist/**', '**/node_modules/**'],
+    // Thresholds enforced by `pnpm test:coverage` — not by `pnpm test`.
+    // Set at current actual baseline to prevent regression.
+    // Targets are from docs/QA.md MUST TDD domains (see issue #188 for gap plan).
+    thresholds: {
+      // API routes — SHOULD TDD target: 70% | current: ~82% stmts / ~69% branch
+      // Branches just below 70% target; floor set at current to avoid regression.
+      'src/routes/**': {
+        statements: 81,
+        branches: 68,
+        functions: 78,
+        lines: 82,
+      },
+      // Analysis pricing — MUST TDD target: 85% | current: ~34% stmts / ~48% branch
+      // Gap plan: add unit tests for cost calculation functions in analysis-pricing.ts
+      'src/llm/analysis-pricing.ts': {
+        statements: 34,
+        branches: 47,
+        functions: 66,
+        lines: 33,
+      },
+      // NOTE: response-parsers.ts (MUST TDD target: 85%) shows 0% coverage.
+      // No threshold set here — floor of 0% enforces nothing.
+      // Gap plan: write response-parsers.test.ts before next change to that file.
+      //
+      // NOTE: *-normalize.ts files show 0% in server coverage due to V8
+      // re-export attribution. Implementations live in cli/src/analysis/ (100% covered).
+      // Threshold enforcement is handled by cli/vitest.config.ts.
+    },
+  },
 });


### PR DESCRIPTION
## Summary

Closes #188

Adds per-glob vitest coverage thresholds to `cli/` and `server/` packages so `pnpm test:coverage` fails if any MUST TDD domain drops below its current baseline. Does not block `pnpm test` (fast path stays unaffected).

## Baseline vs Target

| Domain | Target | Stmts | Branch | Status |
|--------|--------|-------|--------|--------|
| `cli/src/providers/**` (parsers) | 90% | 38% | 32% | ❌ gap plan below |
| `cli/src/db/**` (migrations) | 90% | 81% | 69% | ❌ gap plan below |
| `cli/src/utils/**` | 85% | 63% | 53% | ❌ gap plan below |
| `server/src/routes/**` | 70% | 81% | 68% | ⚠️ branches 2% short |
| `server/src/llm/analysis-pricing.ts` | 85% | 34% | 47% | ❌ gap plan below |
| `server/src/llm/response-parsers.ts` | 85% | 0% | 0% | ❌ no floor set yet |
| `server/src/llm/*-normalize.ts` | 85% | 0%* | 0%* | ✅ re-exports; 100% in CLI |

*Normalizer files in server are thin re-export wrappers — V8 attributes coverage to the CLI package where the actual implementations live (100% covered). No server threshold needed.

## Gap Plan

1. **`cli/src/providers/`** — `claude-code.ts` (13%), `codex.ts` (37%), `cursor.ts` (42%) — all below 90% target. Each needs unit tests for its parsing logic (message iteration, tool call detection, event normalization).
2. **`cli/src/db/`** — `db/client.ts` (17%) dragging the domain. Needs connection lifecycle tests.
3. **`cli/src/utils/`** — `ollama-detect.ts` (6%) is the outlier. Needs process-detection mocks.
4. **`server/src/llm/analysis-pricing.ts`** — Cost calculation functions need unit tests before raising the floor.
5. **`server/src/llm/response-parsers.ts`** — 0% with no tests. Must write `response-parsers.test.ts` before the next change to that file.

## Changes

- `cli/vitest.config.ts` — added `coverage` section with per-glob thresholds + gap plan comments
- `server/vitest.config.ts` — added `coverage` section with per-glob thresholds + gap plan comments
- `cli/package.json` — added `test:coverage` script
- `server/package.json` — added `test:coverage` script
- `package.json` (root) — updated `test:coverage` to run per-package (avoids vitest workspace glob resolution issues; thresholds must be evaluated from each package's own root)

## Test plan

- [x] `pnpm --filter @code-insights/cli test:coverage` → 28 tests passed, exit 0
- [x] `pnpm --filter @code-insights/server test:coverage` → 25 tests passed, exit 0
- [x] `pnpm test:coverage` (root) → both run sequentially, exit 0
- [x] `pnpm test` (root, fast path) → unaffected — still `pnpm -r test`, no coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)