### PR TITLE
Activity chart: metric selector + composite & cognitive-load scores

### DIFF
--- a/dashboard/src/components/dashboard/DashboardActivityChart.tsx
+++ b/dashboard/src/components/dashboard/DashboardActivityChart.tsx
@@ -1,5 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
+  BarChart,
+  Bar,
   AreaChart,
   Area,
   XAxis,
@@ -10,16 +12,35 @@ import {
 } from 'recharts';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { useThemeColors } from '@/lib/hooks/useThemeColors';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { CHART_COLORS } from '@/lib/constants/colors';
-import type { DailyStats } from '@/lib/types';
+import { formatTokenCount } from '@/lib/utils';
+import { formatCost } from '@/lib/cost-utils';
+import type { ActivityDay } from '@/lib/types';
 
 type DashboardRange = '7d' | '30d' | '90d' | 'all';
+type MetricKey =
+  | 'composite'
+  | 'cognitive_load'
+  | 'cost'
+  | 'tokens'
+  | 'tool_calls'
+  | 'messages'
+  | 'projects'
+  | 'sessions';
+type CompositeMode = 'weighted' | 'stacked';
 
 interface DashboardActivityChartProps {
-  data: DailyStats[];
+  days: ActivityDay[];
   range: DashboardRange;
   onRangeChange: (range: DashboardRange) => void;
+  isLoading?: boolean;
 }
 
 const rangeOptions: { value: DashboardRange; label: string }[] = [
@@ -29,105 +50,325 @@ const rangeOptions: { value: DashboardRange; label: string }[] = [
   { value: 'all', label: 'All' },
 ];
 
-export function DashboardActivityChart({ data, range, onRangeChange }: DashboardActivityChartProps) {
-  const { tooltipBg, tooltipBorder } = useThemeColors();
+// Metric config. Composite is a weighted blend of the keys in COMPOSITE_KEYS;
+// `sessions` is deliberately excluded from the composite (a count, not effort).
+// Weights match the reference design: cost .30, tokens .25, tool_calls .20,
+// messages .15, projects .10 (sum = 1.0).
+const M = CHART_COLORS.activityMetrics;
+const METRICS: Record<MetricKey, { label: string; color: string; weight?: number; fmt: (n: number) => string }> = {
+  composite:      { label: 'Composite score', color: M.composite,      fmt: (n) => n.toFixed(1) },
+  cognitive_load: { label: 'Cognitive load',  color: M.cognitive_load, fmt: (n) => Math.round(n).toLocaleString() },
+  cost:           { label: 'Cost (USD)',      color: M.cost,       weight: 0.30, fmt: formatCost },
+  tokens:         { label: 'Tokens',          color: M.tokens,     weight: 0.25, fmt: formatTokenCount },
+  tool_calls:     { label: 'Tool calls',      color: M.tool_calls, weight: 0.20, fmt: (n) => Math.round(n).toLocaleString() },
+  messages:       { label: 'Messages',        color: M.messages,   weight: 0.15, fmt: (n) => Math.round(n).toLocaleString() },
+  projects:       { label: 'Projects',        color: M.projects,   weight: 0.10, fmt: (n) => Math.round(n).toLocaleString() },
+  sessions:       { label: 'Sessions',        color: M.sessions,   fmt: (n) => Math.round(n).toLocaleString() },
+};
+const METRIC_ORDER: MetricKey[] = ['composite', 'cognitive_load', 'cost', 'tokens', 'tool_calls', 'messages', 'projects', 'sessions'];
+const COMPOSITE_KEYS = ['cost', 'tokens', 'tool_calls', 'messages', 'projects'] as const;
+const TOTAL_W = COMPOSITE_KEYS.reduce((s, k) => s + (METRICS[k].weight ?? 0), 0);
 
-  const chartData = useMemo(
-    () =>
-      data.map((d) => ({
-        ...d,
-        date: new Date(d.date).toLocaleDateString('en-US', {
-          month: 'short',
-          day: 'numeric',
-        }),
-        // Normalize field names to match recharts dataKey
-        sessionCount: d.session_count,
-        insightCount: d.insight_count,
-      })),
-    [data]
+type CompositeKey = (typeof COMPOSITE_KEYS)[number];
+type NormFactors = Record<CompositeKey, number>;
+
+function computeNormFactors(days: ActivityDay[]): NormFactors {
+  const max = {} as NormFactors;
+  for (const k of COMPOSITE_KEYS) {
+    max[k] = days.reduce((m, d) => Math.max(m, d[k] || 0), 0) || 1;
+  }
+  return max;
+}
+
+// Weighted contribution of metric k for day d, in score points (0..100). The
+// contributions sum to the composite score. Uses a FIXED reference (max across
+// all-time days) so a day's score is stable regardless of the selected range.
+function contribution(d: ActivityDay, k: CompositeKey, norm: NormFactors): number {
+  return 100 * ((METRICS[k].weight ?? 0) / TOTAL_W) * ((d[k] || 0) / norm[k]);
+}
+function composite(d: ActivityDay, norm: NormFactors): number {
+  return COMPOSITE_KEYS.reduce((s, k) => s + contribution(d, k, norm), 0);
+}
+
+function shortNum(n: number): string {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)}K`;
+  return String(Math.round(n));
+}
+function fmtDate(iso: string): string {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+interface ChartRow extends ActivityDay {
+  label: string;
+  score: number;
+  contrib_cost: number;
+  contrib_tokens: number;
+  contrib_tool_calls: number;
+  contrib_messages: number;
+  contrib_projects: number;
+}
+
+// Breakdown tooltip: headline score plus the raw metrics that feed it.
+interface ActivityTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload?: ChartRow }>;
+}
+function ActivityTooltip({ active, payload }: ActivityTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const row = payload[0]?.payload;
+  if (!row) return null;
+
+  const metrics: { label: string; value: string; color?: string }[] = [
+    { label: 'Cognitive load', value: Math.round(row.cognitive_load).toLocaleString(), color: M.cognitive_load },
+    { label: 'Cost', value: formatCost(row.cost), color: M.cost },
+    { label: 'Tokens', value: formatTokenCount(row.tokens), color: M.tokens },
+    { label: 'Tool calls', value: row.tool_calls.toLocaleString(), color: M.tool_calls },
+    { label: 'Messages', value: row.messages.toLocaleString(), color: M.messages },
+    { label: 'Projects', value: row.projects.toLocaleString(), color: M.projects },
+    { label: 'Sessions', value: row.sessions.toLocaleString(), color: M.sessions },
+  ];
+
+  return (
+    <div className="rounded-lg border bg-popover px-3 py-2 text-popover-foreground shadow-md">
+      <div className="mb-1.5 flex items-baseline justify-between gap-4">
+        <span className="text-xs font-medium text-muted-foreground">{row.label}</span>
+        <span className="text-sm font-semibold" style={{ color: M.composite }}>
+          {row.score.toFixed(1)}
+          <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">/100</span>
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+        {metrics.map((m) => (
+          <div key={m.label} className="flex items-center justify-between gap-3 text-xs">
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <span className="h-2 w-2 rounded-[2px]" style={{ backgroundColor: m.color }} />
+              {m.label}
+            </span>
+            <span className="font-medium tabular-nums">{m.value}</span>
+          </div>
+        ))}
+      </div>
+      {row.peak_sessions > 0 && (
+        <div className="mt-1.5 border-t pt-1.5 text-[11px] text-muted-foreground">
+          Peak multitasking: <span className="font-medium text-foreground">{row.peak_sessions}</span> session
+          {row.peak_sessions !== 1 ? 's' : ''} across{' '}
+          <span className="font-medium text-foreground">{row.peak_projects}</span> project
+          {row.peak_projects !== 1 ? 's' : ''}
+        </div>
+      )}
+    </div>
   );
+}
+
+export function DashboardActivityChart({ days, range, onRangeChange, isLoading }: DashboardActivityChartProps) {
+  const [metric, setMetric] = useState<MetricKey>('composite');
+  const [compositeMode, setCompositeMode] = useState<CompositeMode>('weighted');
+
+  const isComposite = metric === 'composite';
+  const stacked = isComposite && compositeMode === 'stacked';
+
+  // Fixed all-time reference — computed across ALL days, never the window.
+  const norm = useMemo(() => computeNormFactors(days), [days]);
+
+  // Window the series client-side; composite scores stay on the fixed reference.
+  const windowed = useMemo(() => {
+    if (range === 'all') return days;
+    const n = range === '7d' ? 7 : range === '30d' ? 30 : 90;
+    return days.slice(-n);
+  }, [days, range]);
+
+  const chartData = useMemo<ChartRow[]>(
+    () =>
+      windowed.map((d) => ({
+        ...d,
+        label: fmtDate(d.date),
+        score: composite(d, norm),
+        contrib_cost: contribution(d, 'cost', norm),
+        contrib_tokens: contribution(d, 'tokens', norm),
+        contrib_tool_calls: contribution(d, 'tool_calls', norm),
+        contrib_messages: contribution(d, 'messages', norm),
+        contrib_projects: contribution(d, 'projects', norm),
+      })),
+    [windowed, norm]
+  );
+
+  // Y-axis zooms to the min/max actually shown. Stacked must start at 0 (layers
+  // sum to the whole); a single series zooms to [min, max] so the quietest day
+  // sits near the floor and the busiest fills the frame.
+  const [yMin, yMax] = useMemo<[number, number]>(() => {
+    const vals = chartData.map((d) => (isComposite ? d.score : (d[metric] ?? 0)));
+    if (vals.length === 0) return [0, 1];
+    const maxShown = Math.max(...vals, 0);
+    const minShown = Math.min(...vals);
+    const baseline = stacked || minShown === maxShown ? 0 : minShown;
+    let yTop = maxShown + (maxShown - baseline) * 0.08;
+    if (yTop <= baseline) yTop = baseline + 1;
+    return [baseline, yTop];
+  }, [chartData, isComposite, metric, stacked]);
+
+  const accent = METRICS[metric].color;
+  const span = windowed.length;
+  const dateSpan = span > 0 ? `${windowed[0].date} → ${windowed[span - 1].date}` : '';
+
+  const tickFormatter = (v: number) => (isComposite ? v.toFixed(0) : shortNum(v));
+  const xInterval = range === '7d' ? 0 : range === '30d' ? 4 : range === '90d' ? 13 : Math.ceil(span / 8);
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between pb-1">
-        <CardTitle className="text-sm font-medium">Activity</CardTitle>
-        <div className="flex gap-1">
-          {rangeOptions.map(({ value, label }) => (
-            <Button
-              key={value}
-              variant={range === value ? 'default' : 'ghost'}
-              size="sm"
-              className="h-7 px-2.5 text-xs"
-              onClick={() => onRangeChange(value)}
-            >
-              {label}
-            </Button>
-          ))}
+      <CardHeader className="space-y-2 pb-1">
+        <div className="flex flex-row items-start justify-between gap-2">
+          <div className="space-y-0.5">
+            <CardTitle className="text-sm font-medium">Activity</CardTitle>
+            <p className="text-[11px] text-muted-foreground">
+              {isComposite
+                ? 'Composite = weighted blend of cost, tokens, tool calls, messages & projects · fixed all-time scale'
+                : metric === 'cognitive_load'
+                ? 'Context-switching load — concurrent sessions × projects², integrated over active time'
+                : `Daily ${METRICS[metric].label.toLowerCase()}`}
+              {dateSpan && ` · ${dateSpan}`}
+            </p>
+          </div>
+          <div className="flex gap-1">
+            {rangeOptions.map(({ value, label }) => (
+              <Button
+                key={value}
+                variant={range === value ? 'default' : 'ghost'}
+                size="sm"
+                className="h-7 px-2.5 text-xs"
+                onClick={() => onRangeChange(value)}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-row items-center gap-2">
+          <Select value={metric} onValueChange={(v) => setMetric(v as MetricKey)}>
+            <SelectTrigger className="h-7 w-[150px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {METRIC_ORDER.map((k) => (
+                <SelectItem key={k} value={k} className="text-xs">
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: METRICS[k].color }} />
+                    {METRICS[k].label}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {isComposite && (
+            <div className="flex overflow-hidden rounded-md border">
+              {(['weighted', 'stacked'] as CompositeMode[]).map((mode) => (
+                <button
+                  key={mode}
+                  onClick={() => setCompositeMode(mode)}
+                  className={`px-2.5 py-1 text-xs capitalize transition-colors ${
+                    compositeMode === mode
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </CardHeader>
       <CardContent>
         <div className="h-[200px]">
-          {chartData.length > 0 ? (
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={chartData}>
-                <defs>
-                  <linearGradient id="dashColorSessions" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={CHART_COLORS.activity.sessions} stopOpacity={0.3} />
-                    <stop offset="95%" stopColor={CHART_COLORS.activity.sessions} stopOpacity={0} />
-                  </linearGradient>
-                  <linearGradient id="dashColorInsights" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor={CHART_COLORS.activity.insights} stopOpacity={0.3} />
-                    <stop offset="95%" stopColor={CHART_COLORS.activity.insights} stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fontSize: 11 }}
-                  tickLine={false}
-                  axisLine={false}
-                  className="text-muted-foreground"
-                  interval={range === '7d' ? 0 : range === '30d' ? 4 : range === '90d' ? 13 : 'preserveStartEnd'}
-                />
-                <YAxis
-                  tick={{ fontSize: 11 }}
-                  tickLine={false}
-                  axisLine={false}
-                  className="text-muted-foreground"
-                  width={30}
-                />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: tooltipBg,
-                    borderColor: tooltipBorder,
-                    borderRadius: '8px',
-                    fontSize: '12px',
-                  }}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="sessionCount"
-                  name="Sessions"
-                  stroke={CHART_COLORS.activity.sessions}
-                  fillOpacity={1}
-                  fill="url(#dashColorSessions)"
-                />
-                <Area
-                  type="monotone"
-                  dataKey="insightCount"
-                  name="Insights"
-                  stroke={CHART_COLORS.activity.insights}
-                  fillOpacity={1}
-                  fill="url(#dashColorInsights)"
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          ) : (
+          {isLoading || chartData.length === 0 ? (
             <div className="flex h-full items-center justify-center">
-              <p className="text-sm text-muted-foreground">No activity data yet</p>
+              <p className="text-sm text-muted-foreground">
+                {isLoading ? 'Loading activity…' : 'No activity data yet'}
+              </p>
             </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              {stacked ? (
+                // Stacked composite → bar chart (layers sum to the score)
+                <BarChart data={chartData} barCategoryGap={span > 60 ? 1 : span > 30 ? '10%' : '20%'}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-muted-foreground"
+                    interval={xInterval}
+                  />
+                  <YAxis
+                    domain={[yMin, yMax]}
+                    allowDataOverflow
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-muted-foreground"
+                    width={38}
+                    tickFormatter={tickFormatter}
+                  />
+                  <Tooltip content={<ActivityTooltip />} cursor={{ fill: 'currentColor', opacity: 0.05 }} />
+                  {COMPOSITE_KEYS.map((k) => (
+                    <Bar key={k} dataKey={`contrib_${k}`} stackId="composite" fill={METRICS[k].color} />
+                  ))}
+                </BarChart>
+              ) : (
+                // Weighted composite & single metrics → area/line chart
+                <AreaChart data={chartData}>
+                  <defs>
+                    <linearGradient id="activityAccentFill" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor={accent} stopOpacity={0.3} />
+                      <stop offset="95%" stopColor={accent} stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-muted-foreground"
+                    interval={xInterval}
+                  />
+                  <YAxis
+                    domain={[yMin, yMax]}
+                    allowDataOverflow
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    className="text-muted-foreground"
+                    width={38}
+                    tickFormatter={tickFormatter}
+                  />
+                  <Tooltip content={<ActivityTooltip />} cursor={{ stroke: accent, strokeOpacity: 0.3 }} />
+                  <Area
+                    type="monotone"
+                    dataKey={isComposite ? 'score' : metric}
+                    stroke={accent}
+                    strokeWidth={2}
+                    fillOpacity={1}
+                    fill="url(#activityAccentFill)"
+                  />
+                </AreaChart>
+              )}
+            </ResponsiveContainer>
           )}
         </div>
+        {/* Legend — stacked composite shows the weighted layers */}
+        {stacked && (
+          <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+            {COMPOSITE_KEYS.map((k) => (
+              <span key={k} className="flex items-center gap-1.5">
+                <span className="h-2.5 w-2.5 rounded-[2px]" style={{ backgroundColor: METRICS[k].color }} />
+                {METRICS[k].label} ({Math.round((METRICS[k].weight ?? 0) * 100)}%)
+              </span>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/dashboard/src/hooks/index.ts
+++ b/dashboard/src/hooks/index.ts
@@ -2,7 +2,7 @@ export { useProjects, useProject } from './useProjects';
 export { useSessions, useSession, useSessionMutation, useDeleteSession, useDeletedSessionCount } from './useSessions';
 export { useInsights, useDeleteInsight } from './useInsights';
 export { useMessages } from './useMessages';
-export { useDashboardStats } from './useAnalytics';
+export { useDashboardStats, useActivity } from './useAnalytics';
 export { useAnalyzeSession } from './useAnalysis';
 export { useLlmConfig, useSaveLlmConfig } from './useConfig';
 export { useExportMarkdown } from './useExport';

--- a/dashboard/src/hooks/useAnalytics.ts
+++ b/dashboard/src/hooks/useAnalytics.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchDashboardStats } from '@/lib/api';
+import { fetchDashboardStats, fetchActivity } from '@/lib/api';
 
 type Range = '7d' | '30d' | '90d' | 'all';
 
@@ -7,6 +7,16 @@ export function useDashboardStats(range: Range = '7d') {
   return useQuery({
     queryKey: ['analytics', 'dashboard', range],
     queryFn: () => fetchDashboardStats(range).then((r) => r.stats),
+    refetchInterval: 60_000,
+  });
+}
+
+// All-time per-day activity series. Range-independent: the Activity chart slices
+// the window client-side so the composite score keeps a fixed all-time reference.
+export function useActivity() {
+  return useQuery({
+    queryKey: ['analytics', 'activity'],
+    queryFn: () => fetchActivity().then((r) => r.days),
     refetchInterval: 60_000,
   });
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -2,7 +2,7 @@
 // Base URL is relative in production (SPA served by the same server).
 // In Vite dev mode, the proxy forwards /api -> localhost:7890.
 
-import type { Project, Session, Message, Insight, DashboardStats, LLMConfig, ExportTemplate, FacetRow } from '@/lib/types';
+import type { Project, Session, Message, Insight, DashboardStats, ActivityDay, LLMConfig, ExportTemplate, FacetRow } from '@/lib/types';
 
 const BASE = '/api';
 
@@ -132,6 +132,10 @@ export function fetchSearch(params: { q: string; limit?: number }) {
 
 export function fetchDashboardStats(range: '7d' | '30d' | '90d' | 'all' = '7d') {
   return request<{ range: string; stats: DashboardStats }>(`/analytics/dashboard?range=${range}`);
+}
+
+export function fetchActivity() {
+  return request<{ days: ActivityDay[] }>(`/analytics/activity`);
 }
 
 // ── Analysis (Phase 4) ────────────────────────────────────────────────────────

--- a/dashboard/src/lib/constants/colors.ts
+++ b/dashboard/src/lib/constants/colors.ts
@@ -121,6 +121,17 @@ export const CHART_COLORS = {
     sessions: '#3b82f6',  // blue-500
     insights: '#22c55e',  // green-500
   },
+  // Activity chart metric selector — per-metric accent + stacked composite layers
+  activityMetrics: {
+    composite: '#6366f1',      // indigo-500
+    cost: '#10b981',           // emerald-500
+    tokens: '#3b82f6',         // blue-500
+    tool_calls: '#f59e0b',     // amber-500
+    messages: '#ec4899',       // pink-500
+    projects: '#a855f7',       // purple-500
+    sessions: '#64748b',       // slate-500
+    cognitive_load: '#ef4444', // red-500 — context-switching intensity
+  },
   // Top projects bar chart
   projects: {
     sessions: '#3b82f6',  // blue-500

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -125,6 +125,28 @@ export interface DailyStats {
   estimated_cost_usd?: number;
 }
 
+// Per-day activity series from /api/analytics/activity.
+// All-time, gap-filled (zero-filled) calendar days. Powers the Activity chart's
+// metric selector and composite score. Metric defs match the CLI dashboard:
+//   tokens = input + output + cache_creation + cache_read
+//   cost   = SUM(estimated_cost_usd)
+export interface ActivityDay {
+  date: string;          // YYYY-MM-DD (local calendar day, from started_at)
+  sessions: number;
+  projects: number;      // distinct projects touched that day
+  messages: number;
+  tool_calls: number;
+  tokens: number;
+  cost: number;
+  // Cognitive load: integral of (concurrent warm sessions × concurrent warm
+  // projects²) over the day's active minutes. A human turn keeps a session "warm"
+  // for ~15 min; cross-project concurrency compounds steeply (S×P²). Idle sessions
+  // cool off and add nothing — captures context-switching cost, not raw volume.
+  cognitive_load: number;
+  peak_sessions: number;  // max concurrent warm sessions in any single minute
+  peak_projects: number;  // max concurrent warm projects in any single minute
+}
+
 /**
  * Safely parse a JSON-encoded string field from the SQLite API response.
  * Returns defaultValue if the field is null, empty, or invalid JSON.

--- a/dashboard/src/pages/DashboardPage.tsx
+++ b/dashboard/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router';
-import { useDashboardStats } from '@/hooks/useAnalytics';
+import { useDashboardStats, useActivity } from '@/hooks/useAnalytics';
 import { useSessions } from '@/hooks/useSessions';
 import { useInsights } from '@/hooks/useInsights';
 import { useProjects } from '@/hooks/useProjects';
@@ -12,7 +12,6 @@ import { StatsHeroSkeleton } from '@/components/skeletons/StatsHeroSkeleton';
 import { ErrorCard } from '@/components/ErrorCard';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import type { DailyStats } from '@/lib/types';
 import { Sparkles, ArrowRight } from 'lucide-react';
 
 type DashboardRange = '7d' | '30d' | '90d' | 'all';
@@ -28,6 +27,7 @@ export default function DashboardPage() {
   const [range, setRange] = useState<DashboardRange>('7d');
 
   const { data: dashStats, isLoading: statsLoading, isError: statsError, refetch: refetchStats } = useDashboardStats(range);
+  const { data: activityDays = [], isLoading: activityLoading } = useActivity();
   const { data: sessions = [], isLoading: sessionsLoading, isError: sessionsError, refetch: refetchSessions } = useSessions({ limit: 500 });
   const { data: insights = [], isLoading: insightsLoading } = useInsights();
   const { data: projects = [] } = useProjects();
@@ -43,35 +43,6 @@ export default function DashboardPage() {
   // Sessions not yet analyzed
   const analyzedSessionIds = new Set(insights.map((i) => i.session_id));
   const unanalyzedSessions = sessions.filter((s) => !analyzedSessionIds.has(s.id));
-
-  // Build daily stats for activity chart
-  const dailyStats: DailyStats[] = useMemo(() => {
-    const now = Date.now();
-    const rangeDays = range === '7d' ? 7 : range === '30d' ? 30 : range === '90d' ? 90 : Infinity;
-    const cutoff = rangeDays === Infinity ? 0 : now - rangeDays * 86_400_000;
-
-    const grouped: Record<string, { session_count: number; insight_count: number }> = {};
-    for (const s of sessions) {
-      if (new Date(s.started_at).getTime() < cutoff) continue;
-      const date = s.started_at.slice(0, 10);
-      if (!grouped[date]) grouped[date] = { session_count: 0, insight_count: 0 };
-      grouped[date].session_count++;
-    }
-    for (const i of insights) {
-      if (new Date(i.timestamp).getTime() < cutoff) continue;
-      const date = i.timestamp.slice(0, 10);
-      if (!grouped[date]) grouped[date] = { session_count: 0, insight_count: 0 };
-      grouped[date].insight_count++;
-    }
-    return Object.entries(grouped)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, counts]) => ({
-        date,
-        session_count: counts.session_count,
-        message_count: 0,
-        insight_count: counts.insight_count,
-      }));
-  }, [sessions, insights, range]);
 
   // Compute stats for hero — all from dashStats (range-filtered)
   const totalTokens = dashStats
@@ -153,7 +124,12 @@ export default function DashboardPage() {
         </Card>
       ) : (
         <div className="animate-in fade-in slide-in-from-bottom-2 duration-300 delay-150">
-          <DashboardActivityChart data={dailyStats} range={range} onRangeChange={setRange} />
+          <DashboardActivityChart
+            days={activityDays}
+            range={range}
+            onRangeChange={setRange}
+            isLoading={activityLoading}
+          />
         </div>
       )}
 

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -53,6 +53,118 @@ app.get('/dashboard', (c) => {
   return c.json({ range, stats });
 });
 
+// Cognitive-load model: a human turn keeps its session "warm" for ATTENTION_MIN
+// minutes. While warm, the session contributes to concurrent multitasking. Load
+// at any minute = (concurrent warm sessions) × (concurrent warm projects)² — the
+// projects term is squared so juggling across multiple projects compounds far
+// faster than stacking sessions within one project. Daily load integrates that
+// over the day's active minutes (1-minute resolution). Truly idle sessions emit
+// no human turns, so they go cold and add nothing — matching the intuition that
+// a long unattended session is cheap, but rapid switching is expensive.
+const ATTENTION_MIN = 15;
+const MS_PER_MIN = 60_000;
+
+interface CognitiveDay {
+  cognitive_load: number; // Σ (sessions × projects²) over active minutes
+  peak_sessions: number;  // max concurrent warm sessions in any minute
+  peak_projects: number;  // max concurrent warm projects in any minute
+}
+
+function computeCognitiveLoad(db: ReturnType<typeof getDb>): Map<string, CognitiveDay> {
+  // Genuine human turns only: type='user' AND non-empty content. (type='user'
+  // with empty content is an automated tool-result message, not a human pulse.)
+  const pulses = db.prepare(`
+    SELECT m.timestamp AS t, m.session_id AS sid, s.project_id AS pid
+    FROM messages m
+    JOIN sessions s ON s.id = m.session_id
+    WHERE m.type = 'user' AND m.content <> '' AND s.deleted_at IS NULL
+    ORDER BY m.timestamp
+  `).all() as Array<{ t: string; sid: string; pid: string }>;
+
+  // Spread each pulse across the warm window into 1-minute buckets, tracking the
+  // distinct sessions and projects live in each minute.
+  const buckets = new Map<number, { sessions: Set<string>; projects: Set<string> }>();
+  for (const p of pulses) {
+    const startMin = Math.floor(new Date(p.t).getTime() / MS_PER_MIN);
+    for (let k = 0; k < ATTENTION_MIN; k++) {
+      const mi = startMin + k;
+      let b = buckets.get(mi);
+      if (!b) { b = { sessions: new Set(), projects: new Set() }; buckets.set(mi, b); }
+      b.sessions.add(p.sid);
+      b.projects.add(p.pid);
+    }
+  }
+
+  const byDate = new Map<string, CognitiveDay>();
+  for (const [mi, b] of buckets) {
+    const date = new Date(mi * MS_PER_MIN).toISOString().slice(0, 10);
+    const s = b.sessions.size;
+    const pr = b.projects.size;
+    const d = byDate.get(date) ?? { cognitive_load: 0, peak_sessions: 0, peak_projects: 0 };
+    d.cognitive_load += s * pr * pr;
+    if (s > d.peak_sessions) d.peak_sessions = s;
+    if (pr > d.peak_projects) d.peak_projects = pr;
+    byDate.set(date, d);
+  }
+  return byDate;
+}
+
+// Per-day activity series (all-time, gap-filled) for the Activity chart.
+// One row per calendar day from the first recorded session to the last, with
+// zero-filled gaps so the timeline has no holes. Metric definitions match the
+// CLI dashboard: tokens = input+output+cache_creation+cache_read.
+app.get('/activity', (c) => {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT substr(started_at, 1, 10) AS date,
+           COUNT(*) AS sessions,
+           COUNT(DISTINCT project_id) AS projects,
+           COALESCE(SUM(message_count), 0) AS messages,
+           COALESCE(SUM(tool_call_count), 0) AS tool_calls,
+           COALESCE(SUM(
+             COALESCE(total_input_tokens, 0) + COALESCE(total_output_tokens, 0)
+             + COALESCE(cache_creation_tokens, 0) + COALESCE(cache_read_tokens, 0)
+           ), 0) AS tokens,
+           COALESCE(SUM(estimated_cost_usd), 0) AS cost
+    FROM sessions
+    WHERE deleted_at IS NULL AND started_at IS NOT NULL AND started_at <> ''
+    GROUP BY date
+    ORDER BY date
+  `).all() as Array<{
+    date: string;
+    sessions: number;
+    projects: number;
+    messages: number;
+    tool_calls: number;
+    tokens: number;
+    cost: number;
+  }>;
+
+  if (rows.length === 0) return c.json({ days: [] });
+
+  const cognitive = computeCognitiveLoad(db);
+  const zeroCog: CognitiveDay = { cognitive_load: 0, peak_sessions: 0, peak_projects: 0 };
+
+  // Gap-fill every calendar day between the first and last recorded day.
+  const byDate = new Map(rows.map((r) => [r.date, r]));
+  const days = [];
+  const oneDay = 86_400_000;
+  const start = new Date(`${rows[0].date}T00:00:00Z`).getTime();
+  const end = new Date(`${rows[rows.length - 1].date}T00:00:00Z`).getTime();
+  for (let t = start; t <= end; t += oneDay) {
+    const date = new Date(t).toISOString().slice(0, 10);
+    const r = byDate.get(date);
+    const cog = cognitive.get(date) ?? zeroCog;
+    days.push(
+      r
+        ? { ...r, tokens: Math.round(r.tokens), cost: Math.round(r.cost * 100) / 100, ...cog }
+        : { date, sessions: 0, projects: 0, messages: 0, tool_calls: 0, tokens: 0, cost: 0, ...cog }
+    );
+  }
+
+  return c.json({ days });
+});
+
 // Global cumulative usage stats
 app.get('/usage', (c) => {
   const db = getDb();


### PR DESCRIPTION
## What

Turns the dashboard **Activity** card from a fixed sessions/insights chart into a metric explorer, and adds two derived scores: a **Composite** activity score and a **Cognitive load** score.

### Metric selector
A dropdown to plot any of: **Composite score · Cognitive load · Cost · Tokens · Tool calls · Messages · Projects · Sessions**, over 7d / 30d / 90d / All.

### Composite score
Weighted blend — cost .30, tokens .25, tool calls .20, messages .15, projects .10 — on a **fixed all-time reference**, so a given day's score is stable when you change the range (only the y-axis zoom changes). Toggle between **Weighted** (single area) and **Stacked** (per-metric bars summing to the score).

### Cognitive load (context-switching cost)
Volume metrics miss *multitasking* cost. This models it:
- Each genuine human turn (`type='user'` with non-empty content — not automated tool-result messages) keeps its session **"warm" for 15 minutes**.
- Load at each minute = **(concurrent warm sessions) × (concurrent warm projects)²** — projects compound, since juggling across repos is far more expensive than stacking sessions in one.
- Daily load integrates that over active minutes. Idle/autonomous sessions emit no human turns, so they go cold and add nothing.
- The tooltip surfaces peak concurrency, e.g. *"Peak multitasking: 7 sessions across 3 projects."*

## How

**Server** — new `GET /api/analytics/activity` returns an all-time, gap-filled per-day series. Metric definitions match the CLI dashboard (`tokens = input+output+cache_creation+cache_read`). Cognitive load is computed from a single ordered pass over human-turn message timestamps joined to their project.

**Dashboard** — single-series metrics render as a gradient area, stacked composite as bars; y-axis zooms to the visible min/max; rich breakdown tooltip. Adds `useActivity()` hook, `fetchActivity()` client, `ActivityDay` type, and centralized per-metric colors. Reuses existing shadcn `Card` / recharts / theme for visual consistency.

## Notes
- No schema changes; reads existing `sessions` / `messages` tables.
- Cognitive-load window (15 min) and the projects² weighting are easy to tune in `computeCognitiveLoad`.
- Screenshots (weighted area, stacked bars, cognitive-load + tooltip) can be added to this description.
