### PR TITLE
feat: make conversation analysis durable and serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ code-insights install-hook             # auto-sync + auto-analyze when sessions 
 
 See [`cli/README.md`](cli/README.md) for the full CLI reference.
 
+### Optional macOS Scheduled Maintenance
+
+When running from a source checkout, you can install one daily LaunchAgent plus
+the Claude Code SessionEnd hook:
+
+```bash
+./automation/install-launchd.sh --install
+```
+
+The daily job runs at 03:15 and uses a shared process lock to keep scheduled,
+hook, direct CLI, and dashboard LLM work strictly serial. It syncs every
+supported source, drains up to 5 durable hook jobs, then analyzes the remaining
+sessions newest-first in batches of 5 (up to 50 per day). Quarantined failures
+are retried on a later run. The previous complete ISO week is refreshed only
+when its analyzed-session count or extracted facet content changes. Logs are
+stored under `~/.code-insights/logs/`.
+
+```bash
+./automation/install-launchd.sh --uninstall
+```
+
 ---
 
 ## Architecture

--- a/automation/code-insights-maintenance.sh
+++ b/automation/code-insights-maintenance.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# Daily, strictly serial maintenance: sync -> bounded analysis -> weekly reflect.
+
+set -uo pipefail
+umask 077
+
+ORIGINAL_ARGS=("$@")
+
+if [[ "${1:-run}" != "run" ]]; then
+  printf 'Usage: %s run\n' "$0" >&2
+  exit 64
+fi
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONFIG_DIR="${CODE_INSIGHTS_CONFIG_DIR:-$HOME/.code-insights}"
+DB="${CODE_INSIGHTS_DB:-$CONFIG_DIR/data.db}"
+ANALYZE_SCRIPT="${CODE_INSIGHTS_ANALYZE_SCRIPT:-$ROOT/throttled-analyze.sh}"
+SQLITE_BIN="${CODE_INSIGHTS_SQLITE_BIN:-$(command -v sqlite3 2>/dev/null || true)}"
+CURL_BIN="${CODE_INSIGHTS_CURL_BIN:-$(command -v curl 2>/dev/null || true)}"
+CODE_INSIGHTS_BIN="${CODE_INSIGHTS_BIN:-$(command -v code-insights 2>/dev/null || true)}"
+LOOKBACK_DAYS="${CODE_INSIGHTS_LOOKBACK_DAYS:-36500}"
+BATCH_SIZE="${CODE_INSIGHTS_BATCH_SIZE:-5}"
+MAX_BATCHES="${CODE_INSIGHTS_MAX_BATCHES:-10}"
+DELAY="${CODE_INSIGHTS_DELAY:-10}"
+QUEUE_LIMIT="${CODE_INSIGHTS_QUEUE_LIMIT:-5}"
+FAIL_LOG="${CODE_INSIGHTS_FAIL_LOG:-$CONFIG_DIR/throttled-analyze.failures}"
+LOG_DIR="${CODE_INSIGHTS_LOG_DIR:-$CONFIG_DIR/logs}"
+RUN_LOG="$LOG_DIR/maintenance-$(date '+%Y%m%dT%H%M%S').log"
+DASHBOARD_PORT=7890
+DASHBOARD_URL='http://127.0.0.1:7890'
+DASHBOARD_CAN_START_LOCAL=1
+
+DASHBOARD_PID=""
+
+log() {
+  printf '[%s] %s\n' "$(date -Iseconds)" "$*" | tee -a "$RUN_LOG"
+}
+
+stop_dashboard() {
+  if [[ -n "$DASHBOARD_PID" ]] && kill -0 "$DASHBOARD_PID" 2>/dev/null; then
+    kill "$DASHBOARD_PID" 2>/dev/null || true
+    wait "$DASHBOARD_PID" 2>/dev/null || true
+  fi
+  DASHBOARD_PID=""
+}
+
+cleanup() {
+  stop_dashboard
+}
+
+exit_for_signal() {
+  exit "$1"
+}
+
+trap cleanup EXIT
+trap 'exit_for_signal 130' INT
+trap 'exit_for_signal 143' TERM
+
+is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+read_configured_dashboard_port() {
+  local config_file="$CONFIG_DIR/config.json"
+  local candidate=""
+  local authority=""
+
+  if [[ -n "${CODE_INSIGHTS_DASHBOARD_URL:-}" ]]; then
+    DASHBOARD_URL="${CODE_INSIGHTS_DASHBOARD_URL%/}"
+    DASHBOARD_CAN_START_LOCAL=0
+    case "$DASHBOARD_URL" in
+      http://*)
+        candidate=80
+        authority=${DASHBOARD_URL#http://}
+        ;;
+      https://*)
+        candidate=443
+        authority=${DASHBOARD_URL#https://}
+        ;;
+      *)
+        log "Invalid CODE_INSIGHTS_DASHBOARD_URL: $DASHBOARD_URL"
+        return 64
+        ;;
+    esac
+    authority=${authority%%/*}
+    if [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+      candidate=${BASH_REMATCH[1]}
+    elif [[ "$authority" =~ :([0-9]+)$ ]]; then
+      candidate=${BASH_REMATCH[1]}
+    elif [[ "$authority" == *:* ]]; then
+      log "Invalid CODE_INSIGHTS_DASHBOARD_URL port: $DASHBOARD_URL"
+      return 64
+    fi
+    if ! is_uint "$candidate" || [[ "$candidate" -lt 1 || "$candidate" -gt 65535 ]]; then
+      log "Invalid CODE_INSIGHTS_DASHBOARD_URL port: $DASHBOARD_URL"
+      return 64
+    fi
+    if [[ "$DASHBOARD_URL" =~ ^http://(127\.0\.0\.1|localhost)(:[0-9]+)?$ ]] \
+      || [[ "$DASHBOARD_URL" =~ ^http://\[::1\](:[0-9]+)?$ ]]; then
+      DASHBOARD_CAN_START_LOCAL=1
+    fi
+    DASHBOARD_PORT="$candidate"
+    return 0
+  fi
+
+  if [[ -f "$config_file" ]]; then
+    if command -v plutil >/dev/null 2>&1; then
+      candidate=$(plutil -extract dashboard.port raw "$config_file" 2>/dev/null || true)
+    fi
+    if [[ -z "$candidate" ]] && command -v node >/dev/null 2>&1; then
+      candidate=$(node -e '
+        try {
+          const value = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))?.dashboard?.port;
+          if (value !== undefined) process.stdout.write(String(value));
+        } catch {}
+      ' "$config_file" 2>/dev/null || true)
+    fi
+  fi
+
+  if [[ -n "$candidate" ]]; then
+    if ! is_uint "$candidate" || [[ "$candidate" -lt 1 || "$candidate" -gt 65535 ]]; then
+      log "Invalid dashboard port in $config_file: $candidate"
+      return 64
+    fi
+    DASHBOARD_PORT="$candidate"
+  fi
+  DASHBOARD_URL="http://127.0.0.1:$DASHBOARD_PORT"
+}
+
+validate_environment() {
+  is_uint "$LOOKBACK_DAYS" && [[ "$LOOKBACK_DAYS" -gt 0 ]] || { log 'Invalid CODE_INSIGHTS_LOOKBACK_DAYS'; return 64; }
+  is_uint "$BATCH_SIZE" && [[ "$BATCH_SIZE" -gt 0 ]] || { log 'Invalid CODE_INSIGHTS_BATCH_SIZE'; return 64; }
+  is_uint "$MAX_BATCHES" && [[ "$MAX_BATCHES" -gt 0 ]] || { log 'Invalid CODE_INSIGHTS_MAX_BATCHES'; return 64; }
+  is_uint "$DELAY" || { log 'Invalid CODE_INSIGHTS_DELAY'; return 64; }
+  is_uint "$QUEUE_LIMIT" && [[ "$QUEUE_LIMIT" -gt 0 ]] || { log 'Invalid CODE_INSIGHTS_QUEUE_LIMIT'; return 64; }
+  [[ -n "$CODE_INSIGHTS_BIN" && -x "$CODE_INSIGHTS_BIN" ]] || { log 'code-insights executable not found'; return 69; }
+  [[ -n "$SQLITE_BIN" && -x "$SQLITE_BIN" ]] || { log 'sqlite3 executable not found'; return 69; }
+  [[ -n "$CURL_BIN" && -x "$CURL_BIN" ]] || { log 'curl executable not found'; return 69; }
+  [[ -x "$ANALYZE_SCRIPT" ]] || { log "Analysis script is not executable: $ANALYZE_SCRIPT"; return 69; }
+  [[ -f "$DB" ]] || { log "Database not found: $DB"; return 66; }
+  read_configured_dashboard_port || return $?
+}
+
+run_pending_queue() {
+  log "Processing up to $QUEUE_LIMIT durable hook queue item(s), newest first."
+  local output status
+  output=$(NO_COLOR=1 "$CODE_INSIGHTS_BIN" queue process -q --limit "$QUEUE_LIMIT" --delay "$DELAY" 2>&1)
+  status=$?
+  [[ -z "$output" ]] || printf '%s\n' "$output" | tee -a "$RUN_LOG"
+  if [[ "$status" -eq 75 ]]; then
+    log 'Queue processing was deferred because another LLM process holds the lock.'
+  elif [[ "$status" -ne 0 ]]; then
+    log "Queue processing failed with status $status; continuing with bounded database analysis."
+  fi
+  return "$status"
+}
+
+run_sync() {
+  log 'Syncing all supported conversation sources.'
+  local output status
+  output=$(NO_COLOR=1 "$CODE_INSIGHTS_BIN" sync 2>&1)
+  status=$?
+  printf '%s\n' "$output" | tee -a "$RUN_LOG"
+  if [[ "$status" -ne 0 ]] || grep -Eq 'Errors:[[:space:]]*[1-9][0-9]*' <<< "$output"; then
+    log 'Sync completed with errors; continuing with safely imported sessions.'
+    return 1
+  fi
+  return 0
+}
+
+run_analysis_batch() {
+  local output status
+  output=$(NO_COLOR=1 "$ANALYZE_SCRIPT" \
+    --days "$LOOKBACK_DAYS" \
+    --batch-size "$BATCH_SIZE" \
+    --delay "$DELAY" \
+    "$@" 2>&1)
+  status=$?
+  printf '%s\n' "$output" | tee -a "$RUN_LOG"
+  ANALYSIS_OUTPUT="$output"
+  return "$status"
+}
+
+drain_analysis() {
+  local had_failures=0
+  local status batch
+
+  # Retry a bounded set quarantined by an earlier day. Failures created during
+  # this run are intentionally deferred until tomorrow.
+  if [[ -s "$FAIL_LOG" ]]; then
+    log "Retrying up to $BATCH_SIZE previously quarantined session(s)."
+    run_analysis_batch --retry-failed
+    status=$?
+    if [[ "$status" -eq 2 ]]; then
+      log 'Rate limit reached while retrying; stopping until the next schedule.'
+      return 2
+    elif [[ "$status" -ne 0 ]]; then
+      had_failures=1
+    fi
+  fi
+
+  for ((batch = 1; batch <= MAX_BATCHES; batch++)); do
+    log "Analysis batch $batch/$MAX_BATCHES (newest sessions first)."
+    run_analysis_batch
+    status=$?
+
+    if [[ "$status" -eq 2 ]]; then
+      log 'Rate limit reached; stopping until the next schedule.'
+      return 2
+    elif [[ "$status" -ne 0 ]]; then
+      had_failures=1
+    fi
+
+    if grep -Eq '^Selected:[[:space:]]+0 session' <<< "$ANALYSIS_OUTPUT"; then
+      log 'No incomplete sessions remain outside quarantine.'
+      return "$had_failures"
+    fi
+    if ! grep -Eq '^Selected:[[:space:]]+[0-9]+ session' <<< "$ANALYSIS_OUTPUT"; then
+      log 'Could not determine batch selection count.'
+      return 1
+    fi
+  done
+
+  log "Reached the daily cap of $((BATCH_SIZE * MAX_BATCHES)) sessions; remaining work will resume tomorrow."
+  return "$had_failures"
+}
+
+calendar_values() {
+  if [[ -n "${CODE_INSIGHTS_REFLECT_WEEK:-}" && -n "${CODE_INSIGHTS_CURRENT_WEEK_START:-}" ]]; then
+    REFLECT_WEEK="$CODE_INSIGHTS_REFLECT_WEEK"
+    CURRENT_WEEK_START="$CODE_INSIGHTS_CURRENT_WEEK_START"
+  # The server interprets YYYY-WNN boundaries as UTC Monday-to-Monday, so the
+  # scheduler must use UTC too (especially during early Monday hours in Asia).
+  elif date -u -v-1d '+%Y-%m-%d' >/dev/null 2>&1; then
+    local weekday offset
+    weekday=$(date -u '+%u')
+    offset=$((weekday - 1))
+    CURRENT_WEEK_START=$(date -u -v-"${offset}"d '+%Y-%m-%d')
+    REFLECT_WEEK=$(date -u -v-7d '+%G-W%V')
+  else
+    CURRENT_WEEK_START=$(date -u -d 'monday this week' '+%Y-%m-%d')
+    REFLECT_WEEK=$(date -u -d '7 days ago' '+%G-W%V')
+  fi
+
+  [[ "$REFLECT_WEEK" =~ ^[0-9]{4}-W[0-9]{2}$ ]] || return 1
+  [[ "$CURRENT_WEEK_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+}
+
+dashboard_is_healthy() {
+  "$CURL_BIN" --fail --silent --show-error --max-time 2 \
+    "${DASHBOARD_URL%/}/api/health" >/dev/null 2>&1
+}
+
+ensure_dashboard() {
+  if dashboard_is_healthy; then
+    return 0
+  fi
+
+  if [[ "$DASHBOARD_CAN_START_LOCAL" -ne 1 ]]; then
+    log 'Explicit dashboard URL is unavailable; cannot start a local replacement.'
+    return 1
+  fi
+
+  log 'Starting a temporary dashboard server for reflection.'
+  NO_COLOR=1 "$CODE_INSIGHTS_BIN" dashboard --no-open --no-sync --port "$DASHBOARD_PORT" >> "$RUN_LOG" 2>&1 &
+  DASHBOARD_PID=$!
+
+  local attempt
+  for ((attempt = 1; attempt <= 30; attempt++)); do
+    if dashboard_is_healthy; then
+      return 0
+    fi
+    if ! kill -0 "$DASHBOARD_PID" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  log 'Dashboard did not become healthy within 30 seconds.'
+  return 1
+}
+
+refresh_previous_week() {
+  if ! calendar_values; then
+    log 'Could not calculate the previous ISO week.'
+    return 1
+  fi
+
+  local facet_count snapshot_session_count snapshot_content_stale output status refreshed_count
+  facet_count=$("$SQLITE_BIN" "$DB" "
+    SELECT COUNT(*)
+    FROM session_facets sf
+    JOIN sessions s ON s.id = sf.session_id
+    WHERE s.deleted_at IS NULL
+      AND datetime(s.started_at) >= datetime('$CURRENT_WEEK_START', '-7 days')
+      AND datetime(s.started_at) < datetime('$CURRENT_WEEK_START');
+  ") || return 1
+  snapshot_session_count=$("$SQLITE_BIN" "$DB" "
+    SELECT session_count
+    FROM reflect_snapshots
+    WHERE period = '$REFLECT_WEEK' AND project_id = '__all__';
+  ") || return 1
+  snapshot_content_stale=$("$SQLITE_BIN" "$DB" "
+    SELECT CASE
+      WHEN datetime(MAX(sf.extracted_at)) > datetime((
+        SELECT generated_at
+        FROM reflect_snapshots
+        WHERE period = '$REFLECT_WEEK' AND project_id = '__all__'
+      )) THEN 1
+      ELSE 0
+    END
+    FROM session_facets sf
+    JOIN sessions s ON s.id = sf.session_id
+    WHERE s.deleted_at IS NULL
+      AND datetime(s.started_at) >= datetime('$CURRENT_WEEK_START', '-7 days')
+      AND datetime(s.started_at) < datetime('$CURRENT_WEEK_START');
+  ") || return 1
+
+  [[ "$facet_count" =~ ^[0-9]+$ ]] || { log 'Invalid weekly facet count from database.'; return 1; }
+  [[ -z "$snapshot_session_count" || "$snapshot_session_count" =~ ^[0-9]+$ ]] || { log 'Invalid snapshot session count from database.'; return 1; }
+  [[ "$snapshot_content_stale" =~ ^[01]$ ]] || { log 'Invalid snapshot freshness result from database.'; return 1; }
+
+  if [[ "$facet_count" -lt 8 ]]; then
+    log "Skipping $REFLECT_WEEK reflection: $facet_count analyzed session(s), minimum is 8."
+    return 0
+  fi
+  if [[ "$snapshot_session_count" == "$facet_count" && "$snapshot_content_stale" -eq 0 ]]; then
+    log "Reflection for $REFLECT_WEEK is already current ($facet_count facets)."
+    return 0
+  fi
+
+  ensure_dashboard || return 1
+  log "Refreshing reflection for $REFLECT_WEEK (${snapshot_session_count:-none} -> $facet_count analyzed sessions)."
+  output=$(NO_COLOR=1 "$CODE_INSIGHTS_BIN" reflect --week "$REFLECT_WEEK" 2>&1)
+  status=$?
+  printf '%s\n' "$output" | tee -a "$RUN_LOG"
+  [[ "$status" -eq 0 ]] || return "$status"
+
+  refreshed_count=$("$SQLITE_BIN" "$DB" "
+    SELECT session_count
+    FROM reflect_snapshots
+    WHERE period = '$REFLECT_WEEK' AND project_id = '__all__';
+  ") || return 1
+  if [[ "$refreshed_count" != "$facet_count" ]]; then
+    log "Reflection postcondition failed: expected $facet_count facets, found ${refreshed_count:-none}."
+    return 1
+  fi
+
+  log "Reflection for $REFLECT_WEEK is current."
+  stop_dashboard
+  return 0
+}
+
+mkdir -p "$LOG_DIR"
+find "$LOG_DIR" -type f -name 'maintenance-*.log' -mtime +30 -delete 2>/dev/null || true
+
+validate_environment || exit $?
+if [[ "${CODE_INSIGHTS_LOCK_HELD:-}" != "1" ]]; then
+  exec "$CODE_INSIGHTS_BIN" lock-run /bin/bash "$0" "${ORIGINAL_ARGS[@]}"
+fi
+
+log 'Code Insights maintenance started.'
+overall_status=0
+run_sync || overall_status=1
+run_pending_queue || overall_status=1
+
+drain_analysis
+analysis_status=$?
+if [[ "$analysis_status" -eq 2 ]]; then
+  exit 2
+elif [[ "$analysis_status" -ne 0 ]]; then
+  overall_status=1
+fi
+
+refresh_previous_week || overall_status=1
+log "Code Insights maintenance finished with status $overall_status."
+exit "$overall_status"

--- a/automation/com.code-insights.maintenance.plist.in
+++ b/automation/com.code-insights.maintenance.plist.in
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.code-insights.maintenance</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>@MAINTENANCE_SCRIPT@</string>
+    <string>run</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>@WORKING_DIRECTORY@</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>@HOME@</string>
+    <key>PATH</key>
+    <string>@PATH@</string>
+    <key>CODE_INSIGHTS_BIN</key>
+    <string>@CODE_INSIGHTS_BIN@</string>
+    <key>CODE_INSIGHTS_CONFIG_DIR</key>
+    <string>@CONFIG_DIR@</string>
+  </dict>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>15</integer>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+  <key>Nice</key>
+  <integer>10</integer>
+  <key>ThrottleInterval</key>
+  <integer>300</integer>
+
+  <key>StandardOutPath</key>
+  <string>@STDOUT_LOG@</string>
+  <key>StandardErrorPath</key>
+  <string>@STDERR_LOG@</string>
+</dict>
+</plist>

--- a/automation/install-launchd.sh
+++ b/automation/install-launchd.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+# Render/install the macOS daily maintenance LaunchAgent and Claude SessionEnd hook.
+
+set -euo pipefail
+umask 077
+
+LABEL='com.code-insights.maintenance'
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEMPLATE="${CODE_INSIGHTS_LAUNCHD_TEMPLATE:-$ROOT/automation/$LABEL.plist.in}"
+MAINTENANCE_SCRIPT="${CODE_INSIGHTS_MAINTENANCE_SCRIPT:-$ROOT/automation/code-insights-maintenance.sh}"
+CODE_INSIGHTS_BIN="${CODE_INSIGHTS_BIN:-$(command -v code-insights 2>/dev/null || true)}"
+CONFIG_DIR="${CODE_INSIGHTS_CONFIG_DIR:-$HOME/.code-insights}"
+LOG_DIR="$CONFIG_DIR/logs"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+xml_sed_escape() {
+  local value=$1
+  value=${value//&/&amp;}
+  value=${value//</&lt;}
+  value=${value//>/&gt;}
+  value=${value//\\/\\\\}
+  value=${value//&/\\&}
+  value=${value//|/\\|}
+  printf '%s' "$value"
+}
+
+render_plist() {
+  local destination=$1
+  local bin_dir path_value
+  bin_dir=$(dirname "$CODE_INSIGHTS_BIN")
+  path_value="$bin_dir:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+  mkdir -p "$(dirname "$destination")" "$LOG_DIR"
+  sed \
+    -e "s|@MAINTENANCE_SCRIPT@|$(xml_sed_escape "$MAINTENANCE_SCRIPT")|g" \
+    -e "s|@WORKING_DIRECTORY@|$(xml_sed_escape "$ROOT")|g" \
+    -e "s|@HOME@|$(xml_sed_escape "$HOME")|g" \
+    -e "s|@PATH@|$(xml_sed_escape "$path_value")|g" \
+    -e "s|@CODE_INSIGHTS_BIN@|$(xml_sed_escape "$CODE_INSIGHTS_BIN")|g" \
+    -e "s|@CONFIG_DIR@|$(xml_sed_escape "$CONFIG_DIR")|g" \
+    -e "s|@STDOUT_LOG@|$(xml_sed_escape "$LOG_DIR/launchd.stdout.log")|g" \
+    -e "s|@STDERR_LOG@|$(xml_sed_escape "$LOG_DIR/launchd.stderr.log")|g" \
+    "$TEMPLATE" > "$destination"
+  chmod 600 "$destination"
+}
+
+validate_inputs() {
+  [[ -x "$MAINTENANCE_SCRIPT" ]] || { printf 'Maintenance script is not executable: %s\n' "$MAINTENANCE_SCRIPT" >&2; exit 69; }
+  [[ -n "$CODE_INSIGHTS_BIN" && -x "$CODE_INSIGHTS_BIN" ]] || { printf 'code-insights executable not found\n' >&2; exit 69; }
+  [[ -f "$TEMPLATE" ]] || { printf 'LaunchAgent template not found: %s\n' "$TEMPLATE" >&2; exit 66; }
+}
+
+case "${1:---install}" in
+  --render)
+    [[ $# -eq 2 ]] || { printf 'Usage: %s --render DESTINATION\n' "$0" >&2; exit 64; }
+    validate_inputs
+    render_plist "$2"
+    ;;
+  --install)
+    [[ $# -le 1 ]] || { printf 'Usage: %s --install\n' "$0" >&2; exit 64; }
+    validate_inputs
+    [[ "$(uname -s)" == 'Darwin' ]] || { printf 'LaunchAgent installation requires macOS.\n' >&2; exit 69; }
+    NODE_BIN=$(command -v node 2>/dev/null || true)
+    [[ -n "$NODE_BIN" && -x "$NODE_BIN" ]] || { printf 'node executable not found\n' >&2; exit 69; }
+    mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+    temporary_plist=""
+    backup_plist=""
+    claude_settings="$HOME/.claude/settings.json"
+    backup_claude_settings=""
+    claude_settings_kind='absent'
+    claude_settings_target=''
+    claude_settings_link=''
+    previous_agent_existed=0
+    previous_agent_loaded=0
+    previous_plist_state='absent'
+    previous_plist_fingerprint=''
+    previous_plist_content_signature=''
+    new_plist_installed=0
+    new_plist_replacement_started=0
+    new_plist_fingerprint=''
+    new_plist_content_signature=''
+    install_transaction_started=0
+    install_committed=0
+    new_agent_bootstrapped=0
+    hook_install_started=0
+    agent_restore_complete=0
+    settings_restore_complete=0
+
+    cleanup_install_staging() {
+      [[ -z "$temporary_plist" ]] || rm -f "$temporary_plist"
+    }
+
+    settings_file_mode() {
+      if stat -c '%a' "$1" >/dev/null 2>&1; then
+        stat -c '%a' "$1"
+      else
+        stat -f '%Lp' "$1"
+      fi
+    }
+
+    file_fingerprint() {
+      if stat -c '%d:%i:%f:%s:%Y:%Z' "$1" >/dev/null 2>&1; then
+        stat -c '%d:%i:%f:%s:%Y:%Z' "$1"
+      else
+        stat -f '%d:%i:%p:%z:%m:%c' "$1"
+      fi
+    }
+
+    file_content_signature() {
+      printf '%s:' "$(settings_file_mode "$1")"
+      cksum < "$1"
+    }
+
+    create_hard_link_if_absent() {
+      "$NODE_BIN" -e 'const fs=require("node:fs");try{fs.linkSync(process.argv[1],process.argv[2])}catch{process.exit(1)}' "$1" "$2"
+    }
+
+    create_symlink_if_absent() {
+      "$NODE_BIN" -e 'const fs=require("node:fs");try{fs.symlinkSync(process.argv[1],process.argv[2])}catch{process.exit(1)}' "$1" "$2"
+    }
+
+    plist_matches_snapshot() {
+      local expected_fingerprint=$1 expected_content=$2
+      [[ -f "$PLIST" && ! -L "$PLIST" ]] || return 1
+      [[ "$(file_fingerprint "$PLIST")" == "$expected_fingerprint" ]] || return 1
+      [[ "$(file_content_signature "$PLIST")" == "$expected_content" ]]
+    }
+
+    assert_previous_plist_unchanged() {
+      if [[ "$previous_plist_state" == 'absent' ]]; then
+        [[ ! -e "$PLIST" && ! -L "$PLIST" ]]
+      else
+        plist_matches_snapshot "$previous_plist_fingerprint" "$previous_plist_content_signature"
+      fi
+    }
+
+    install_file_if_absent() {
+      local source=$1 destination=$2 staged
+      staged=$(mktemp "$(dirname "$destination")/.$LABEL.restore.XXXXXX") || return 1
+      if ! cp -p "$source" "$staged" || ! create_hard_link_if_absent "$staged" "$destination"; then
+        rm -f "$staged"
+        return 1
+      fi
+      rm -f "$staged"
+    }
+
+    resolve_existing_settings_target() {
+      if [[ -L "$claude_settings" ]]; then
+        command -v realpath >/dev/null 2>&1 || {
+          printf 'Cannot safely resolve the Claude settings symlink: realpath is unavailable.\n' >&2
+          return 1
+        }
+        claude_settings_target=$(realpath "$claude_settings" 2>/dev/null) || {
+          printf 'Claude settings.json is a dangling or unsafe symlink; refusing to modify it.\n' >&2
+          return 1
+        }
+        [[ -f "$claude_settings_target" && ! -L "$claude_settings_target" ]] || {
+          printf 'Claude settings.json symlink does not resolve to a regular file.\n' >&2
+          return 1
+        }
+        claude_settings_kind='symlink'
+        claude_settings_link=$(readlink "$claude_settings")
+      elif [[ -e "$claude_settings" ]]; then
+        [[ -f "$claude_settings" ]] || {
+          printf 'Claude settings.json is not a regular file; refusing to modify it.\n' >&2
+          return 1
+        }
+        claude_settings_kind='file'
+        claude_settings_target="$claude_settings"
+      else
+        claude_settings_kind='absent'
+        claude_settings_target="$claude_settings"
+      fi
+    }
+
+    backup_hook_settings() {
+      mkdir -p "$(dirname "$claude_settings")"
+      resolve_existing_settings_target
+      if [[ "$claude_settings_kind" != 'absent' ]]; then
+        backup_claude_settings=$(mktemp "$(dirname "$claude_settings_target")/.settings.json.previous.XXXXXX")
+        cp -p "$claude_settings_target" "$backup_claude_settings"
+        case "$claude_settings_kind" in
+          file)
+            [[ -f "$claude_settings" && ! -L "$claude_settings" ]] || return 1
+            ;;
+          symlink)
+            [[ -L "$claude_settings" ]] || return 1
+            [[ "$(readlink "$claude_settings")" == "$claude_settings_link" ]] || return 1
+            [[ "$(realpath "$claude_settings" 2>/dev/null)" == "$claude_settings_target" ]] || return 1
+            [[ -f "$claude_settings_target" && ! -L "$claude_settings_target" ]] || return 1
+            ;;
+        esac
+        cmp -s "$claude_settings_target" "$backup_claude_settings" || {
+          printf 'Claude settings changed while they were being backed up; refusing to continue.\n' >&2
+          return 1
+        }
+        [[ "$(settings_file_mode "$claude_settings_target")" == "$(settings_file_mode "$backup_claude_settings")" ]] || return 1
+      fi
+    }
+
+    settings_state_matches_backup() {
+      case "$claude_settings_kind" in
+        absent)
+          [[ ! -e "$claude_settings" && ! -L "$claude_settings" ]]
+          ;;
+        file)
+          [[ -f "$claude_settings" && ! -L "$claude_settings" ]] || return 1
+          cmp -s "$claude_settings" "$backup_claude_settings" || return 1
+          [[ "$(settings_file_mode "$claude_settings")" == "$(settings_file_mode "$backup_claude_settings")" ]]
+          ;;
+        symlink)
+          [[ -L "$claude_settings" ]] || return 1
+          [[ "$(readlink "$claude_settings")" == "$claude_settings_link" ]] || return 1
+          [[ -f "$claude_settings_target" && ! -L "$claude_settings_target" ]] || return 1
+          cmp -s "$claude_settings_target" "$backup_claude_settings" || return 1
+          [[ "$(settings_file_mode "$claude_settings_target")" == "$(settings_file_mode "$backup_claude_settings")" ]]
+          ;;
+      esac
+    }
+
+    reserve_settings_recovery_path() {
+      local template=$1
+      local recovery_path
+      recovery_path=$(mktemp "$template") || return 1
+      rm -f "$recovery_path" || return 1
+      printf '%s' "$recovery_path"
+    }
+
+    preserve_failed_hook_settings() {
+      local entry_backup='' target_backup=''
+      case "$claude_settings_kind" in
+        absent|file)
+          if [[ -e "$claude_settings" || -L "$claude_settings" ]]; then
+            [[ -f "$claude_settings" || -L "$claude_settings" ]] || return 1
+            entry_backup=$(reserve_settings_recovery_path "$(dirname "$claude_settings")/.settings.json.failed-current.XXXXXX") || return 1
+            mv "$claude_settings" "$entry_backup" || return 1
+          fi
+          ;;
+        symlink)
+          if [[ -e "$claude_settings" || -L "$claude_settings" ]]; then
+            [[ -f "$claude_settings" || -L "$claude_settings" ]] || return 1
+          fi
+          if [[ -e "$claude_settings_target" || -L "$claude_settings_target" ]]; then
+            [[ -f "$claude_settings_target" || -L "$claude_settings_target" ]] || return 1
+          fi
+          if [[ -e "$claude_settings" || -L "$claude_settings" ]]; then
+            entry_backup=$(reserve_settings_recovery_path "$(dirname "$claude_settings")/.settings.json.failed-entry.XXXXXX") || return 1
+            mv "$claude_settings" "$entry_backup" || return 1
+          fi
+          if [[ -e "$claude_settings_target" || -L "$claude_settings_target" ]]; then
+            target_backup=$(reserve_settings_recovery_path "$(dirname "$claude_settings_target")/.settings.json.failed-target.XXXXXX") || return 1
+            mv "$claude_settings_target" "$target_backup" || return 1
+          fi
+          ;;
+      esac
+
+      if [[ -n "$entry_backup" ]]; then
+        printf 'Failed hook settings state retained at %s.\n' "$entry_backup" >&2
+      fi
+      if [[ -n "$target_backup" ]]; then
+        printf 'Failed hook settings target retained at %s.\n' "$target_backup" >&2
+      fi
+    }
+
+    restore_previous_hook_settings() {
+      local restore_file
+      if settings_state_matches_backup; then
+        settings_restore_complete=1
+        [[ -z "$backup_claude_settings" ]] || rm -f "$backup_claude_settings"
+        backup_claude_settings=""
+        return 0
+      fi
+
+      preserve_failed_hook_settings || return 1
+      case "$claude_settings_kind" in
+        absent)
+          [[ ! -e "$claude_settings" && ! -L "$claude_settings" ]] || return 1
+          ;;
+        file|symlink)
+          [[ -n "$backup_claude_settings" && -f "$backup_claude_settings" ]] || return 1
+          [[ ! -e "$claude_settings_target" && ! -L "$claude_settings_target" ]] || return 1
+          restore_file=$(mktemp "$(dirname "$claude_settings_target")/.settings.json.restore.XXXXXX") || return 1
+          if ! cp -p "$backup_claude_settings" "$restore_file" || ! create_hard_link_if_absent "$restore_file" "$claude_settings_target"; then
+            rm -f "$restore_file"
+            return 1
+          fi
+          rm -f "$restore_file"
+          if [[ "$claude_settings_kind" == 'symlink' ]]; then
+            if ! create_symlink_if_absent "$claude_settings_link" "$claude_settings"; then
+              return 1
+            fi
+          fi
+          ;;
+      esac
+      settings_restore_complete=1
+      [[ -z "$backup_claude_settings" ]] || rm -f "$backup_claude_settings"
+      backup_claude_settings=""
+    }
+
+    restore_previous_agent() {
+      local displaced_plist=''
+      local displaced_is_generated=0
+      if [[ "$new_agent_bootstrapped" -eq 1 ]]; then
+        if ! launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1; then
+          if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+            printf 'Failed to unload the new LaunchAgent; leaving its plist in place and retaining the old backup.\n' >&2
+            return 1
+          fi
+        fi
+      fi
+
+      # Bash defers signal traps while waiting for an external command. If mv
+      # completed just before INT/TERM was handled, the assignment following
+      # mv did not run even though the generated plist is already canonical.
+      if [[ "$new_plist_replacement_started" -eq 1 && "$new_plist_installed" -eq 0 &&
+            -f "$PLIST" && ! -L "$PLIST" &&
+            "$(file_content_signature "$PLIST")" == "$new_plist_content_signature" ]]; then
+        new_plist_installed=1
+      fi
+
+      if [[ "$previous_agent_existed" -eq 1 ]]; then
+        [[ -n "$backup_plist" && -f "$backup_plist" ]] || return 1
+        if [[ "$new_plist_installed" -eq 1 ]]; then
+          [[ -e "$PLIST" || -L "$PLIST" ]] || return 1
+          [[ -f "$PLIST" || -L "$PLIST" ]] || return 1
+          displaced_plist=$(mktemp "$(dirname "$PLIST")/.$LABEL.failed-new.XXXXXX") || return 1
+          rm -f "$displaced_plist"
+          mv "$PLIST" "$displaced_plist" || return 1
+          if [[ -f "$displaced_plist" && ! -L "$displaced_plist" && "$(file_content_signature "$displaced_plist")" == "$new_plist_content_signature" ]]; then
+            displaced_is_generated=1
+          else
+            printf 'Concurrent LaunchAgent plist retained at %s.\n' "$displaced_plist" >&2
+          fi
+          install_file_if_absent "$backup_plist" "$PLIST" || return 1
+        elif ! assert_previous_plist_unchanged; then
+          if [[ "$previous_agent_loaded" -eq 1 ]]; then
+            launchctl bootstrap "gui/$(id -u)" "$backup_plist" || return 1
+          fi
+          printf 'LaunchAgent plist changed during rollback; current file preserved and old backup retained at %s.\n' "$backup_plist" >&2
+          return 1
+        fi
+        if [[ "$previous_agent_loaded" -eq 1 ]]; then
+          if ! launchctl bootstrap "gui/$(id -u)" "$PLIST"; then
+            printf 'Failed to reload the previous LaunchAgent; backup retained at %s.\n' "$backup_plist" >&2
+            return 1
+          fi
+        fi
+      else
+        if [[ "$new_plist_installed" -eq 1 ]]; then
+          [[ -e "$PLIST" || -L "$PLIST" ]] || return 1
+          [[ -f "$PLIST" || -L "$PLIST" ]] || return 1
+          displaced_plist=$(mktemp "$(dirname "$PLIST")/.$LABEL.failed-new.XXXXXX") || return 1
+          rm -f "$displaced_plist"
+          mv "$PLIST" "$displaced_plist" || return 1
+          if [[ -f "$displaced_plist" && ! -L "$displaced_plist" && "$(file_content_signature "$displaced_plist")" == "$new_plist_content_signature" ]]; then
+            displaced_is_generated=1
+          else
+            printf 'Concurrent LaunchAgent plist retained at %s.\n' "$displaced_plist" >&2
+          fi
+        else
+          [[ ! -e "$PLIST" && ! -L "$PLIST" ]] || return 1
+        fi
+      fi
+
+      agent_restore_complete=1
+      if [[ "$displaced_is_generated" -eq 1 ]]; then
+        rm -f "$displaced_plist"
+      fi
+      [[ -z "$backup_plist" ]] || rm -f "$backup_plist"
+      backup_plist=""
+    }
+
+    finish_install_transaction() {
+      local status=$?
+      local rollback_failed=0
+      trap - EXIT INT TERM
+      set +e
+
+      if [[ "$status" -ne 0 && "$install_transaction_started" -eq 1 && "$install_committed" -eq 0 ]]; then
+        if [[ "$hook_install_started" -eq 1 ]]; then
+          restore_previous_hook_settings || {
+            rollback_failed=1
+            printf 'Failed to restore the previous Claude settings after installation failed.\n' >&2
+          }
+        fi
+        restore_previous_agent || {
+          rollback_failed=1
+          printf 'Failed to fully restore the previous LaunchAgent after installation failed.\n' >&2
+        }
+      fi
+
+      cleanup_install_staging
+
+      if [[ "$status" -eq 0 && "$install_committed" -eq 1 ]]; then
+        [[ -z "$backup_plist" ]] || rm -f "$backup_plist"
+        [[ -z "$backup_claude_settings" ]] || rm -f "$backup_claude_settings"
+      elif [[ "$install_transaction_started" -eq 0 ]]; then
+        # Nothing user-visible changed, so these are disposable staging copies.
+        [[ -z "$backup_plist" ]] || rm -f "$backup_plist"
+        [[ -z "$backup_claude_settings" ]] || rm -f "$backup_claude_settings"
+      else
+        if [[ -n "$backup_plist" && -f "$backup_plist" ]]; then
+          printf 'Previous LaunchAgent backup retained at %s.\n' "$backup_plist" >&2
+        fi
+        if [[ -n "$backup_claude_settings" && -f "$backup_claude_settings" ]]; then
+          printf 'Previous Claude settings backup retained at %s.\n' "$backup_claude_settings" >&2
+        fi
+      fi
+
+      if [[ "$status" -eq 0 && "$rollback_failed" -ne 0 ]]; then
+        status=1
+      fi
+      exit "$status"
+    }
+
+    stop_install_on_signal() {
+      local status=$1
+      trap - INT TERM
+      exit "$status"
+    }
+
+    trap finish_install_transaction EXIT
+    trap 'stop_install_on_signal 130' INT
+    trap 'stop_install_on_signal 143' TERM
+
+    # Keep the staging file beside the destination so the final mv is an
+    # atomic rename even when the config directory is on another filesystem.
+    temporary_plist=$(mktemp "$(dirname "$PLIST")/.$LABEL.plist.tmp.XXXXXX")
+    render_plist "$temporary_plist"
+    plutil -lint "$temporary_plist" >/dev/null
+    new_plist_content_signature=$(file_content_signature "$temporary_plist")
+    if [[ -L "$PLIST" ]]; then
+      printf 'LaunchAgent plist is a symbolic link; refusing to replace it.\n' >&2
+      exit 1
+    fi
+    if [[ -e "$PLIST" && ! -f "$PLIST" ]]; then
+      printf 'LaunchAgent plist is not a regular file; refusing to replace it.\n' >&2
+      exit 1
+    fi
+    if [[ -f "$PLIST" ]]; then
+      previous_agent_existed=1
+      previous_plist_state='file'
+      previous_plist_fingerprint=$(file_fingerprint "$PLIST")
+      previous_plist_content_signature=$(file_content_signature "$PLIST")
+    fi
+    if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+      previous_agent_loaded=1
+    fi
+    if [[ "$previous_agent_loaded" -eq 1 && "$previous_agent_existed" -eq 0 ]]; then
+      printf 'LaunchAgent is loaded but its plist is missing; refusing an update that cannot be rolled back.\n' >&2
+      exit 1
+    fi
+    backup_hook_settings
+    assert_previous_plist_unchanged || {
+      printf 'LaunchAgent plist changed while installation was being prepared; refusing to continue.\n' >&2
+      exit 1
+    }
+    if [[ "$previous_agent_existed" -eq 1 ]]; then
+      backup_plist=$(mktemp "$CONFIG_DIR/$LABEL.plist.previous.XXXXXX")
+      cp -p "$PLIST" "$backup_plist"
+      assert_previous_plist_unchanged || exit 1
+      cmp -s "$PLIST" "$backup_plist" || exit 1
+      [[ "$(settings_file_mode "$PLIST")" == "$(settings_file_mode "$backup_plist")" ]] || exit 1
+    fi
+    assert_previous_plist_unchanged || exit 1
+    install_transaction_started=1
+    if [[ "$previous_agent_loaded" -eq 1 ]]; then
+      launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1
+    elif [[ "$previous_agent_existed" -eq 0 ]]; then
+      launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1 || true
+    fi
+    assert_previous_plist_unchanged || exit 1
+    new_plist_replacement_started=1
+    mv "$temporary_plist" "$PLIST"
+    temporary_plist=""
+    new_plist_installed=1
+    new_plist_fingerprint=$(file_fingerprint "$PLIST")
+    # A bootstrap can partially load the job before returning non-zero. Mark it
+    # first so rollback always issues a matching bootout.
+    new_agent_bootstrapped=1
+    launchctl bootstrap "gui/$(id -u)" "$PLIST"
+    hook_install_started=1
+    if "$CODE_INSIGHTS_BIN" install-hook; then
+      :
+    else
+      hook_status=$?
+      exit "$hook_status"
+    fi
+    install_committed=1
+    printf 'Installed %s (daily at 03:15) and the Claude SessionEnd hook.\n' "$PLIST"
+    ;;
+  --uninstall)
+    [[ $# -eq 1 ]] || { printf 'Usage: %s --uninstall\n' "$0" >&2; exit 64; }
+    uninstall_status=0
+    if [[ "$(uname -s)" == 'Darwin' ]]; then
+      if launchctl bootout "gui/$(id -u)" "$PLIST" >/dev/null 2>&1; then
+        :
+      else
+        bootout_status=$?
+        if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+          uninstall_status=$bootout_status
+        fi
+      fi
+    fi
+    if [[ "$uninstall_status" -eq 0 ]]; then
+      rm -f "$PLIST" || uninstall_status=$?
+    fi
+    hook_uninstall_status=0
+    if [[ -n "$CODE_INSIGHTS_BIN" && -x "$CODE_INSIGHTS_BIN" ]]; then
+      if "$CODE_INSIGHTS_BIN" uninstall-hook; then
+        :
+      else
+        hook_uninstall_status=$?
+      fi
+    else
+      printf 'Skipping Claude hook removal: code-insights executable not found.\n' >&2
+      hook_uninstall_status=69
+    fi
+    if [[ "$uninstall_status" -eq 0 && "$hook_uninstall_status" -eq 0 ]]; then
+      printf 'Removed %s and the Claude SessionEnd hook.\n' "$LABEL"
+    elif [[ "$uninstall_status" -eq 0 ]]; then
+      printf 'LaunchAgent was removed, but the Claude hook was not removed.\n' >&2
+      exit "$hook_uninstall_status"
+    elif [[ "$hook_uninstall_status" -eq 0 ]]; then
+      printf 'Claude hook removal completed, but the LaunchAgent plist could not be removed.\n' >&2
+      exit "$uninstall_status"
+    else
+      printf 'Neither the LaunchAgent nor the Claude hook could be fully removed.\n' >&2
+      exit "$uninstall_status"
+    fi
+    ;;
+  *)
+    printf 'Usage: %s [--install | --uninstall | --render DESTINATION]\n' "$0" >&2
+    exit 64
+    ;;
+esac

--- a/automation/tests/install-launchd.test.sh
+++ b/automation/tests/install-launchd.test.sh
@@ -1,0 +1,717 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/automation/install-launchd.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/code-insights-launchd-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+file_mode() {
+  if stat -c '%a' "$1" >/dev/null 2>&1; then
+    stat -c '%a' "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/home" "$TMP_ROOT/bin"
+real_node=$(command -v node)
+ln -s "$real_node" "$TMP_ROOT/bin/node"
+cat > "$TMP_ROOT/bin/code-insights" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${CLI_CALL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$CLI_CALL_LOG"
+fi
+if [[ "${1:-}" == 'install-hook' && "${MUTATE_SETTINGS_THEN_FAIL:-0}" == '1' ]]; then
+  mkdir -p "$HOME/.claude"
+  printf '%s\n' '{"mutated":true}' > "$HOME/.claude/settings.json"
+  chmod 600 "$HOME/.claude/settings.json"
+  exit 1
+fi
+if [[ "${1:-}" == 'install-hook' && "${REPLACE_SYMLINK_THEN_FAIL:-0}" == '1' ]]; then
+  printf '%s\n' '{"mutatedTarget":true}' > "$HOME/.claude/settings.json"
+  rm -f "$HOME/.claude/settings.json"
+  printf '%s\n' '{"replacementFile":true}' > "$HOME/.claude/settings.json"
+  exit 1
+fi
+if [[ "${1:-}" == 'install-hook' && "${REPLACE_SYMLINK_WITH_DIR_THEN_FAIL:-0}" == '1' ]]; then
+  printf '%s\n' '{"mutatedTarget":true}' > "$HOME/.claude/settings.json"
+  rm -f "$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude/settings.json"
+  printf 'do not delete\n' > "$HOME/.claude/settings.json/user-file"
+  exit 1
+fi
+if [[ "${1:-}" == 'install-hook' && "${FAIL_INSTALL_HOOK:-0}" == '1' ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == 'uninstall-hook' && "${FAIL_UNINSTALL_HOOK:-0}" == '1' ]]; then
+  exit 42
+fi
+exit 0
+EOF
+chmod +x "$TMP_ROOT/bin/code-insights"
+
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  "$SCRIPT" --render "$TMP_ROOT/maintenance.plist"
+
+grep -Fq '<string>com.code-insights.maintenance</string>' "$TMP_ROOT/maintenance.plist" || fail 'missing launchd label'
+grep -Fq "$ROOT/automation/code-insights-maintenance.sh" "$TMP_ROOT/maintenance.plist" || fail 'missing absolute maintenance path'
+grep -Fq "$TMP_ROOT/bin" "$TMP_ROOT/maintenance.plist" || fail 'missing executable directory in PATH'
+grep -Fq '<key>CODE_INSIGHTS_CONFIG_DIR</key>' "$TMP_ROOT/maintenance.plist" || fail 'missing config directory environment key'
+grep -Fq "<string>$TMP_ROOT/home/.code-insights</string>" "$TMP_ROOT/maintenance.plist" || fail 'missing rendered config directory'
+grep -Fq '<integer>3</integer>' "$TMP_ROOT/maintenance.plist" || fail 'missing scheduled hour'
+grep -Fq '<integer>15</integer>' "$TMP_ROOT/maintenance.plist" || fail 'missing scheduled minute'
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$TMP_ROOT/maintenance.plist" >/dev/null
+fi
+
+# Uninstall is a recovery action: it must unload/remove the agent even when the
+# checkout or CLI it originally referenced no longer exists.
+cat > "$TMP_ROOT/bin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$LAUNCHCTL_LOG"
+if [[ "${1:-}" == "print" ]]; then
+  [[ "${PRINT_LOADED_WITHOUT_PLIST:-0}" == "1" ]] && exit 0
+  [[ "${PRINT_UNLOADED:-0}" == "1" ]] && exit 1
+  [[ -n "${FAKE_INSTALLED_PLIST:-}" && ( -e "$FAKE_INSTALLED_PLIST" || -L "$FAKE_INSTALLED_PLIST" ) ]] && exit 0
+  exit 1
+fi
+if [[ "${1:-}" == "bootout" && "${FAIL_BOOTOUT:-0}" == "1" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "bootout" && "${FAIL_SECOND_BOOTOUT:-0}" == "1" ]]; then
+  count=0
+  [[ -f "$BOOTOUT_COUNT_FILE" ]] && read -r count < "$BOOTOUT_COUNT_FILE"
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$BOOTOUT_COUNT_FILE"
+  [[ "$count" -ne 2 ]] || exit 1
+fi
+if [[ "${1:-}" == "bootout" && -n "${SIGNAL_ON_BOOTOUT:-}" ]]; then
+  kill "-${SIGNAL_ON_BOOTOUT}" "$PPID"
+  exit 0
+fi
+if [[ "${1:-}" == "bootstrap" && "${FAIL_ALL_BOOTSTRAP:-0}" == "1" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "bootstrap" && "${FAIL_FIRST_BOOTSTRAP:-0}" == "1" ]]; then
+  count=0
+  [[ -f "$BOOTSTRAP_COUNT_FILE" ]] && read -r count < "$BOOTSTRAP_COUNT_FILE"
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$BOOTSTRAP_COUNT_FILE"
+  [[ "$count" -gt 1 ]] || exit 1
+fi
+exit 0
+EOF
+cat > "$TMP_ROOT/bin/plutil" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${PLUTIL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$PLUTIL_LOG"
+fi
+exit "${PLUTIL_STATUS:-0}"
+EOF
+cat > "$TMP_ROOT/bin/mv" <<'EOF'
+#!/usr/bin/env bash
+arguments=("$@")
+last_index=$((${#arguments[@]} - 1))
+destination=${arguments[$last_index]}
+source=${arguments[$((last_index - 1))]}
+if [[ -n "${PLIST_MV_LOG:-}" && "$destination" == *'/com.code-insights.maintenance.plist' ]]; then
+  printf '%s|%s\n' "$source" "$destination" >> "$PLIST_MV_LOG"
+fi
+if [[ "${FAIL_PLIST_MV:-0}" == '1' && "$destination" == *'/com.code-insights.maintenance.plist' ]]; then
+  if [[ -z "${FAIL_PLIST_MV_ONCE_FILE:-}" || ! -e "$FAIL_PLIST_MV_ONCE_FILE" ]]; then
+    [[ -z "${FAIL_PLIST_MV_ONCE_FILE:-}" ]] || : > "$FAIL_PLIST_MV_ONCE_FILE"
+    exit 1
+  fi
+fi
+/bin/mv "$@" || exit $?
+if [[ -n "${SIGNAL_AFTER_PLIST_MV:-}" && "$destination" == *'/com.code-insights.maintenance.plist' ]]; then
+  kill "-${SIGNAL_AFTER_PLIST_MV}" "$PPID"
+fi
+EOF
+cat > "$TMP_ROOT/bin/cp" <<'EOF'
+#!/usr/bin/env bash
+arguments=("$@")
+last_index=$((${#arguments[@]} - 1))
+destination=${arguments[$last_index]}
+/bin/cp "$@" || exit $?
+if [[ "${CREATE_SETTINGS_RACE_AFTER_RESTORE_COPY:-0}" == '1' && "$destination" == *'/.settings.json.restore.'* ]]; then
+  printf '%s\n' '{"concurrentDuringRestore":true}' > "$SETTINGS_RACE_DESTINATION"
+fi
+if [[ "${CREATE_SETTINGS_DIRECTORY_AFTER_RESTORE_COPY:-0}" == '1' && "$destination" == *'/.settings.json.restore.'* ]]; then
+  mkdir -p "$SETTINGS_RACE_DESTINATION"
+  printf 'concurrent directory entry\n' > "$SETTINGS_RACE_DESTINATION/user-file"
+fi
+if [[ "${MUTATE_SETTINGS_AFTER_BACKUP_COPY:-0}" == '1' && "$destination" == *'/.settings.json.previous.'* ]]; then
+  printf '%s\n' '{"changedDuringBackup":true}' > "$SETTINGS_BACKUP_SOURCE"
+fi
+if [[ "${REPLACE_PLIST_AFTER_SETTINGS_BACKUP:-0}" == '1' && "$destination" == *'/.settings.json.previous.'* ]]; then
+  rm -f "$PLIST_RACE_PATH"
+  ln -s "$PLIST_RACE_TARGET" "$PLIST_RACE_PATH"
+fi
+if [[ "${EDIT_PLIST_SAME_SIZE_AFTER_SETTINGS_BACKUP:-0}" == '1' && "$destination" == *'/.settings.json.previous.'* ]]; then
+  printf 'BBBB\n' > "$PLIST_RACE_PATH"
+fi
+EOF
+cat > "$TMP_ROOT/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+EOF
+chmod +x "$TMP_ROOT/bin/cp" "$TMP_ROOT/bin/launchctl" "$TMP_ROOT/bin/mv" "$TMP_ROOT/bin/plutil" "$TMP_ROOT/bin/uname"
+export LAUNCHCTL_LOG="$TMP_ROOT/launchctl.log"
+export CLI_CALL_LOG="$TMP_ROOT/cli-calls.log"
+export PLUTIL_LOG="$TMP_ROOT/plutil.log"
+export PLIST_MV_LOG="$TMP_ROOT/plist-mv.log"
+installed_plist="$TMP_ROOT/home/Library/LaunchAgents/com.code-insights.maintenance.plist"
+export FAKE_INSTALLED_PLIST="$installed_plist"
+mkdir -p "$(dirname "$installed_plist")"
+printf 'obsolete agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/missing/code-insights" \
+  CODE_INSIGHTS_MAINTENANCE_SCRIPT="$TMP_ROOT/missing/maintenance.sh" \
+  CODE_INSIGHTS_LAUNCHD_TEMPLATE="$TMP_ROOT/missing/maintenance.plist.in" \
+  "$SCRIPT" --uninstall > "$TMP_ROOT/uninstall.log" 2>&1
+uninstall_status=$?
+set -e
+[[ "$uninstall_status" -ne 0 ]] || fail 'missing CLI must make uninstall report a partial failure'
+[[ ! -e "$installed_plist" ]] || fail 'uninstall did not remove the existing plist'
+grep -Fq "bootout gui/$(id -u) $installed_plist" "$LAUNCHCTL_LOG" || fail 'uninstall did not bootout the existing plist'
+grep -Fq 'Skipping Claude hook removal' "$TMP_ROOT/uninstall.log" || fail 'uninstall did not explain the missing CLI'
+grep -Fq 'LaunchAgent was removed, but the Claude hook was not removed' "$TMP_ROOT/uninstall.log" || fail 'uninstall did not report partial completion'
+if grep -Fq 'and the Claude SessionEnd hook' "$TMP_ROOT/uninstall.log"; then
+  fail 'partial uninstall falsely reported complete hook removal'
+fi
+
+# A CLI hook-removal failure is also partial: the agent remains removed, the
+# command returns non-zero, and the all-success message is withheld.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'installed agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  FAIL_UNINSTALL_HOOK=1 \
+  "$SCRIPT" --uninstall > "$TMP_ROOT/uninstall-hook-failure.log" 2>&1
+uninstall_hook_status=$?
+set -e
+[[ "$uninstall_hook_status" -eq 42 ]] || fail "expected hook failure status 42, got $uninstall_hook_status"
+[[ ! -e "$installed_plist" ]] || fail 'hook failure left the LaunchAgent plist installed'
+grep -Fq 'LaunchAgent was removed, but the Claude hook was not removed' "$TMP_ROOT/uninstall-hook-failure.log" || fail 'hook failure did not report partial completion'
+if grep -Fq 'and the Claude SessionEnd hook' "$TMP_ROOT/uninstall-hook-failure.log"; then
+  fail 'hook failure falsely reported a complete uninstall'
+fi
+
+# Only a successful hook removal reports complete uninstall success.
+: > "$CLI_CALL_LOG"
+printf 'installed agent\n' > "$installed_plist"
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  "$SCRIPT" --uninstall > "$TMP_ROOT/uninstall-success.log" 2>&1
+grep -Fq 'Removed com.code-insights.maintenance and the Claude SessionEnd hook.' "$TMP_ROOT/uninstall-success.log" || fail 'successful uninstall did not report full completion'
+
+# An unload failure is not a successful uninstall while launchctl still
+# reports the job loaded. Keep the plist for recovery and return non-zero.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'installed agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_BOOTOUT=1 \
+  "$SCRIPT" --uninstall > "$TMP_ROOT/uninstall-bootout-failure.log" 2>&1
+uninstall_bootout_status=$?
+set -e
+[[ "$uninstall_bootout_status" -ne 0 ]] || fail 'loaded-agent bootout failure unexpectedly reported success'
+[[ -f "$installed_plist" ]] || fail 'uninstall deleted the plist after failing to unload a loaded job'
+grep -Fq 'uninstall-hook' "$CLI_CALL_LOG" || fail 'unload failure skipped independent hook removal'
+if grep -Fq 'and the Claude SessionEnd hook' "$TMP_ROOT/uninstall-bootout-failure.log"; then
+  fail 'unload failure falsely reported a complete uninstall'
+fi
+
+# No action argument remains an alias for --install; action-specific input
+# validation must happen after that default is resolved.
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/missing/code-insights" \
+  CODE_INSIGHTS_MAINTENANCE_SCRIPT="$TMP_ROOT/missing/maintenance.sh" \
+  CODE_INSIGHTS_LAUNCHD_TEMPLATE="$TMP_ROOT/missing/maintenance.plist.in" \
+  "$SCRIPT" > "$TMP_ROOT/default-install.log" 2>&1
+default_status=$?
+set -e
+[[ "$default_status" -eq 69 ]] || fail "expected default install to validate inputs (69), got $default_status"
+if grep -Fq 'Usage:' "$TMP_ROOT/default-install.log"; then
+  fail 'default install was rejected as an invalid action invocation'
+fi
+
+# Unknown actions report usage before probing action-irrelevant assets.
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/missing/code-insights" \
+  CODE_INSIGHTS_MAINTENANCE_SCRIPT="$TMP_ROOT/missing/maintenance.sh" \
+  CODE_INSIGHTS_LAUNCHD_TEMPLATE="$TMP_ROOT/missing/maintenance.plist.in" \
+  "$SCRIPT" --unknown > "$TMP_ROOT/unknown-action.log" 2>&1
+unknown_status=$?
+set -e
+[[ "$unknown_status" -eq 64 ]] || fail "expected unknown action exit 64, got $unknown_status"
+grep -Fq 'Usage:' "$TMP_ROOT/unknown-action.log" || fail 'unknown action did not print usage'
+
+# The final plist replacement must be a rename within LaunchAgents. Staging in
+# the config directory can cross filesystems and lose atomic replacement.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+: > "$PLIST_MV_LOG"
+rm -f "$installed_plist"
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  "$SCRIPT" --install > "$TMP_ROOT/install-same-directory-staging.log" 2>&1
+IFS='|' read -r staged_plist staging_destination < "$PLIST_MV_LOG"
+[[ -n "$staged_plist" && -n "$staging_destination" ]] || fail 'successful install did not replace the plist'
+[[ "$(dirname "$staged_plist")" == "$(dirname "$staging_destination")" ]] || fail 'plist was not staged in the LaunchAgents directory'
+rm -f "$installed_plist"
+
+# User-managed LaunchAgent plist symlinks are rejected before any launchctl
+# mutation rather than being silently replaced with regular files.
+: > "$LAUNCHCTL_LOG"
+managed_plist="$TMP_ROOT/managed-launch-agent.plist"
+printf 'managed agent\n' > "$managed_plist"
+rm -f "$installed_plist"
+ln -s "$managed_plist" "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  "$SCRIPT" --install > "$TMP_ROOT/install-plist-symlink.log" 2>&1
+plist_symlink_status=$?
+set -e
+[[ "$plist_symlink_status" -ne 0 ]] || fail 'LaunchAgent plist symlink installation unexpectedly succeeded'
+[[ -L "$installed_plist" && "$(readlink "$installed_plist")" == "$managed_plist" ]] || fail 'LaunchAgent plist symlink shape was destroyed'
+[[ "$(cat "$managed_plist")" == 'managed agent' ]] || fail 'LaunchAgent plist symlink target was modified'
+[[ ! -s "$LAUNCHCTL_LOG" ]] || fail 'rejected LaunchAgent symlink changed launchctl state'
+rm -f "$installed_plist"
+
+# The settings backup must be a consistent snapshot. A source edit during the
+# copy aborts before any launchctl state change and leaves the edit intact.
+: > "$LAUNCHCTL_LOG"
+snapshot_settings="$TMP_ROOT/home/.claude/settings.json"
+mkdir -p "$(dirname "$snapshot_settings")"
+printf '%s\n' '{"theme":"snapshot-source"}' > "$snapshot_settings"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" MUTATE_SETTINGS_AFTER_BACKUP_COPY=1 \
+  SETTINGS_BACKUP_SOURCE="$snapshot_settings" \
+  "$SCRIPT" --install > "$TMP_ROOT/settings-snapshot-race.log" 2>&1
+settings_snapshot_status=$?
+set -e
+[[ "$settings_snapshot_status" -ne 0 ]] || fail 'inconsistent settings snapshot unexpectedly installed'
+grep -Fq 'changedDuringBackup' "$snapshot_settings" || fail 'settings snapshot test edit was lost'
+if grep -Eq '^(bootout|bootstrap) ' "$LAUNCHCTL_LOG"; then
+  fail 'inconsistent settings snapshot changed launchctl state'
+fi
+rm -f "$snapshot_settings"
+
+# Replacing the plist with a symlink after the initial safety check must be
+# detected before bootout or replacement; preserve the concurrent link/target.
+: > "$LAUNCHCTL_LOG"
+mkdir -p "$(dirname "$snapshot_settings")"
+printf '%s\n' '{"theme":"trigger-plist-backup-race"}' > "$snapshot_settings"
+printf 'original agent\n' > "$installed_plist"
+plist_race_target="$TMP_ROOT/concurrent-managed-agent.plist"
+printf 'concurrent managed agent\n' > "$plist_race_target"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" REPLACE_PLIST_AFTER_SETTINGS_BACKUP=1 \
+  PLIST_RACE_PATH="$installed_plist" PLIST_RACE_TARGET="$plist_race_target" \
+  "$SCRIPT" --install > "$TMP_ROOT/plist-race.log" 2>&1
+plist_race_status=$?
+set -e
+[[ "$plist_race_status" -ne 0 ]] || fail 'concurrent plist symlink replacement unexpectedly installed'
+[[ -L "$installed_plist" && "$(readlink "$installed_plist")" == "$plist_race_target" ]] || fail 'plist race destroyed the concurrent symlink'
+[[ "$(cat "$plist_race_target")" == 'concurrent managed agent' ]] || fail 'plist race modified the concurrent symlink target'
+if grep -Eq '^(bootout|bootstrap) ' "$LAUNCHCTL_LOG"; then
+  fail 'plist race changed loaded launchctl state'
+fi
+rm -f "$snapshot_settings" "$installed_plist"
+
+# Fingerprinting also includes content, not only second-granularity timestamps:
+# detect an in-place same-size edit made while settings are backed up.
+: > "$LAUNCHCTL_LOG"
+mkdir -p "$(dirname "$snapshot_settings")"
+printf '%s\n' '{"theme":"trigger-same-size-plist-race"}' > "$snapshot_settings"
+printf 'AAAA\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" EDIT_PLIST_SAME_SIZE_AFTER_SETTINGS_BACKUP=1 \
+  PLIST_RACE_PATH="$installed_plist" \
+  "$SCRIPT" --install > "$TMP_ROOT/plist-same-size-race.log" 2>&1
+plist_same_size_status=$?
+set -e
+[[ "$plist_same_size_status" -ne 0 ]] || fail 'same-size concurrent plist edit unexpectedly installed'
+[[ "$(cat "$installed_plist")" == 'BBBB' ]] || fail 'same-size concurrent plist edit was overwritten'
+if grep -Eq '^(bootout|bootstrap) ' "$LAUNCHCTL_LOG"; then
+  fail 'same-size plist race changed loaded launchctl state'
+fi
+rm -f "$snapshot_settings" "$installed_plist"
+
+# A loaded job without a recoverable plist cannot participate in an atomic
+# update. Fail before bootout instead of unloading an unrecoverable job.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" PRINT_LOADED_WITHOUT_PLIST=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/loaded-without-plist.log" 2>&1
+loaded_without_plist_status=$?
+set -e
+[[ "$loaded_without_plist_status" -ne 0 ]] || fail 'loaded job without plist unexpectedly installed'
+if grep -Eq '^(bootout|bootstrap) ' "$LAUNCHCTL_LOG"; then
+  fail 'loaded job without plist was mutated'
+fi
+if [[ -f "$CLI_CALL_LOG" ]] && grep -Fq 'install-hook' "$CLI_CALL_LOG"; then
+  fail 'loaded job without plist ran hook installation'
+fi
+
+# A failed bootstrap of an updated agent restores and reloads the previous
+# plist instead of leaving maintenance uninstalled.
+: > "$LAUNCHCTL_LOG"
+export BOOTSTRAP_COUNT_FILE="$TMP_ROOT/bootstrap-count"
+rm -f "$BOOTSTRAP_COUNT_FILE" "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  FAIL_FIRST_BOOTSTRAP=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/install-rollback.log" 2>&1
+install_status=$?
+set -e
+[[ "$install_status" -ne 0 ]] || fail 'expected failed new bootstrap to fail installation'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'failed bootstrap did not restore the previous plist'
+[[ "$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG")" -eq 2 ]] || fail 'expected bootstrap of new and restored agents'
+[[ "$(grep -c '^bootout ' "$LAUNCHCTL_LOG")" -eq 2 ]] || fail 'expected cleanup bootout after a failed or partial new bootstrap'
+if [[ -f "$CLI_CALL_LOG" ]] && grep -Fq 'install-hook' "$CLI_CALL_LOG"; then
+  fail 'hook installation ran after the LaunchAgent bootstrap failed'
+fi
+
+# Once the old agent has been booted out, failures at bootout or plist move are
+# transaction failures: the old plist is restored and bootstrapped again.
+for failure_mode in bootout move; do
+  : > "$LAUNCHCTL_LOG"
+  : > "$CLI_CALL_LOG"
+  printf 'previous agent\n' > "$installed_plist"
+  set +e
+  if [[ "$failure_mode" == 'bootout' ]]; then
+    HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+      CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_BOOTOUT=1 \
+      "$SCRIPT" --install > "$TMP_ROOT/install-$failure_mode-failure.log" 2>&1
+  else
+    HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+      CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_PLIST_MV=1 \
+      FAIL_PLIST_MV_ONCE_FILE="$TMP_ROOT/plist-mv-failed-once" \
+      "$SCRIPT" --install > "$TMP_ROOT/install-$failure_mode-failure.log" 2>&1
+  fi
+  transaction_status=$?
+  set -e
+  [[ "$transaction_status" -ne 0 ]] || fail "$failure_mode failure unexpectedly succeeded"
+  [[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail "$failure_mode failure did not restore the previous plist"
+  grep -Fq "bootstrap gui/$(id -u) $installed_plist" "$LAUNCHCTL_LOG" || fail "$failure_mode failure did not re-bootstrap the previous agent"
+  if grep -Fq 'install-hook' "$CLI_CALL_LOG"; then
+    fail "$failure_mode failure ran hook installation"
+  fi
+done
+
+# INT/TERM use the same rollback path. A signal delivered just after bootout
+# must restore/reload the old agent and preserve the conventional exit code.
+for signal in INT TERM; do
+  : > "$LAUNCHCTL_LOG"
+  : > "$CLI_CALL_LOG"
+  printf 'previous agent\n' > "$installed_plist"
+  expected_signal_status=130
+  [[ "$signal" == 'INT' ]] || expected_signal_status=143
+  set +e
+  HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+    CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" SIGNAL_ON_BOOTOUT="$signal" \
+    "$SCRIPT" --install > "$TMP_ROOT/install-$signal.log" 2>&1
+  signal_status=$?
+  set -e
+  [[ "$signal_status" -eq "$expected_signal_status" ]] || fail "expected $signal status $expected_signal_status, got $signal_status"
+  [[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail "$signal did not restore the previous plist"
+  grep -Fq "bootstrap gui/$(id -u) $installed_plist" "$LAUNCHCTL_LOG" || fail "$signal did not re-bootstrap the previous agent"
+done
+
+# Bash defers traps while waiting for an external mv. A signal delivered after
+# mv has replaced the plist but before the next shell statement must still
+# classify that file as generated and restore the previous agent.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" SIGNAL_AFTER_PLIST_MV=TERM \
+  "$SCRIPT" --install > "$TMP_ROOT/install-TERM-after-plist-mv.log" 2>&1
+signal_after_mv_status=$?
+set -e
+[[ "$signal_after_mv_status" -eq 143 ]] || fail "expected post-mv TERM status 143, got $signal_after_mv_status"
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'post-mv TERM did not restore the previous plist'
+grep -Fq "bootstrap gui/$(id -u) $installed_plist" "$LAUNCHCTL_LOG" || fail 'post-mv TERM did not re-bootstrap the previous agent'
+
+# If even recovery bootstrap fails, EXIT cleanup must retain the only staged
+# backup instead of deleting the user's recovery copy.
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+rm -f "$TMP_ROOT/home/.code-insights"/*.previous.* 2>/dev/null || true
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_ALL_BOOTSTRAP=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/install-recovery-failure.log" 2>&1
+recovery_failure_status=$?
+set -e
+[[ "$recovery_failure_status" -ne 0 ]] || fail 'bootstrap and recovery failure unexpectedly succeeded'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'recovery failure lost the previous plist content'
+recovery_backup=$(find "$TMP_ROOT/home/.code-insights" -maxdepth 1 -name 'com.code-insights.maintenance.plist.previous.*' -print -quit)
+[[ -n "$recovery_backup" && -f "$recovery_backup" ]] || fail 'EXIT cleanup deleted the recovery plist backup'
+[[ "$(cat "$recovery_backup")" == 'previous agent' ]] || fail 'retained recovery plist backup has wrong content'
+
+# A hook-install failure also rolls the LaunchAgent back, so install cannot
+# leave a new daily job paired with a missing or stale SessionEnd hook.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  FAIL_INSTALL_HOOK=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-rollback.log" 2>&1
+hook_install_status=$?
+set -e
+[[ "$hook_install_status" -ne 0 ]] || fail 'expected hook failure to fail installation'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'hook failure did not restore the previous plist'
+[[ "$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG")" -eq 2 ]] || fail 'expected new and restored bootstrap after hook failure'
+[[ "$(grep -c '^bootout ' "$LAUNCHCTL_LOG")" -eq 2 ]] || fail 'expected old and failed-new bootout after hook failure'
+grep -Fq 'install-hook' "$CLI_CALL_LOG" || fail 'hook failure test did not run hook installation'
+
+# If the new job cannot be unloaded during rollback, do not delete its plist or
+# overwrite it with the old one. Retain the previous plist backup for recovery.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+bootout_count_file="$TMP_ROOT/bootout-count"
+rm -f "$bootout_count_file"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_INSTALL_HOOK=1 \
+  FAIL_SECOND_BOOTOUT=1 BOOTOUT_COUNT_FILE="$bootout_count_file" \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-rollback-bootout-failure.log" 2>&1
+rollback_bootout_status=$?
+set -e
+[[ "$rollback_bootout_status" -ne 0 ]] || fail 'rollback bootout failure unexpectedly succeeded'
+grep -Fq '<string>com.code-insights.maintenance</string>' "$installed_plist" || fail 'rollback bootout failure overwrote the active new plist'
+rollback_plist_backup=$(find "$TMP_ROOT/home/.code-insights" -maxdepth 1 -name 'com.code-insights.maintenance.plist.previous.*' -print -quit)
+[[ -n "$rollback_plist_backup" && -f "$rollback_plist_backup" ]] || fail 'rollback bootout failure deleted the previous plist backup'
+[[ "$(cat "$rollback_plist_backup")" == 'previous agent' ]] || fail 'retained previous plist backup has wrong content'
+rm -f "$rollback_plist_backup"
+
+# A stale plist that was not loaded before installation is restored on failure
+# without starting a job that was previously stopped.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'stale stopped agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" FAIL_INSTALL_HOOK=1 PRINT_UNLOADED=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/stopped-agent-rollback.log" 2>&1
+stopped_agent_status=$?
+set -e
+[[ "$stopped_agent_status" -ne 0 ]] || fail 'stopped-agent hook failure unexpectedly succeeded'
+[[ "$(cat "$installed_plist")" == 'stale stopped agent' ]] || fail 'stopped-agent rollback did not restore its plist'
+[[ "$(grep -c '^bootstrap ' "$LAUNCHCTL_LOG")" -eq 1 ]] || fail 'rollback started an old job that was previously stopped'
+
+# Hook installation is part of the same transaction as the LaunchAgent. Even
+# if a broken CLI mutates settings.json before returning non-zero, the exact
+# previous settings content and permissions are restored with the prior plist.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+settings_file="$TMP_ROOT/home/.claude/settings.json"
+mkdir -p "$(dirname "$settings_file")"
+printf '%s\n' '{"theme":"dark","hooks":{"SessionEnd":[]}}' > "$settings_file"
+chmod 640 "$settings_file"
+expected_settings_file="$TMP_ROOT/expected-settings.json"
+cp -p "$settings_file" "$expected_settings_file"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  MUTATE_SETTINGS_THEN_FAIL=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-settings-rollback.log" 2>&1
+settings_rollback_status=$?
+set -e
+[[ "$settings_rollback_status" -ne 0 ]] || fail 'expected mutating hook failure to fail installation'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'mutating hook failure did not restore the previous plist'
+cmp -s "$settings_file" "$expected_settings_file" || fail 'mutating hook failure did not restore previous settings content'
+[[ "$(file_mode "$settings_file")" == '640' ]] || fail 'mutating hook failure did not restore settings permissions'
+failed_regular_settings=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.failed-current.*' -print -quit)
+[[ -n "$failed_regular_settings" && -f "$failed_regular_settings" ]] || fail 'rollback discarded the failed hook settings state'
+grep -Fq '"mutated":true' "$failed_regular_settings" || fail 'failed hook settings recovery copy has wrong content'
+
+# A concurrent settings creation after the old bytes are staged for restore
+# must win. Rollback fails closed and retains the original backup instead of
+# overwriting the newly created file.
+printf '%s\n' '{"theme":"before-race"}' > "$settings_file"
+chmod 640 "$settings_file"
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" MUTATE_SETTINGS_THEN_FAIL=1 \
+  CREATE_SETTINGS_RACE_AFTER_RESTORE_COPY=1 SETTINGS_RACE_DESTINATION="$settings_file" \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-settings-restore-race.log" 2>&1
+settings_race_status=$?
+set -e
+[[ "$settings_race_status" -ne 0 ]] || fail 'settings restore race unexpectedly succeeded'
+grep -Fq 'concurrentDuringRestore' "$settings_file" || fail 'rollback overwrote a settings file created during restore'
+race_previous_backup=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.previous.*' -print -quit)
+[[ -n "$race_previous_backup" && -f "$race_previous_backup" ]] || fail 'restore race deleted the original settings backup'
+grep -Fq 'before-race' "$race_previous_backup" || fail 'restore-race original backup has wrong content'
+rm -f "$race_previous_backup"
+
+# A directory created at the destination during restore must be treated as
+# EEXIST, not as ln's "put the link inside this directory" shorthand.
+rm -rf "$settings_file"
+printf '%s\n' '{"theme":"before-directory-race"}' > "$settings_file"
+chmod 640 "$settings_file"
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" MUTATE_SETTINGS_THEN_FAIL=1 \
+  CREATE_SETTINGS_DIRECTORY_AFTER_RESTORE_COPY=1 SETTINGS_RACE_DESTINATION="$settings_file" \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-settings-directory-race.log" 2>&1
+settings_directory_race_status=$?
+set -e
+[[ "$settings_directory_race_status" -ne 0 ]] || fail 'settings directory restore race unexpectedly succeeded'
+[[ -d "$settings_file" && -f "$settings_file/user-file" ]] || fail 'restore damaged a concurrently created settings directory'
+directory_race_backup=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.previous.*' -print -quit)
+[[ -n "$directory_race_backup" && -f "$directory_race_backup" ]] || fail 'directory restore race deleted the original settings backup'
+grep -Fq 'before-directory-race' "$directory_race_backup" || fail 'directory-race original backup has wrong content'
+rm -rf "$settings_file"
+rm -f "$directory_race_backup"
+
+# Absence is also backed up as state: if no settings.json existed before the
+# transaction, a failed hook must not leave behind the file it created.
+: > "$LAUNCHCTL_LOG"
+: > "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+rm -f "$settings_file"
+failed_settings_count_before=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.failed-current.*' | wc -l | tr -d ' ')
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  MUTATE_SETTINGS_THEN_FAIL=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-settings-absent-rollback.log" 2>&1
+absent_rollback_status=$?
+set -e
+[[ "$absent_rollback_status" -ne 0 ]] || fail 'expected hook failure from absent settings state'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'absent-settings hook failure did not restore the previous plist'
+[[ ! -e "$settings_file" ]] || fail 'hook failure left settings.json that did not exist before installation'
+failed_settings_count_after=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.failed-current.*' | wc -l | tr -d ' ')
+[[ "$failed_settings_count_after" -gt "$failed_settings_count_before" ]] || fail 'absent-state rollback discarded the file created by the failed hook'
+
+# When settings.json is a symlink, rollback restores both the exact link shape
+# and the target's prior bytes/permissions even if a faulty hook replaces the
+# symlink itself before failing.
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+shared_settings_dir="$TMP_ROOT/home/shared-claude"
+shared_settings="$shared_settings_dir/settings.json"
+mkdir -p "$shared_settings_dir" "$(dirname "$settings_file")"
+printf '%s\n' '{"theme":"linked"}' > "$shared_settings"
+chmod 640 "$shared_settings"
+rm -f "$settings_file"
+ln -s '../shared-claude/settings.json' "$settings_file"
+expected_link=$(readlink "$settings_file")
+expected_linked_settings="$TMP_ROOT/expected-linked-settings.json"
+cp -p "$shared_settings" "$expected_linked_settings"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" REPLACE_SYMLINK_THEN_FAIL=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-symlink-rollback.log" 2>&1
+symlink_rollback_status=$?
+set -e
+[[ "$symlink_rollback_status" -ne 0 ]] || fail 'symlink-replacing hook failure unexpectedly succeeded'
+[[ -L "$settings_file" ]] || fail 'hook rollback did not restore settings.json as a symlink'
+[[ "$(readlink "$settings_file")" == "$expected_link" ]] || fail 'hook rollback changed the settings.json symlink target text'
+cmp -s "$shared_settings" "$expected_linked_settings" || fail 'hook rollback did not restore symlink target content'
+[[ "$(file_mode "$shared_settings")" == '640' ]] || fail 'hook rollback did not restore symlink target permissions'
+failed_link_entry=$(find "$(dirname "$settings_file")" -maxdepth 1 -name '.settings.json.failed-entry.*' -print -quit)
+failed_link_target=$(find "$shared_settings_dir" -maxdepth 1 -name '.settings.json.failed-target.*' -print -quit)
+[[ -n "$failed_link_entry" && -f "$failed_link_entry" ]] || fail 'symlink rollback discarded the failed hook replacement file'
+[[ -n "$failed_link_target" && -f "$failed_link_target" ]] || fail 'symlink rollback discarded the mutated target state'
+grep -Fq 'replacementFile' "$failed_link_entry" || fail 'failed symlink entry recovery copy has wrong content'
+grep -Fq 'mutatedTarget' "$failed_link_target" || fail 'failed symlink target recovery copy has wrong content'
+
+# If a faulty hook replaces the link with a non-empty directory, rollback must
+# fail closed rather than delete/move user files. The original target backup is
+# retained for manual recovery.
+rm -rf "$settings_file"
+printf '%s\n' '{"theme":"linked-directory-case"}' > "$shared_settings"
+chmod 640 "$shared_settings"
+ln -s '../shared-claude/settings.json' "$settings_file"
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" REPLACE_SYMLINK_WITH_DIR_THEN_FAIL=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/hook-unsafe-symlink-rollback.log" 2>&1
+unsafe_symlink_status=$?
+set -e
+[[ "$unsafe_symlink_status" -ne 0 ]] || fail 'unsafe symlink rollback unexpectedly succeeded'
+[[ -d "$settings_file" && -f "$settings_file/user-file" ]] || fail 'unsafe rollback destroyed the replacement directory'
+unsafe_settings_backup=$(find "$shared_settings_dir" -maxdepth 1 -name '.settings.json.previous.*' -print -quit)
+[[ -n "$unsafe_settings_backup" && -f "$unsafe_settings_backup" ]] || fail 'unsafe rollback deleted the original settings backup'
+grep -Fq 'linked-directory-case' "$unsafe_settings_backup" || fail 'retained settings backup has wrong content'
+
+# Dangling settings symlinks are unsafe to back up. Installation fails before
+# launchctl is touched and leaves the dangling link unchanged.
+: > "$LAUNCHCTL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+rm -rf "$settings_file"
+dangling_target='../../missing-claude/settings.json'
+ln -s "$dangling_target" "$settings_file"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  "$SCRIPT" --install > "$TMP_ROOT/dangling-settings.log" 2>&1
+dangling_status=$?
+set -e
+[[ "$dangling_status" -ne 0 ]] || fail 'dangling settings symlink installation unexpectedly succeeded'
+[[ -L "$settings_file" && "$(readlink "$settings_file")" == "$dangling_target" ]] || fail 'dangling settings symlink was modified'
+if grep -Eq '^(bootout|bootstrap) ' "$LAUNCHCTL_LOG"; then
+  fail 'dangling settings symlink changed launchctl state'
+fi
+
+# The replacement plist is fully validated before the currently loaded agent
+# is touched, and failed validation leaves no staging artifacts behind.
+: > "$LAUNCHCTL_LOG"
+: > "$PLUTIL_LOG"
+rm -f "$CLI_CALL_LOG"
+printf 'previous agent\n' > "$installed_plist"
+set +e
+HOME="$TMP_ROOT/home" PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
+  CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights" \
+  PLUTIL_STATUS=1 \
+  "$SCRIPT" --install > "$TMP_ROOT/install-invalid.log" 2>&1
+invalid_install_status=$?
+set -e
+[[ "$invalid_install_status" -ne 0 ]] || fail 'expected invalid rendered plist to fail installation'
+[[ "$(cat "$installed_plist")" == 'previous agent' ]] || fail 'invalid rendered plist replaced the previous plist'
+[[ ! -s "$LAUNCHCTL_LOG" ]] || fail 'invalid rendered plist caused launchctl state changes'
+if find "$TMP_ROOT/home/.code-insights" -maxdepth 1 -name 'com.code-insights.maintenance.plist.tmp.*' -print -quit | grep -q .; then
+  fail 'invalid rendered plist left a staging file behind'
+fi
+
+printf 'launchd installer render tests passed\n'

--- a/automation/tests/maintenance.test.sh
+++ b/automation/tests/maintenance.test.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/automation/code-insights-maintenance.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/code-insights-maintenance-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file=$1
+  local expected=$2
+  grep -Fq -- "$expected" "$file" || fail "expected $file to contain: $expected"
+}
+
+assert_not_contains() {
+  local file=$1
+  local unexpected=$2
+  if [[ -f "$file" ]] && grep -Fq -- "$unexpected" "$file"; then
+    fail "expected $file not to contain: $unexpected"
+  fi
+}
+
+mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/home/.code-insights"
+touch "$TMP_ROOT/home/.code-insights/data.db"
+
+cat > "$TMP_ROOT/bin/code-insights" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'code-insights %s\n' "$*" >> "$CALL_LOG"
+case "${1:-}" in
+  lock-run)
+    shift
+    export CODE_INSIGHTS_LOCK_HELD=1
+    exec "$@"
+    ;;
+  sync)
+    printf 'Already up to date!\n'
+    ;;
+  queue)
+    ;;
+  dashboard)
+    printf '%s\n' "$$" > "$DASHBOARD_PID_FILE"
+    touch "$DASHBOARD_STARTED_FILE"
+    trap 'rm -f "$DASHBOARD_STARTED_FILE"; exit 0' TERM INT
+    while :; do sleep 1; done
+    ;;
+  reflect)
+    touch "$REFLECTED_FILE"
+    printf 'Reflection complete\n'
+    ;;
+esac
+EOF
+
+cat > "$TMP_ROOT/bin/analyze" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'analyze %s\n' "$*" >> "$CALL_LOG"
+count=0
+[[ -f "$ANALYZE_COUNT_FILE" ]] && read -r count < "$ANALYZE_COUNT_FILE"
+if [[ "$count" -eq 0 ]]; then
+  printf '1\n' > "$ANALYZE_COUNT_FILE"
+  printf 'Selected: 2 session(s)\nCompleted: 2 succeeded, 0 failed, 0 not attempted.\n'
+else
+  printf 'Selected: 0 session(s)\nNo incomplete sessions match this batch.\n'
+fi
+EOF
+
+cat > "$TMP_ROOT/bin/sqlite3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+query=${*: -1}
+if [[ "$query" == *"MAX(sf.extracted_at)"* ]]; then
+  printf '%s\n' "${FACETS_NEWER_THAN_SNAPSHOT:-0}"
+elif [[ "$query" == *"FROM session_facets"* ]]; then
+  printf '%s\n' "${FACET_COUNT:-0}"
+elif [[ "$query" == *"SELECT session_count"* ]]; then
+  if [[ "${SNAPSHOT_MATCH:-0}" == "1" || -f "$REFLECTED_FILE" ]]; then
+    printf '%s\n' "${FACET_COUNT:-0}"
+  else
+    printf '%s\n' "${SNAPSHOT_COUNT:-0}"
+  fi
+fi
+EOF
+
+cat > "$TMP_ROOT/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CURL_LOG"
+if [[ -n "${CURL_STATUS:-}" ]]; then
+  exit "$CURL_STATUS"
+fi
+[[ -f "$DASHBOARD_STARTED_FILE" ]]
+EOF
+
+chmod +x "$TMP_ROOT/bin/code-insights" "$TMP_ROOT/bin/analyze" "$TMP_ROOT/bin/sqlite3" "$TMP_ROOT/bin/curl"
+
+export HOME="$TMP_ROOT/home"
+export PATH="$TMP_ROOT/bin:/usr/bin:/bin"
+export CODE_INSIGHTS_BIN="$TMP_ROOT/bin/code-insights"
+export CODE_INSIGHTS_ANALYZE_SCRIPT="$TMP_ROOT/bin/analyze"
+export CODE_INSIGHTS_SQLITE_BIN="$TMP_ROOT/bin/sqlite3"
+export CODE_INSIGHTS_CURL_BIN="$TMP_ROOT/bin/curl"
+export CODE_INSIGHTS_DB="$HOME/.code-insights/data.db"
+export CODE_INSIGHTS_MAX_BATCHES=3
+export CODE_INSIGHTS_BATCH_SIZE=5
+export CODE_INSIGHTS_DELAY=0
+export CODE_INSIGHTS_REFLECT_WEEK=2026-W27
+export CODE_INSIGHTS_CURRENT_WEEK_START=2026-07-06
+export CALL_LOG="$TMP_ROOT/calls.log"
+export ANALYZE_COUNT_FILE="$TMP_ROOT/analyze-count"
+export REFLECTED_FILE="$TMP_ROOT/reflected"
+export CURL_LOG="$TMP_ROOT/curl.log"
+export DASHBOARD_PID_FILE="$TMP_ROOT/dashboard.pid"
+export DASHBOARD_STARTED_FILE="$TMP_ROOT/dashboard.started"
+
+# Newest-first drain repeats bounded batches until there is no work.
+FACET_COUNT=0 "$SCRIPT" run > "$TMP_ROOT/run.log" 2>&1
+assert_contains "$CALL_LOG" "code-insights lock-run /bin/bash $SCRIPT run"
+assert_contains "$CALL_LOG" 'code-insights sync'
+assert_contains "$CALL_LOG" 'code-insights queue process -q --limit 5 --delay 0'
+assert_contains "$CALL_LOG" 'analyze --days 36500 --batch-size 5 --delay 0'
+[[ "$(grep -c '^analyze ' "$CALL_LOG")" -eq 2 ]] || fail 'expected two bounded analyze calls'
+
+# A stale weekly snapshot is refreshed through an already-running dashboard.
+: > "$CALL_LOG"
+printf '1\n' > "$ANALYZE_COUNT_FILE"
+rm -f "$REFLECTED_FILE"
+FACET_COUNT=9 SNAPSHOT_COUNT=8 CURL_STATUS=0 "$SCRIPT" run > "$TMP_ROOT/reflect.log" 2>&1
+assert_contains "$CALL_LOG" 'code-insights reflect --week 2026-W27'
+assert_not_contains "$CALL_LOG" 'code-insights dashboard'
+[[ -f "$REFLECTED_FILE" ]] || fail 'expected reflect to update the snapshot marker'
+
+# An up-to-date weekly snapshot is idempotently skipped.
+: > "$CALL_LOG"
+SNAPSHOT_MATCH=1 FACET_COUNT=9 FACETS_NEWER_THAN_SNAPSHOT=0 \
+  "$SCRIPT" run > "$TMP_ROOT/idempotent.log" 2>&1
+assert_not_contains "$CALL_LOG" 'code-insights reflect'
+
+# Equal counts are still stale when any facet was re-extracted after the
+# snapshot was generated.
+grep -Fq 'WHEN datetime(MAX(sf.extracted_at)) > datetime((' "$SCRIPT" \
+  || fail 'snapshot freshness does not normalize SQLite and ISO timestamps'
+: > "$CALL_LOG"
+rm -f "$REFLECTED_FILE"
+SNAPSHOT_MATCH=1 FACET_COUNT=9 FACETS_NEWER_THAN_SNAPSHOT=1 CURL_STATUS=0 \
+  "$SCRIPT" run > "$TMP_ROOT/content-stale.log" 2>&1
+assert_contains "$CALL_LOG" 'code-insights reflect --week 2026-W27'
+[[ -f "$REFLECTED_FILE" ]] || fail 'expected newer facet content to refresh the snapshot'
+
+# The configured dashboard port drives both the health check and the temporary
+# server, so reflection never probes one port while starting another.
+printf '%s\n' '{"dashboard":{"port":8123}}' > "$HOME/.code-insights/config.json"
+: > "$CALL_LOG"
+: > "$CURL_LOG"
+printf '1\n' > "$ANALYZE_COUNT_FILE"
+rm -f "$REFLECTED_FILE" "$DASHBOARD_STARTED_FILE" "$DASHBOARD_PID_FILE"
+FACET_COUNT=9 SNAPSHOT_COUNT=8 FACETS_NEWER_THAN_SNAPSHOT=0 \
+  "$SCRIPT" run > "$TMP_ROOT/configured-port.log" 2>&1
+assert_contains "$CURL_LOG" 'http://127.0.0.1:8123/api/health'
+assert_contains "$CALL_LOG" 'code-insights dashboard --no-open --no-sync --port 8123'
+[[ ! -f "$DASHBOARD_STARTED_FILE" ]] || fail 'temporary dashboard was not stopped after reflection'
+
+# An explicit URL overrides config.json, including the port used when a local
+# temporary dashboard has to be started.
+: > "$CALL_LOG"
+: > "$CURL_LOG"
+rm -f "$REFLECTED_FILE" "$DASHBOARD_STARTED_FILE" "$DASHBOARD_PID_FILE"
+CODE_INSIGHTS_DASHBOARD_URL='http://127.0.0.1:9123' \
+  FACET_COUNT=9 SNAPSHOT_COUNT=8 FACETS_NEWER_THAN_SNAPSHOT=0 \
+  "$SCRIPT" run > "$TMP_ROOT/url-override.log" 2>&1
+assert_contains "$CURL_LOG" 'http://127.0.0.1:9123/api/health'
+assert_not_contains "$CURL_LOG" 'http://127.0.0.1:8123/api/health'
+assert_contains "$CALL_LOG" 'code-insights dashboard --no-open --no-sync --port 9123'
+
+# An unhealthy explicit remote URL cannot be repaired by launching a local
+# dashboard. Fail the reflection promptly without starting an unrelated server.
+: > "$CALL_LOG"
+: > "$CURL_LOG"
+rm -f "$REFLECTED_FILE" "$DASHBOARD_STARTED_FILE" "$DASHBOARD_PID_FILE"
+set +e
+CODE_INSIGHTS_DASHBOARD_URL='https://insights.example.test' CURL_STATUS=1 \
+  FACET_COUNT=9 SNAPSHOT_COUNT=8 FACETS_NEWER_THAN_SNAPSHOT=0 \
+  "$SCRIPT" run > "$TMP_ROOT/remote-url.log" 2>&1
+remote_status=$?
+set -e
+[[ "$remote_status" -eq 1 ]] || fail "expected unhealthy remote dashboard exit 1, got $remote_status"
+assert_contains "$CURL_LOG" 'https://insights.example.test/api/health'
+assert_not_contains "$CALL_LOG" 'code-insights dashboard'
+assert_contains "$TMP_ROOT/remote-url.log" 'Explicit dashboard URL is unavailable; cannot start a local replacement.'
+
+# Week boundaries must use UTC because the server parses YYYY-WNN in UTC.
+grep -Fq "date -u '+%u'" "$SCRIPT" || fail 'calendar calculation is not aligned to server UTC weeks'
+
+# TERM must stop maintenance immediately and let EXIT cleanup release its
+# temporary dashboard child. The Node lock-run tests cover shared-lock release.
+: > "$CALL_LOG"
+printf '1\n' > "$ANALYZE_COUNT_FILE"
+rm -f "$REFLECTED_FILE" "$DASHBOARD_PID_FILE" "$DASHBOARD_STARTED_FILE"
+FACET_COUNT=9 SNAPSHOT_COUNT=8 CURL_STATUS=1 \
+  "$SCRIPT" run > "$TMP_ROOT/term.log" 2>&1 &
+maintenance_pid=$!
+for _ in {1..100}; do
+  [[ -f "$DASHBOARD_PID_FILE" ]] && break
+  sleep 0.05
+done
+[[ -f "$DASHBOARD_PID_FILE" ]] || fail 'maintenance never started its temporary dashboard'
+read -r dashboard_pid < "$DASHBOARD_PID_FILE"
+kill -TERM "$maintenance_pid"
+set +e
+wait "$maintenance_pid"
+term_status=$?
+set -e
+[[ "$term_status" -eq 143 ]] || fail "expected TERM exit 143, got $term_status"
+if kill -0 "$dashboard_pid" 2>/dev/null; then
+  fail 'TERM left the temporary dashboard running'
+fi
+assert_not_contains "$TMP_ROOT/term.log" 'Code Insights maintenance finished'
+
+printf 'maintenance automation tests passed\n'

--- a/automation/tests/throttled-lock.test.sh
+++ b/automation/tests/throttled-lock.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SCRIPT="$ROOT/throttled-analyze.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/code-insights-throttled-lock-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/home/.code-insights/locks"
+touch "$TMP_ROOT/home/.code-insights/data.db"
+
+cat > "$TMP_ROOT/bin/sqlite3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${SQLITE_LOG:-}" ]] || printf 'sqlite3 %s\n' "$*" >> "$SQLITE_LOG"
+query=${*: -1}
+if [[ "$query" == *"SELECT s.id"* ]]; then
+  printf 'session-1\n'
+elif [[ "$query" == *"COUNT(DISTINCT analysis_type)"* ]]; then
+  printf '2\n'
+fi
+EOF
+
+cat > "$TMP_ROOT/bin/code-insights" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'code-insights %s\n' "$*" >> "$CALL_LOG"
+if [[ "${1:-}" == 'lock-run' ]]; then
+  shift
+  [[ ! -d "$HOME/.code-insights/locks/llm.lock" ]] || exit 75
+  CODE_INSIGHTS_LOCK_HELD=1 "$@"
+fi
+exit 0
+EOF
+chmod +x "$TMP_ROOT/bin/sqlite3" "$TMP_ROOT/bin/code-insights"
+
+export HOME="$TMP_ROOT/home"
+export PATH="$TMP_ROOT/bin:/usr/bin:/bin"
+export CODE_INSIGHTS_DB="$HOME/.code-insights/data.db"
+export CODE_INSIGHTS_LOG="$HOME/.code-insights/test.log"
+export CODE_INSIGHTS_FAIL_LOG="$HOME/.code-insights/test.failures"
+export CALL_LOG="$TMP_ROOT/calls.log"
+export SQLITE_LOG="$TMP_ROOT/sqlite.log"
+
+"$SCRIPT" --days 1 --batch-size 1 --delay 0 > "$TMP_ROOT/delegated.log" 2>&1
+grep -Fq "code-insights lock-run /bin/bash $SCRIPT --days 1 --batch-size 1 --delay 0" "$CALL_LOG" \
+  || fail 'standalone batch did not delegate locking to the Node lock runner'
+
+mkdir -p "$HOME/.code-insights/locks/llm.lock"
+printf '%s\n' "$$" > "$HOME/.code-insights/locks/llm.lock/pid"
+
+set +e
+"$SCRIPT" --days 1 --batch-size 1 --delay 0 > "$TMP_ROOT/busy.log" 2>&1
+status=$?
+set -e
+[[ "$status" -eq 75 ]] || fail "expected shared lock exit 75, got $status"
+
+CODE_INSIGHTS_LOCK_HELD=1 "$SCRIPT" --days 1 --batch-size 1 --delay 0 > "$TMP_ROOT/inherited.log" 2>&1
+grep -Fq 'Completed: 1 succeeded, 0 failed' "$TMP_ROOT/inherited.log" || fail 'inherited lock did not allow serial child batch'
+
+# All default data/log paths follow CODE_INSIGHTS_CONFIG_DIR. Maintenance sets
+# this in launchd, so the child batch must not silently fall back to $HOME.
+unset CODE_INSIGHTS_DB CODE_INSIGHTS_LOG CODE_INSIGHTS_FAIL_LOG
+export CODE_INSIGHTS_CONFIG_DIR="$TMP_ROOT/custom-config"
+mkdir -p "$CODE_INSIGHTS_CONFIG_DIR"
+touch "$CODE_INSIGHTS_CONFIG_DIR/data.db"
+: > "$SQLITE_LOG"
+CODE_INSIGHTS_LOCK_HELD=1 "$SCRIPT" --days 1 --batch-size 1 --delay 0 > "$TMP_ROOT/custom.log" 2>&1
+grep -Fq "sqlite3 $CODE_INSIGHTS_CONFIG_DIR/data.db" "$SQLITE_LOG" \
+  || fail 'custom config directory did not select its database'
+[[ -f "$CODE_INSIGHTS_CONFIG_DIR/throttled-analyze.log" ]] \
+  || fail 'custom config directory did not receive the analysis log'
+
+printf 'throttled shared-lock tests passed\n'

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,6 +28,7 @@
     "./analysis/prompt-quality-normalize": "./dist/analysis/prompt-quality-normalize.js",
     "./analysis/runner-types": "./dist/analysis/runner-types.js",
     "./analysis/native-runner": "./dist/analysis/native-runner.js",
+    "./analysis/llm-lock": "./dist/analysis/llm-lock.js",
     "./analysis/analysis-db": "./dist/analysis/analysis-db.js",
     "./analysis/analysis-usage-db": "./dist/analysis/analysis-usage-db.js",
     "./analysis/provider-runner": "./dist/analysis/provider-runner.js",

--- a/cli/src/__tests__/index-entry.test.ts
+++ b/cli/src/__tests__/index-entry.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const entryState = vi.hoisted(() => ({
+  asyncActionWasAwaited: false,
+  lockRunArgs: null as string[] | null,
+  lockRunResult: 0,
+}));
+
+vi.mock('../commands/init.js', () => ({ initCommand: vi.fn() }));
+vi.mock('../commands/sync.js', () => ({
+  syncCommand: vi.fn(),
+  getTrivialSessions: vi.fn(() => []),
+  pruneTrivialSessions: vi.fn(),
+}));
+vi.mock('../commands/status.js', () => ({ statusCommand: vi.fn() }));
+vi.mock('../commands/install-hook.js', () => ({
+  installHookCommand: vi.fn(),
+  uninstallHookCommand: vi.fn(),
+}));
+vi.mock('../commands/open.js', () => ({ openCommand: vi.fn() }));
+vi.mock('../commands/dashboard.js', () => ({ dashboardCommand: vi.fn() }));
+vi.mock('../commands/insights.js', () => ({
+  insightsCommand: vi.fn(),
+  insightsCheckCommand: vi.fn(),
+}));
+vi.mock('../commands/session-end.js', () => ({ sessionEndCommand: vi.fn() }));
+vi.mock('../commands/doctor/index.js', () => ({ doctorCommand: vi.fn() }));
+vi.mock('../commands/lock-run.js', () => ({
+  runCommandWithLlmLock: vi.fn(async (command: string[]) => {
+    entryState.lockRunArgs = command;
+    return entryState.lockRunResult;
+  }),
+}));
+
+vi.mock('../commands/reset.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  return { resetCommand: new Command('reset') };
+});
+vi.mock('../commands/stats/index.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  return { statsCommand: new Command('stats') };
+});
+vi.mock('../commands/config.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  return { configCommand: new Command('config') };
+});
+vi.mock('../commands/telemetry.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  return { telemetryCommand: new Command('telemetry') };
+});
+vi.mock('../commands/queue.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  return { buildQueueCommand: () => new Command('queue') };
+});
+
+vi.mock('../commands/reflect.js', async () => {
+  const { Command } = await vi.importActual<typeof import('commander')>('commander');
+  const reflectCommand = new Command('reflect');
+
+  reflectCommand.action(() => {
+    const rejection = new Error('Synthetic asynchronous command failure');
+    const thenable = {
+      then(
+        _onFulfilled: (value?: unknown) => unknown,
+        onRejected?: (reason: unknown) => unknown,
+      ) {
+        // Commander.parse() chains thenables without awaiting their rejection,
+        // while parseAsync() eventually supplies an onRejected callback.
+        if (onRejected) {
+          entryState.asyncActionWasAwaited = true;
+          onRejected(rejection);
+        }
+        return thenable;
+      },
+    };
+    return thenable as unknown as Promise<void>;
+  });
+
+  return { reflectCommand };
+});
+
+vi.mock('../utils/telemetry.js', () => ({ showTelemetryNoticeIfNeeded: vi.fn() }));
+
+describe('CLI production entry point', () => {
+  const originalArgv = process.argv;
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    entryState.asyncActionWasAwaited = false;
+    entryState.lockRunArgs = null;
+    entryState.lockRunResult = 0;
+    process.argv = ['node', 'code-insights', 'reflect'];
+    process.exitCode = undefined;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it('awaits an asynchronous command failure and reports it without a stack trace', async () => {
+    await import('../index.js');
+
+    expect(entryState.asyncActionWasAwaited).toBe(true);
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledOnce();
+    expect(console.error).toHaveBeenCalledWith(
+      '[Code Insights] Synthetic asynchronous command failure',
+    );
+  }, 20_000);
+
+  it('passes all child arguments to lock-run and propagates its exit status', async () => {
+    process.argv = [
+      'node',
+      'code-insights',
+      'lock-run',
+      '/usr/bin/example',
+      '--child-flag',
+      'value',
+    ];
+    entryState.lockRunResult = 7;
+    vi.spyOn(process, 'exit').mockImplementation((code): never => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    await import('../index.js');
+
+    expect(entryState.lockRunArgs).toEqual([
+      '/usr/bin/example',
+      '--child-flag',
+      'value',
+    ]);
+    expect(process.exitCode).toBe(7);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('reports a busy lock concisely and preserves exit status 75', async () => {
+    process.argv = ['node', 'code-insights', 'lock-run', '/usr/bin/true'];
+    entryState.lockRunResult = 75;
+    vi.spyOn(process, 'exit').mockImplementation((code): never => {
+      throw new Error(`process.exit(${String(code)})`);
+    });
+
+    await import('../index.js');
+
+    expect(entryState.lockRunArgs).toEqual(['/usr/bin/true']);
+    expect(process.exitCode).toBe(75);
+    expect(console.error).toHaveBeenCalledOnce();
+    expect(console.error).toHaveBeenCalledWith(
+      '[Code Insights] Another LLM analysis process is already running.',
+    );
+  });
+
+  it('keeps the internal lock-run command out of public help', async () => {
+    process.argv = ['node', 'code-insights', '--help'];
+    let helpOutput = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk): boolean => {
+      helpOutput += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, 'exit').mockImplementation((): never => {
+      throw new Error('help complete');
+    });
+
+    await import('../index.js');
+
+    expect(helpOutput).not.toContain('lock-run');
+  });
+
+  it.each([
+    ['sync', '--dry-run'],
+    ['sync', '--source', 'codex-cli', '--dry-run'],
+    ['sync', '--dry-run', '--project', 'example'],
+  ])('does not persist the telemetry notice for a dry-run sync: %j', async (...args) => {
+    process.argv = ['node', 'code-insights', ...args];
+
+    await import('../index.js');
+    const { showTelemetryNoticeIfNeeded } = await import('../utils/telemetry.js');
+
+    expect(showTelemetryNoticeIfNeeded).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/analysis/__tests__/llm-lock-windows.test.ts
+++ b/cli/src/analysis/__tests__/llm-lock-windows.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const mockSpawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({ spawnSync: mockSpawnSync }));
+
+import { acquireLlmLock } from '../llm-lock.js';
+
+describe('LLM process lock on Windows', () => {
+  let tempDir: string;
+  let platformSpy: ReturnType<typeof vi.spyOn>;
+  let previousSystemRoot: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'code-insights-llm-lock-win32-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(tempDir, 'llm.lock');
+    previousSystemRoot = process.env.SystemRoot;
+    process.env.SystemRoot = 'D:\\Windows';
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    mockSpawnSync.mockReturnValue({ status: 0, stdout: '638881234567890000\n' });
+  });
+
+  afterEach(() => {
+    platformSpy.mockRestore();
+    rmSync(tempDir, { recursive: true, force: true });
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+    else process.env.SystemRoot = previousSystemRoot;
+    mockSpawnSync.mockReset();
+  });
+
+  it('uses the system PowerShell executable instead of caller PATH resolution', () => {
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      expect.any(Array),
+      expect.objectContaining({ windowsHide: true }),
+    );
+    lock?.release();
+  });
+});

--- a/cli/src/analysis/__tests__/llm-lock.test.ts
+++ b/cli/src/analysis/__tests__/llm-lock.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+const testState = vi.hoisted(() => ({ home: '' }));
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => testState.home };
+});
+
+import { acquireLlmLock, isLlmLockTokenOwner } from '../llm-lock.js';
+
+describe('LLM process lock', () => {
+  beforeEach(() => {
+    testState.home = mkdtempSync(join(tmpdir(), 'code-insights-llm-lock-'));
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+    delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    delete process.env.CODE_INSIGHTS_LOCK_TOKEN;
+  });
+
+  afterEach(() => {
+    rmSync(testState.home, { recursive: true, force: true });
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+    delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    delete process.env.CODE_INSIGHTS_LOCK_TOKEN;
+  });
+
+  it('creates an unguessable ownership token that can validate delegated work', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+
+    const lock = acquireLlmLock();
+
+    expect(lock?.token).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(readFileSync(join(lockPath, 'token'), 'utf-8').trim()).toBe(lock?.token);
+    expect(isLlmLockTokenOwner(lock?.token)).toBe(true);
+    expect(isLlmLockTokenOwner('wrong-token')).toBe(false);
+    lock?.release();
+    expect(isLlmLockTokenOwner(lock?.token)).toBe(false);
+  });
+
+  it.runIf(process.platform === 'darwin')('keeps process birth identity stable across caller environments', () => {
+    const previousLocale = process.env.LC_ALL;
+    const previousTimezone = process.env.TZ;
+    const previousPath = process.env.PATH;
+    const fakeBin = join(testState.home, 'fake-bin');
+    mkdirSync(fakeBin);
+    writeFileSync(join(fakeBin, 'ps'), '#!/bin/sh\nprintf "different-ps-identity\\n"\n');
+    chmodSync(join(fakeBin, 'ps'), 0o700);
+    let lock: ReturnType<typeof acquireLlmLock> = null;
+    try {
+      process.env.LC_ALL = 'C';
+      process.env.TZ = 'UTC';
+      process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+      lock = acquireLlmLock();
+      expect(lock).not.toBeNull();
+
+      process.env.LC_ALL = 'zh_CN.UTF-8';
+      process.env.TZ = 'Asia/Shanghai';
+      process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+      expect(isLlmLockTokenOwner(lock?.token)).toBe(true);
+      expect(acquireLlmLock()).toBeNull();
+    } finally {
+      lock?.release();
+      if (previousLocale === undefined) delete process.env.LC_ALL;
+      else process.env.LC_ALL = previousLocale;
+      if (previousTimezone === undefined) delete process.env.TZ;
+      else process.env.TZ = previousTimezone;
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  it('rejects a stale capability after its owner process has exited', () => {
+    const deadProcess = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${deadProcess.pid}\n`);
+    writeFileSync(join(lockPath, 'token'), 'stale-token\n');
+
+    expect(isLlmLockTokenOwner('stale-token')).toBe(false);
+  });
+
+  it('reclaims a lock owned by a dead process', () => {
+    const deadProcess = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    expect(deadProcess.pid).toBeTypeOf('number');
+
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${deadProcess.pid}\n`);
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(process.pid));
+    lock?.release();
+  });
+
+  it('reclaims a stale lock after its PID has been reused by another process', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+    writeFileSync(join(lockPath, 'process-start'), 'a-different-process-birth\n');
+    writeFileSync(join(lockPath, 'token'), 'stale-token\n');
+
+    expect(isLlmLockTokenOwner('stale-token')).toBe(false);
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(readFileSync(join(lockPath, 'token'), 'utf-8').trim()).not.toBe('stale-token');
+    lock?.release();
+  });
+
+  it('inherits a parent-held lock without releasing the parent lock', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+    writeFileSync(join(lockPath, 'token'), 'parent-token\n');
+    process.env.CODE_INSIGHTS_LOCK_HELD = '1';
+    process.env.CODE_INSIGHTS_LOCK_TOKEN = 'parent-token';
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(lock?.token).toBe('parent-token');
+    lock?.release();
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(process.pid));
+  });
+
+  it('fails closed when an inherited marker no longer has a live owning lock', () => {
+    process.env.CODE_INSIGHTS_LOCK_HELD = '1';
+    process.env.CODE_INSIGHTS_LOCK_TOKEN = 'orphaned-token';
+
+    expect(acquireLlmLock()).toBeNull();
+  });
+
+  it('does not release a lock whose owner PID no longer matches', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    const lock = acquireLlmLock();
+    expect(lock).not.toBeNull();
+
+    const replacementPid = process.pid + 1;
+    writeFileSync(join(lockPath, 'pid'), `${replacementPid}\n`);
+
+    lock?.release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(replacementPid));
+  });
+
+  it('does not release a replacement lock owned by the same process with a new token', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    const original = acquireLlmLock();
+    expect(original).not.toBeNull();
+
+    // Simulate external cleanup followed by a fresh acquisition before the old
+    // handle reaches its finally block. PID alone cannot distinguish the two.
+    rmSync(lockPath, { recursive: true, force: true });
+    const replacement = acquireLlmLock();
+    expect(replacement).not.toBeNull();
+    expect(replacement?.token).not.toBe(original?.token);
+
+    original?.release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(join(lockPath, 'token'), 'utf-8').trim()).toBe(replacement?.token);
+    replacement?.release();
+  });
+
+  it('places the lock under CODE_INSIGHTS_CONFIG_DIR when configured', () => {
+    const configDir = join(testState.home, 'custom-config');
+    const expectedLockPath = join(configDir, 'locks', 'llm.lock');
+    process.env.CODE_INSIGHTS_CONFIG_DIR = configDir;
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(expectedLockPath)).toBe(true);
+    lock?.release();
+  });
+
+  it('prefers CODE_INSIGHTS_LLM_LOCK_DIR over the configured config directory', () => {
+    const explicitLockPath = join(testState.home, 'shared-lock', 'llm.lock');
+    process.env.CODE_INSIGHTS_CONFIG_DIR = join(testState.home, 'custom-config');
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = explicitLockPath;
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(explicitLockPath)).toBe(true);
+    lock?.release();
+  });
+
+  it('does not reclaim a stale lock while another process owns the recovery guard', () => {
+    const deadProcess = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    const recoveryPath = `${lockPath}.reclaim`;
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${deadProcess.pid}\n`);
+    mkdirSync(recoveryPath);
+    writeFileSync(join(recoveryPath, 'pid'), `${process.pid}\n`);
+
+    const lock = acquireLlmLock();
+
+    expect(lock).toBeNull();
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(deadProcess.pid));
+  });
+
+  it('reclaims an ownerless lock after the PID-write grace period', () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    const oldTimestamp = new Date(Date.now() - 120_000);
+    utimesSync(lockPath, oldTimestamp, oldTimestamp);
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(process.pid));
+    lock?.release();
+  });
+
+  it('reclaims a recovery guard owned by a dead process', () => {
+    const deadMain = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    const deadRecovery = spawnSync(process.execPath, ['-e', 'process.exit(0)']);
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    const recoveryPath = `${lockPath}.reclaim`;
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${deadMain.pid}\n`);
+    mkdirSync(recoveryPath);
+    writeFileSync(join(recoveryPath, 'pid'), `${deadRecovery.pid}\n`);
+
+    const lock = acquireLlmLock();
+
+    expect(lock).not.toBeNull();
+    expect(readFileSync(join(lockPath, 'pid'), 'utf-8').trim()).toBe(String(process.pid));
+    expect(existsSync(recoveryPath)).toBe(false);
+    lock?.release();
+  });
+});

--- a/cli/src/analysis/__tests__/native-runner.test.ts
+++ b/cli/src/analysis/__tests__/native-runner.test.ts
@@ -19,10 +19,7 @@ const mockUnlinkSync = vi.mocked(unlinkSync);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/**
- * Build the JSON envelope that `claude -p --output-format json` actually returns.
- * The LLM text lives in the result event's `result` field.
- */
+/** Build the legacy stream-style envelope returned by older Claude versions. */
 function makeEnvelope(llmText: string, isError = false): string {
   return JSON.stringify([
     { type: 'system', subtype: 'init', session_id: 'test-session' },
@@ -34,6 +31,51 @@ function makeEnvelope(llmText: string, isError = false): string {
       is_error: isError,
     },
   ]);
+}
+
+/** Build the single result object returned by current `--output-format json`. */
+function makeSingleResult(
+  llmText: string,
+  options?: { isError?: boolean; structuredOutput?: object }
+): string {
+  return JSON.stringify({
+    type: 'result',
+    subtype: options?.isError ? 'error_during_execution' : 'success',
+    result: llmText,
+    is_error: options?.isError ?? false,
+    ...(options?.structuredOutput ? { structured_output: options.structuredOutput } : {}),
+  });
+}
+
+/** Mirror the non-zero execFileSync error shape exposed by Node.js. */
+function makeExecFailure(stdout: string, stderr = 'claude exited with status 1'): Error {
+  return Object.assign(new Error('Command failed: claude -p'), {
+    status: 1,
+    signal: null,
+    output: [null, stdout, stderr],
+    pid: 4242,
+    stdout,
+    stderr,
+  });
+}
+
+/** Build the single error result emitted by Claude Code 2.1.168. */
+function makeCurrentErrorResult(subtype: string, errors: string[]): string {
+  return JSON.stringify({
+    type: 'result',
+    subtype,
+    is_error: true,
+    duration_ms: 25,
+    duration_api_ms: 0,
+    num_turns: 0,
+    session_id: 'test-session',
+    total_cost_usd: 0,
+    usage: {},
+    modelUsage: {},
+    permission_denials: [],
+    errors,
+    uuid: 'test-result-id',
+  });
 }
 
 // ── validate() ────────────────────────────────────────────────────────────────
@@ -110,7 +152,7 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     expect(result.model).toBe('sonnet');
   });
 
-  it('includes --json-schema arg when jsonSchema is provided', async () => {
+  it('passes --json-schema as inline JSON when jsonSchema is provided', async () => {
     const llmJson = '{"summary": {"title": "t", "content": "c", "bullets": []}}';
     mockExecFileSync.mockReturnValueOnce(makeEnvelope(llmJson) as unknown as Buffer);
     const runner = new ClaudeNativeRunner();
@@ -125,7 +167,12 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     expect(callArgs).toContain('--json-schema');
 
     const schemaIndex = callArgs.indexOf('--json-schema');
-    expect(callArgs[schemaIndex + 1]).toContain('ci-schema-');
+    expect(callArgs[schemaIndex + 1]).toBe('{"type":"object","properties":{}}');
+    expect(mockWriteFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('ci-schema-'),
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it('extracts rawJson from the result event (not the full envelope)', async () => {
@@ -138,6 +185,32 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     // Must be the extracted LLM text, not the raw event array
     expect(result.rawJson).toBe(llmJson);
     expect(result.rawJson).not.toContain('"type":"result"');
+  });
+
+  it('extracts rawJson from the single result object returned by current Claude CLI', async () => {
+    const llmJson = '{"summary":{"title":"Current","content":"C","bullets":[]}}';
+    mockExecFileSync.mockReturnValueOnce(makeSingleResult(llmJson) as unknown as Buffer);
+    const runner = new ClaudeNativeRunner();
+
+    const result = await runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' });
+
+    expect(result.rawJson).toBe(llmJson);
+  });
+
+  it('serializes structured_output when Claude returns validated structured data', async () => {
+    const structuredOutput = { summary: { title: 'Structured', content: 'C', bullets: [] } };
+    mockExecFileSync.mockReturnValueOnce(
+      makeSingleResult('The structured response is attached.', { structuredOutput }) as unknown as Buffer
+    );
+    const runner = new ClaudeNativeRunner();
+
+    const result = await runner.runAnalysis({
+      systemPrompt: 's',
+      userPrompt: 'u',
+      jsonSchema: { type: 'object' },
+    });
+
+    expect(JSON.parse(result.rawJson)).toEqual(structuredOutput);
   });
 
   it('returns correct result shape with zero tokens', async () => {
@@ -164,6 +237,42 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
       .rejects.toThrow(/claude -p reported an error/);
   });
 
+  it('preserves errors from a current single-result response on non-zero exit', async () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw makeExecFailure(makeCurrentErrorResult(
+        'error_during_execution',
+        ['API Error: 429 rate limit exceeded'],
+      ));
+    });
+    const runner = new ClaudeNativeRunner();
+
+    await expect(runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' }))
+      .rejects.toThrow(/error_during_execution.*429 rate limit exceeded/);
+  });
+
+  it('preserves the legacy result message from an event-array response on non-zero exit', async () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw makeExecFailure(makeEnvelope('Context window exceeded', true));
+    });
+    const runner = new ClaudeNativeRunner();
+
+    await expect(runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' }))
+      .rejects.toThrow(/error_during_execution.*Context window exceeded/);
+  });
+
+  it.each([
+    'error_max_budget_usd',
+    'error_max_structured_output_retries',
+  ])('preserves the %s subtype from a non-zero Claude result', async (subtype) => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw makeExecFailure(makeCurrentErrorResult(subtype, ['Configured limit reached']));
+    });
+    const runner = new ClaudeNativeRunner();
+
+    await expect(runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' }))
+      .rejects.toThrow(new RegExp(`${subtype}.*Configured limit reached`));
+  });
+
   it('throws when output is not a JSON array', async () => {
     mockExecFileSync.mockReturnValueOnce('not json at all' as unknown as Buffer);
     const runner = new ClaudeNativeRunner();
@@ -172,12 +281,12 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
       .rejects.toThrow(/non-JSON output/);
   });
 
-  it('throws when output is JSON but not an array', async () => {
-    mockExecFileSync.mockReturnValueOnce('{"type":"result"}' as unknown as Buffer);
+  it('throws when output is JSON but is not a result object or event array', async () => {
+    mockExecFileSync.mockReturnValueOnce('{"status":"ok"}' as unknown as Buffer);
     const runner = new ClaudeNativeRunner();
 
     await expect(runner.runAnalysis({ systemPrompt: 's', userPrompt: 'u' }))
-      .rejects.toThrow(/not an array/);
+      .rejects.toThrow(/no result event/);
   });
 
   it('throws when event array is empty', async () => {
@@ -265,7 +374,7 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
     expect(mockUnlinkSync).toHaveBeenCalledWith(expect.stringContaining('ci-prompt-'));
   });
 
-  it('cleans up both temp files when schema is provided and execFileSync throws', async () => {
+  it('does not create a schema temp file when schema is provided and execFileSync throws', async () => {
     mockExecFileSync.mockImplementationOnce(() => { throw new Error('fail'); });
     const runner = new ClaudeNativeRunner();
 
@@ -275,7 +384,7 @@ describe('ClaudeNativeRunner.runAnalysis()', () => {
 
     const unlinkCalls = mockUnlinkSync.mock.calls.map(c => c[0] as string);
     expect(unlinkCalls.some(p => p.includes('ci-prompt-'))).toBe(true);
-    expect(unlinkCalls.some(p => p.includes('ci-schema-'))).toBe(true);
+    expect(unlinkCalls.some(p => p.includes('ci-schema-'))).toBe(false);
   });
 
   it('has the correct runner name', () => {

--- a/cli/src/analysis/__tests__/prompts.test.ts
+++ b/cli/src/analysis/__tests__/prompts.test.ts
@@ -572,6 +572,35 @@ describe('parseAnalysisResponse', () => {
     expect(Array.isArray(result.data.facets?.friction_points)).toBe(true);
     expect(Array.isArray(result.data.facets?.effective_patterns)).toBe(true);
   });
+
+  it('filters friction points without a non-empty string category', () => {
+    const response = `<json>{
+      "summary": { "title": "Test", "content": "c", "bullets": [] },
+      "decisions": [],
+      "learnings": [],
+      "facets": {
+        "friction_points": [
+          "reasoning-only primitive",
+          { "_reasoning": "No friction occurred." },
+          { "category": null, "description": "N/A", "severity": null, "resolution": null },
+          { "category": 42, "description": "N/A" },
+          { "category": { "nested": true }, "description": "N/A" },
+          { "category": ["wrong-approach"], "description": "N/A" },
+          { "category": "   ", "description": "N/A" },
+          { "category": "wrong-approach", "description": "Valid", "severity": "medium", "resolution": "Resolved" }
+        ],
+        "effective_patterns": []
+      }
+    }</json>`;
+
+    const result = parseAnalysisResponse(response);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.facets?.friction_points).toEqual([
+      expect.objectContaining({ category: 'wrong-approach', description: 'Valid' }),
+    ]);
+  });
 });
 
 // ──────────────────────────────────────────────────────

--- a/cli/src/analysis/__tests__/provider-runner.test.ts
+++ b/cli/src/analysis/__tests__/provider-runner.test.ts
@@ -171,6 +171,23 @@ describe('ProviderRunner.runAnalysis() — Anthropic message shaping', () => {
     expect(body.system).toBe('BE HELPFUL');
     expect(body.messages).toEqual([{ role: 'user', content: 'analyze' }]);
   });
+
+  it('replaces isolated UTF-16 surrogates while preserving valid emoji', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({
+      content: [{ text: '{}' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }));
+
+    const runner = new ProviderRunner(makeConfig({ provider: 'anthropic', model: 'glm-4.7', apiKey: 'ak' }));
+    await runner.runAnalysis({
+      systemPrompt: 'system \ud800 prompt',
+      userPrompt: 'valid 🧪 and isolated \udc00 text',
+    });
+
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.system).toBe('system � prompt');
+    expect(body.messages[0].content).toBe('valid 🧪 and isolated � text');
+  });
 });
 
 describe('ProviderRunner.runAnalysis() — missing usage', () => {

--- a/cli/src/analysis/__tests__/queue-worker.test.ts
+++ b/cli/src/analysis/__tests__/queue-worker.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const testState = vi.hoisted(() => ({ home: '' }));
+const queueMocks = vi.hoisted(() => ({
+  claimNext: vi.fn(),
+  markCompleted: vi.fn(),
+  markFailed: vi.fn(),
+  resetStale: vi.fn(() => 0),
+}));
+const runInsightsCommand = vi.hoisted(() => vi.fn());
+const validateNativeRunner = vi.hoisted(() => vi.fn());
+
+function queueItem(sessionId: string) {
+  return {
+    session_id: sessionId,
+    status: 'pending' as const,
+    runner_type: 'provider',
+    enqueued_at: '2026-07-14T00:00:00Z',
+    started_at: null,
+    completed_at: null,
+    error_message: null,
+    attempt_count: 0,
+    max_attempts: 3,
+  };
+}
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => testState.home };
+});
+
+vi.mock('../../db/queue.js', () => queueMocks);
+
+vi.mock('../../commands/insights.js', () => ({ runInsightsCommand }));
+
+vi.mock('../native-runner.js', () => ({
+  ClaudeNativeRunner: class MockNativeRunner {
+    static validate = validateNativeRunner;
+  },
+}));
+
+import { PROCESS_QUEUE_FAILED, processQueue } from '../queue-worker.js';
+
+describe('processQueue LLM lock', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    testState.home = mkdtempSync(join(tmpdir(), 'code-insights-queue-worker-'));
+    queueMocks.resetStale.mockReturnValue(0);
+    queueMocks.claimNext
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(null);
+    runInsightsCommand.mockResolvedValue(undefined);
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+  });
+
+  afterEach(() => {
+    rmSync(testState.home, { recursive: true, force: true });
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+  });
+
+  it('returns a busy status without claiming, leaving pending work durable for a later wake-up', async () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), String(process.pid));
+
+    const result = await processQueue({ quiet: true });
+
+    expect(result).toBe(-1);
+    expect(queueMocks.claimNext).not.toHaveBeenCalled();
+    expect(runInsightsCommand).not.toHaveBeenCalled();
+  });
+
+  it('holds the LLM lock while analyzing and releases it after the bounded run', async () => {
+    const lockPath = join(testState.home, '.code-insights', 'locks', 'llm.lock');
+    let lockWasHeldDuringAnalysis = false;
+    runInsightsCommand.mockImplementationOnce(async () => {
+      lockWasHeldDuringAnalysis = existsSync(lockPath);
+    });
+
+    const result = await processQueue({ quiet: true });
+
+    expect(result).toBe(1);
+    expect(lockWasHeldDuringAnalysis).toBe(true);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('processes at most one item by default for hook-triggered workers', async () => {
+    queueMocks.claimNext
+      .mockReset()
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(queueItem('session-2'));
+
+    const result = await processQueue({ quiet: true });
+
+    expect(result).toBe(1);
+    expect(queueMocks.claimNext).toHaveBeenCalledTimes(1);
+    expect(runInsightsCommand).toHaveBeenCalledTimes(1);
+    expect(queueMocks.markCompleted).toHaveBeenCalledWith('session-1');
+  });
+
+  it('honors an explicit bounded item limit', async () => {
+    queueMocks.claimNext
+      .mockReset()
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(queueItem('session-2'))
+      .mockReturnValueOnce(queueItem('session-3'));
+
+    const result = await processQueue({ quiet: true, maxItems: 2 });
+
+    expect(result).toBe(2);
+    expect(queueMocks.claimNext).toHaveBeenCalledTimes(2);
+    expect(runInsightsCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for the configured delay between bounded items', async () => {
+    queueMocks.claimNext
+      .mockReset()
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(queueItem('session-2'));
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    await processQueue({ quiet: true, maxItems: 2, delayMs: 5 });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5);
+  });
+
+  it('stops after a failure so a re-queued item is not retried in the same run', async () => {
+    queueMocks.claimNext
+      .mockReset()
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(queueItem('session-1'));
+    runInsightsCommand.mockRejectedValue(new Error('provider unavailable'));
+
+    const result = await processQueue({ quiet: true, maxItems: 2 });
+
+    expect(result).toBe(PROCESS_QUEUE_FAILED);
+    expect(queueMocks.claimNext).toHaveBeenCalledTimes(1);
+    expect(queueMocks.markFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns successes completed before a later failure and leaves newer work unclaimed', async () => {
+    queueMocks.claimNext
+      .mockReset()
+      .mockReturnValueOnce(queueItem('session-1'))
+      .mockReturnValueOnce(queueItem('session-2'))
+      .mockReturnValueOnce(queueItem('session-3'));
+    runInsightsCommand
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('rate limited'));
+
+    const result = await processQueue({ quiet: true, maxItems: 3 });
+
+    expect(result).toBe(PROCESS_QUEUE_FAILED);
+    expect(queueMocks.claimNext).toHaveBeenCalledTimes(2);
+    expect(queueMocks.markCompleted).toHaveBeenCalledWith('session-1');
+    expect(queueMocks.markFailed).toHaveBeenCalledWith('session-2', 'rate limited');
+  });
+});

--- a/cli/src/analysis/analysis-db.ts
+++ b/cli/src/analysis/analysis-db.ts
@@ -287,6 +287,14 @@ export function saveFacetsToDb(
 ): void {
   const db = getDb();
 
+  // Facet-only and chunked analysis paths can bypass parseAnalysisResponse(),
+  // so enforce the friction category invariant at the shared persistence boundary.
+  const sanitizedFrictionPoints = Array.isArray(facets.friction_points)
+    ? facets.friction_points.filter(
+        fp => typeof fp?.category === 'string' && fp.category.trim() !== '',
+      )
+    : [];
+
   // Normalize pattern categories at write time so stored data is always clean.
   // This handles LLM variants (e.g., "task-decomposition" → "structured-planning")
   // before they hit the database, keeping aggregation queries simple.
@@ -317,7 +325,7 @@ export function saveFacetsToDb(
     facets.had_course_correction ? 1 : 0,
     facets.course_correction_reason,
     facets.iteration_count,
-    JSON.stringify(Array.isArray(facets.friction_points) ? facets.friction_points : []),
+    JSON.stringify(sanitizedFrictionPoints),
     JSON.stringify(normalizedPatterns),
     analysisVersion,
   );

--- a/cli/src/analysis/analysis-usage-db.ts
+++ b/cli/src/analysis/analysis-usage-db.ts
@@ -104,3 +104,17 @@ export function getSessionAnalysisUsage(sessionId: string): AnalysisUsageRow[] {
     ORDER BY analyzed_at ASC
   `).all(sessionId) as AnalysisUsageRow[];
 }
+
+/**
+ * Mark the resumable two-pass analysis as stale without discarding the last
+ * visible insights. A later successful analysis atomically replaces them.
+ */
+export function invalidateAnalysisUsage(sessionId: string): void {
+  const db = getDb();
+  db.prepare(`
+    UPDATE analysis_usage
+    SET session_message_count = NULL
+    WHERE session_id = ?
+      AND analysis_type IN ('session', 'prompt_quality')
+  `).run(sessionId);
+}

--- a/cli/src/analysis/llm-lock.ts
+++ b/cli/src/analysis/llm-lock.ts
@@ -1,0 +1,266 @@
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { homedir } from 'os';
+import { dirname, join, win32 } from 'path';
+import { randomUUID, timingSafeEqual } from 'crypto';
+import { spawnSync } from 'child_process';
+
+export interface LlmLockHandle {
+  /** Capability passed only to descendants that may delegate work over HTTP. */
+  readonly token?: string;
+  release(): void;
+}
+
+export const LLM_LOCK_TOKEN_HEADER = 'x-code-insights-lock-token';
+
+const OWNER_WRITE_GRACE_MS = 60_000;
+
+export function getLlmLockPath(): string {
+  const configDir = process.env.CODE_INSIGHTS_CONFIG_DIR
+    || join(homedir(), '.code-insights');
+  return process.env.CODE_INSIGHTS_LLM_LOCK_DIR
+    || join(configDir, 'locks', 'llm.lock');
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'EEXIST';
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+function getProcessStartIdentity(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+
+  if (process.platform === 'linux') {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      const commandEnd = stat.lastIndexOf(')');
+      if (commandEnd < 0) return null;
+      // Fields after the command name start at proc field 3; starttime is 22.
+      const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);
+      const startTicks = fields[19];
+      if (!startTicks) return null;
+      const bootId = readFileSync('/proc/sys/kernel/random/boot_id', 'utf-8').trim();
+      return `linux:${bootId}:${startTicks}`;
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      const systemRoot = process.env.SystemRoot
+        || process.env.SYSTEMROOT
+        || process.env.windir
+        || process.env.WINDIR;
+      if (!systemRoot || !win32.isAbsolute(systemRoot)) return null;
+      const powerShell = win32.join(
+        systemRoot,
+        'System32',
+        'WindowsPowerShell',
+        'v1.0',
+        'powershell.exe',
+      );
+      const result = spawnSync(
+        powerShell,
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+        ],
+        { encoding: 'utf-8', timeout: 2_000, windowsHide: true },
+      );
+      const startedAt = result.status === 0 ? result.stdout.trim() : '';
+      return startedAt ? `win32:${startedAt}` : null;
+    }
+
+    const psCommand = process.platform === 'darwin' ? '/bin/ps' : 'ps';
+    const result = spawnSync(
+      psCommand,
+      ['-o', 'lstart=', '-p', String(pid)],
+      {
+        encoding: 'utf-8',
+        timeout: 2_000,
+        windowsHide: true,
+        // ps lstart is localized on macOS. Lock owners and contenders often
+        // run under different terminal/LaunchAgent locales, so canonicalize it.
+        env: {
+          ...process.env,
+          LANG: 'C',
+          LC_ALL: 'C',
+          TZ: 'UTC',
+          PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
+        },
+      },
+    );
+    const startedAt = result.status === 0 ? result.stdout.trim() : '';
+    return startedAt ? `${process.platform}:${startedAt}` : null;
+  } catch {
+    return null;
+  }
+}
+
+function readOwnerProcessStart(lockPath: string): string | null {
+  try {
+    const identity = readFileSync(join(lockPath, 'process-start'), 'utf-8').trim();
+    return identity || null;
+  } catch {
+    // Locks written by older versions have only a PID. Preserve their
+    // fail-closed behavior until that owner exits.
+    return null;
+  }
+}
+
+function isLockOwnerAlive(lockPath: string, pid: number): boolean {
+  if (!isProcessAlive(pid)) return false;
+  const recordedStart = readOwnerProcessStart(lockPath);
+  if (recordedStart === null) return true;
+  const currentStart = getProcessStartIdentity(pid);
+  // If the platform cannot inspect process birth, do not steal a live lock.
+  return currentStart === null || currentStart === recordedStart;
+}
+
+function tryCreateOwnedLock(lockPath: string): LlmLockHandle | null {
+  try {
+    mkdirSync(lockPath, { mode: 0o700 });
+  } catch (error) {
+    if (isAlreadyExistsError(error)) return null;
+    throw error;
+  }
+
+  const token = randomUUID();
+  const processStart = getProcessStartIdentity(process.pid);
+  try {
+    writeFileSync(join(lockPath, 'token'), `${token}\n`, { mode: 0o600 });
+    if (processStart !== null) {
+      writeFileSync(join(lockPath, 'process-start'), `${processStart}\n`, { mode: 0o600 });
+    }
+    // Publish the PID last. Until it exists, contenders use the owner-write
+    // grace period instead of treating a partially initialized lock as stale.
+    writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`, { mode: 0o600 });
+  } catch (error) {
+    rmSync(lockPath, { recursive: true, force: true });
+    throw error;
+  }
+
+  let released = false;
+  const ownerPid = process.pid;
+  return {
+    token,
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        const currentOwnerPid = Number.parseInt(
+          readFileSync(join(lockPath, 'pid'), 'utf-8').trim(),
+          10,
+        );
+        if (currentOwnerPid !== ownerPid) return;
+        const currentToken = readFileSync(join(lockPath, 'token'), 'utf-8').trim();
+        const currentTokenBytes = Buffer.from(currentToken);
+        const ownedTokenBytes = Buffer.from(token);
+        if (currentTokenBytes.length !== ownedTokenBytes.length ||
+            !timingSafeEqual(currentTokenBytes, ownedTokenBytes)) return;
+        rmSync(lockPath, { recursive: true, force: true });
+      } catch {
+        // The lock is gone or no longer readable; it is not safe to remove it.
+      }
+    },
+  };
+}
+
+/** Validate a delegated-work capability against the currently held lock. */
+export function isLlmLockTokenOwner(candidate: string | undefined): boolean {
+  if (!candidate) return false;
+  try {
+    const lockPath = getLlmLockPath();
+    const ownerPid = readOwnerPid(lockPath);
+    if (ownerPid === null || !isLockOwnerAlive(lockPath, ownerPid)) return false;
+    const expected = readFileSync(join(lockPath, 'token'), 'utf-8').trim();
+    const candidateBytes = Buffer.from(candidate);
+    const expectedBytes = Buffer.from(expected);
+    return candidateBytes.length === expectedBytes.length
+      && timingSafeEqual(candidateBytes, expectedBytes);
+  } catch {
+    return false;
+  }
+}
+
+function readOwnerPid(lockPath: string): number | null {
+  try {
+    const ownerPid = Number.parseInt(readFileSync(join(lockPath, 'pid'), 'utf-8').trim(), 10);
+    return Number.isInteger(ownerPid) && ownerPid > 0 ? ownerPid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isOwnerlessLockStale(lockPath: string): boolean {
+  try {
+    return Date.now() - statSync(lockPath).mtimeMs >= OWNER_WRITE_GRACE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function reclaimStaleLock(lockPath: string, observedOwnerPid: number | null): LlmLockHandle | null {
+  const recoveryLock = acquireLockAtPath(`${lockPath}.reclaim`);
+  if (!recoveryLock) return null;
+
+  try {
+    const currentOwnerPid = readOwnerPid(lockPath);
+    if (observedOwnerPid === null) {
+      if (currentOwnerPid !== null || !isOwnerlessLockStale(lockPath)) return null;
+    } else {
+      if (currentOwnerPid !== observedOwnerPid || isLockOwnerAlive(lockPath, currentOwnerPid)) return null;
+    }
+
+    rmSync(lockPath, { recursive: true, force: true });
+    return tryCreateOwnedLock(lockPath);
+  } finally {
+    recoveryLock.release();
+  }
+}
+
+function acquireLockAtPath(lockPath: string): LlmLockHandle | null {
+  const lock = tryCreateOwnedLock(lockPath);
+  if (lock) return lock;
+
+  const ownerPid = readOwnerPid(lockPath);
+  if (ownerPid === null) {
+    return isOwnerlessLockStale(lockPath)
+      ? reclaimStaleLock(lockPath, null)
+      : null;
+  }
+  if (isLockOwnerAlive(lockPath, ownerPid)) return null;
+
+  return reclaimStaleLock(lockPath, ownerPid);
+}
+
+export function acquireLlmLock(): LlmLockHandle | null {
+  if (process.env.CODE_INSIGHTS_LOCK_HELD === '1') {
+    const token = process.env.CODE_INSIGHTS_LOCK_TOKEN;
+    if (!isLlmLockTokenOwner(token)) return null;
+    return {
+      token,
+      release: () => {},
+    };
+  }
+
+  const lockPath = getLlmLockPath();
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  return acquireLockAtPath(lockPath);
+}

--- a/cli/src/analysis/native-runner.ts
+++ b/cli/src/analysis/native-runner.ts
@@ -14,8 +14,8 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import type { AnalysisRunner, RunAnalysisParams, RunAnalysisResult } from './runner-types.js';
 
-// `claude -p --output-format json` returns a JSON array of typed event objects.
-// We care only about the final result event.
+// Current Claude versions return a single result object for `--output-format
+// json`; older versions returned an array of typed event objects. Support both.
 interface ClaudeEvent {
   type: string;
   subtype?: string;
@@ -23,41 +23,85 @@ interface ClaudeEvent {
 
 interface ClaudeResultEvent extends ClaudeEvent {
   type: 'result';
-  subtype: 'success' | 'error_max_turns' | 'error_during_execution';
-  result: string;
-  is_error: boolean;
+  subtype?: string;
+  result?: unknown;
+  errors?: unknown;
+  is_error?: boolean;
+  structured_output?: unknown;
 }
 
-function isResultEvent(e: ClaudeEvent): e is ClaudeResultEvent {
-  return e.type === 'result';
+class ClaudeReportedError extends Error {}
+
+function isClaudeEvent(value: unknown): value is ClaudeEvent {
+  return typeof value === 'object' && value !== null && 'type' in value &&
+    typeof (value as { type?: unknown }).type === 'string';
+}
+
+function isResultEvent(value: unknown): value is ClaudeResultEvent {
+  return isClaudeEvent(value) && value.type === 'result';
+}
+
+function isErrorResult(event: ClaudeResultEvent): boolean {
+  return event.is_error === true ||
+    (typeof event.subtype === 'string' && event.subtype.startsWith('error_'));
+}
+
+function formatClaudeError(event: ClaudeResultEvent): string {
+  const errors = Array.isArray(event.errors)
+    ? event.errors.filter((value): value is string => typeof value === 'string' && value.trim() !== '')
+    : [];
+  if (errors.length === 0 && typeof event.result === 'string' && event.result.trim() !== '') {
+    errors.push(event.result);
+  }
+
+  const subtype = typeof event.subtype === 'string' && event.subtype.trim() !== ''
+    ? ` (${event.subtype})`
+    : '';
+  const detail = errors.length > 0 ? `: ${errors.join('; ')}` : '';
+  return `claude -p reported an error${subtype}${detail}`;
+}
+
+function getCapturedOutput(error: unknown, field: 'stdout' | 'stderr'): string | null {
+  if (typeof error !== 'object' || error === null || !(field in error)) return null;
+  const value = (error as Record<'stdout' | 'stderr', unknown>)[field];
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value)) return value.toString('utf-8');
+  return null;
 }
 
 /**
  * Extract the LLM text payload from a `claude -p --output-format json` response.
- * The output is an array of event objects; the actual content lives in the
- * `result` event's `result` field.
+ * The actual content lives in the result object's `result` field. When a JSON
+ * schema is supplied, current Claude versions also provide the validated value
+ * in `structured_output`; prefer that value over free-form result text.
  */
 function extractResultFromEnvelope(rawOutput: string): string {
-  let events: ClaudeEvent[];
+  let envelope: unknown;
   try {
-    events = JSON.parse(rawOutput) as ClaudeEvent[];
+    envelope = JSON.parse(rawOutput) as unknown;
   } catch {
     throw new Error(
       `claude -p returned non-JSON output. Output preview: ${rawOutput.slice(0, 200)}`
     );
   }
 
-  if (!Array.isArray(events)) {
-    throw new Error('claude -p output was JSON but not an array of events as expected.');
-  }
-
+  const events = Array.isArray(envelope) ? envelope : [envelope];
   const resultEvent = events.find(isResultEvent);
   if (!resultEvent) {
-    throw new Error('claude -p output contained no result event. Events: ' + JSON.stringify(events.map(e => e.type)));
+    const eventTypes = events.filter(isClaudeEvent).map(event => event.type);
+    throw new Error('claude -p output contained no result event. Events: ' + JSON.stringify(eventTypes));
   }
 
-  if (resultEvent.is_error) {
-    throw new Error(`claude -p reported an error: ${resultEvent.result}`);
+  if (isErrorResult(resultEvent)) {
+    throw new ClaudeReportedError(formatClaudeError(resultEvent));
+  }
+
+  if (resultEvent.structured_output !== undefined) {
+    return JSON.stringify(resultEvent.structured_output);
+  }
+
+  if (typeof resultEvent.result !== 'string') {
+    throw new Error('claude -p result event did not contain a string result.');
   }
 
   return resultEvent.result;
@@ -100,12 +144,6 @@ export class ClaudeNativeRunner implements AnalysisRunner {
     const promptFile = join(tmpdir(), `ci-prompt-${fileId}.txt`);
     writeFileSync(promptFile, params.systemPrompt, 'utf-8');
 
-    let schemaFile: string | undefined;
-    if (params.jsonSchema) {
-      schemaFile = join(tmpdir(), `ci-schema-${fileId}.json`);
-      writeFileSync(schemaFile, JSON.stringify(params.jsonSchema), 'utf-8');
-    }
-
     try {
       const args = [
         '-p',
@@ -113,23 +151,40 @@ export class ClaudeNativeRunner implements AnalysisRunner {
         '--output-format', 'json',
         '--append-system-prompt-file', promptFile,
       ];
-      if (schemaFile) {
-        args.push('--json-schema', schemaFile);
+      if (params.jsonSchema) {
+        // Claude Code expects the schema JSON itself, not a path to a file.
+        args.push('--json-schema', JSON.stringify(params.jsonSchema));
       }
 
-      const rawOutput = execFileSync('claude', args, {
-        input: params.userPrompt,
-        encoding: 'utf-8',
-        timeout: 300_000,    // 5-minute hard limit per analysis call
-        maxBuffer: 10 * 1024 * 1024,  // 10 MB
-        cwd: tmpdir(),       // Isolate claude -p session files from user's project
-        // Propagate CODE_INSIGHTS_HOOK_ACTIVE so the claude -p subprocess won't
-        // trigger another SessionEnd hook when its own session ends (breaks the loop).
-        env: { ...process.env, CODE_INSIGHTS_HOOK_ACTIVE: '1' },
-      });
+      let rawOutput: string;
+      try {
+        rawOutput = execFileSync('claude', args, {
+          input: params.userPrompt,
+          encoding: 'utf-8',
+          timeout: 300_000,    // 5-minute hard limit per analysis call
+          maxBuffer: 10 * 1024 * 1024,  // 10 MB
+          cwd: tmpdir(),       // Isolate claude -p session files from user's project
+          // Propagate CODE_INSIGHTS_HOOK_ACTIVE so the claude -p subprocess won't
+          // trigger another SessionEnd hook when its own session ends (breaks the loop).
+          env: { ...process.env, CODE_INSIGHTS_HOOK_ACTIVE: '1' },
+        });
+      } catch (error) {
+        // Claude Code 2.1.168 writes its JSON result to stdout even when the
+        // process exits non-zero. Recover the structured error before falling
+        // back to Node's generic "Command failed" exception.
+        const stdout = getCapturedOutput(error, 'stdout');
+        if (stdout?.trim()) {
+          try {
+            extractResultFromEnvelope(stdout);
+          } catch (responseError) {
+            if (responseError instanceof ClaudeReportedError) throw responseError;
+          }
+        }
+        throw error;
+      }
 
-      // claude -p --output-format json wraps the response in an event array.
-      // Extract the actual LLM text from the result event.
+      // Extract the LLM payload from either the current single-result response
+      // or the legacy event-array envelope.
       const rawJson = extractResultFromEnvelope(rawOutput);
 
       return {
@@ -143,9 +198,6 @@ export class ClaudeNativeRunner implements AnalysisRunner {
     } finally {
       // Always clean up temp files, even if execFileSync throws.
       try { unlinkSync(promptFile); } catch { /* ignore — file may not exist */ }
-      if (schemaFile) {
-        try { unlinkSync(schemaFile); } catch { /* ignore */ }
-      }
     }
   }
 }

--- a/cli/src/analysis/provider-runner.ts
+++ b/cli/src/analysis/provider-runner.ts
@@ -65,11 +65,14 @@ function makeOpenAIChat(apiKey: string, model: string): LLMChatFn {
   };
 }
 
-function makeAnthropicChat(apiKey: string, model: string): LLMChatFn {
+function makeAnthropicChat(apiKey: string, model: string, baseUrl?: string): LLMChatFn {
+  // baseUrl allows Anthropic-compatible endpoints (e.g. Zhipu BigModel's /api/anthropic).
+  // Defaults to the official Anthropic API when unset.
+  const base = (baseUrl || 'https://api.anthropic.com').trim().replace(/\/$/, '');
   return async (messages) => {
     const systemMsg = messages.find(m => m.role === 'system');
     const chatMsgs = messages.filter(m => m.role !== 'system');
-    const response = await fetch('https://api.anthropic.com/v1/messages', {
+    const response = await fetch(`${base}/v1/messages`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -236,7 +239,7 @@ function makeLlamaCppChat(model: string, baseUrl?: string): LLMChatFn {
 function makeChatFn(config: LLMProviderConfig): LLMChatFn {
   switch (config.provider) {
     case 'openai':    return makeOpenAIChat(config.apiKey ?? '', config.model);
-    case 'anthropic': return makeAnthropicChat(config.apiKey ?? '', config.model);
+    case 'anthropic': return makeAnthropicChat(config.apiKey ?? '', config.model, config.baseUrl);
     case 'gemini':    return makeGeminiChat(config.apiKey ?? '', config.model);
     case 'ollama':    return makeOllamaChat(config.model, config.baseUrl);
     case 'llamacpp':  return makeLlamaCppChat(config.model, config.baseUrl);

--- a/cli/src/analysis/provider-runner.ts
+++ b/cli/src/analysis/provider-runner.ts
@@ -36,6 +36,27 @@ interface LLMResponse {
 
 type LLMChatFn = (messages: LLMMessage[]) => Promise<LLMResponse>;
 
+function replaceIsolatedSurrogates(value: string): string {
+  let result = '';
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        result += value[i] + value[i + 1];
+        i++;
+      } else {
+        result += '\ufffd';
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      result += '\ufffd';
+    } else {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
 // ── Provider implementations ──────────────────────────────────────────────────
 
 function makeOpenAIChat(apiKey: string, model: string): LLMChatFn {
@@ -285,8 +306,8 @@ export class ProviderRunner implements AnalysisRunner {
     const start = Date.now();
 
     const messages: LLMMessage[] = [
-      { role: 'system', content: params.systemPrompt },
-      { role: 'user', content: params.userPrompt },
+      { role: 'system', content: replaceIsolatedSurrogates(params.systemPrompt) },
+      { role: 'user', content: replaceIsolatedSurrogates(params.userPrompt) },
     ];
 
     const response = await this.chat(messages);

--- a/cli/src/analysis/queue-worker.ts
+++ b/cli/src/analysis/queue-worker.ts
@@ -2,8 +2,10 @@
  * Queue worker — processes analysis_queue items one at a time.
  *
  * Called as a detached subprocess spawned by `session-end` after enqueue.
- * Resets stale processing items first, then claims and runs pending items
- * until the queue is empty.
+ * Holds the cross-process LLM lock for the bounded processing run so concurrent
+ * hook workers cannot analyze different sessions at the same time.
+ * Hook workers process one item by default; maintenance callers can request a
+ * larger explicit bound and delay. A failed item ends the run immediately.
  *
  * Worker spawned with CODE_INSIGHTS_HOOK_ACTIVE=1 in env so that
  * ClaudeNativeRunner does not re-trigger this hook recursively.
@@ -13,64 +15,105 @@ import chalk from 'chalk';
 import { claimNext, markCompleted, markFailed, resetStale } from '../db/queue.js';
 import { runInsightsCommand } from '../commands/insights.js';
 import { ClaudeNativeRunner } from './native-runner.js';
+import { acquireLlmLock } from './llm-lock.js';
 
 export interface ProcessQueueOptions {
   quiet?: boolean;
   /** Runner type to use — 'native' uses claude -p, anything else uses configured provider */
   runnerType?: string;
   model?: string;
+  /** Maximum queue items to attempt in this run. Defaults to one for hook safety. */
+  maxItems?: number;
+  /** Delay between queue items in milliseconds. */
+  delayMs?: number;
 }
 
+/** Numeric sentinel kept compatible with the existing success-count return type. */
+export const PROCESS_QUEUE_BUSY = -1;
+/** At least one claimed queue item failed during this bounded run. */
+export const PROCESS_QUEUE_FAILED = -2;
+
 /**
- * Process all pending queue items until the queue is empty.
- * Returns the number of items processed successfully.
+ * Process a bounded number of pending queue items.
+ * Returns the number completed successfully, PROCESS_QUEUE_BUSY when the
+ * shared LLM lock is held by another process, or PROCESS_QUEUE_FAILED when a
+ * claimed item could not be analyzed.
  */
 export async function processQueue(options: ProcessQueueOptions = {}): Promise<number> {
   const { quiet = false } = options;
   const log = quiet ? () => {} : console.log.bind(console);
+  const maxItems = Number.isFinite(options.maxItems)
+    ? Math.max(1, Math.floor(options.maxItems!))
+    : 1;
+  const delayMs = Number.isFinite(options.delayMs)
+    ? Math.max(0, Math.floor(options.delayMs!))
+    : 0;
 
-  // Reset any items stuck in 'processing' from a previous crashed worker
-  const staleCount = resetStale();
-  if (staleCount > 0) {
-    log(chalk.yellow(`[Code Insights] Reset ${staleCount} stale processing item(s) to pending`));
+  const lock = acquireLlmLock();
+  if (!lock) {
+    log(chalk.dim('[Code Insights] Another LLM analysis process is already running'));
+    // Nothing was claimed, so every database row remains pending. A later hook
+    // wake-up or the bounded daily maintenance run can durably recover the work.
+    return PROCESS_QUEUE_BUSY;
   }
 
-  let successCount = 0;
-
-  // Build a native runner once and reuse across items (avoids repeated validate() calls)
-  let runner: ClaudeNativeRunner | undefined;
   try {
-    ClaudeNativeRunner.validate();
-    runner = new ClaudeNativeRunner({ model: options.model });
-  } catch {
-    // claude CLI not available — fall back to provider runner (runInsightsCommand handles this)
-    runner = undefined;
-  }
+    // Reset any items stuck in 'processing' from a previous crashed worker
+    const staleCount = resetStale();
+    if (staleCount > 0) {
+      log(chalk.yellow(`[Code Insights] Reset ${staleCount} stale processing item(s) to pending`));
+    }
 
-  while (true) {
-    const item = claimNext();
-    if (!item) break; // Queue empty
+    let successCount = 0;
+    let attemptedCount = 0;
+    let failed = false;
 
-    log(chalk.dim(`[Code Insights] Analyzing session ${item.session_id} (attempt ${item.attempt_count + 1}/${item.max_attempts})...`));
-
+    // Build a native runner once and reuse across items (avoids repeated validate() calls)
+    let runner: ClaudeNativeRunner | undefined;
     try {
-      await runInsightsCommand({
-        sessionId: item.session_id,
-        native: item.runner_type === 'native',
-        quiet,
-        _runner: item.runner_type === 'native' ? runner : undefined,
-      });
-      markCompleted(item.session_id);
-      successCount++;
-      log(chalk.green(`[Code Insights] Session ${item.session_id} analyzed successfully`));
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      markFailed(item.session_id, errorMessage);
-      if (!quiet) {
-        console.error(chalk.red(`[Code Insights] Analysis failed for ${item.session_id}: ${errorMessage}`));
+      ClaudeNativeRunner.validate();
+      runner = new ClaudeNativeRunner({ model: options.model });
+    } catch {
+      // claude CLI not available — fall back to provider runner (runInsightsCommand handles this)
+      runner = undefined;
+    }
+
+    while (attemptedCount < maxItems) {
+      const item = claimNext();
+      if (!item) break; // Queue empty
+
+      if (attemptedCount > 0 && delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+      attemptedCount++;
+
+      log(chalk.dim(`[Code Insights] Analyzing session ${item.session_id} (attempt ${item.attempt_count + 1}/${item.max_attempts})...`));
+
+      try {
+        await runInsightsCommand({
+          sessionId: item.session_id,
+          native: item.runner_type === 'native',
+          quiet,
+          _runner: item.runner_type === 'native' ? runner : undefined,
+        });
+        markCompleted(item.session_id);
+        successCount++;
+        log(chalk.green(`[Code Insights] Session ${item.session_id} analyzed successfully`));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        markFailed(item.session_id, errorMessage);
+        if (!quiet) {
+          console.error(chalk.red(`[Code Insights] Analysis failed for ${item.session_id}: ${errorMessage}`));
+        }
+        // markFailed may have moved the row back to pending. Stop this run so
+        // the same transient failure is never retried in a tight loop.
+        failed = true;
+        break;
       }
     }
-  }
 
-  return successCount;
+    return failed ? PROCESS_QUEUE_FAILED : successCount;
+  } finally {
+    lock.release();
+  }
 }

--- a/cli/src/analysis/response-parsers.ts
+++ b/cli/src/analysis/response-parsers.ts
@@ -68,6 +68,9 @@ export function parseAnalysisResponse(response: string): ParseResult<AnalysisRes
   if (parsed.facets) {
     if (!Array.isArray(parsed.facets.friction_points)) parsed.facets.friction_points = [];
     if (!Array.isArray(parsed.facets.effective_patterns)) parsed.facets.effective_patterns = [];
+    parsed.facets.friction_points = parsed.facets.friction_points.filter(
+      fp => typeof fp?.category === 'string' && fp.category.trim() !== '',
+    );
   }
 
   // Observability: two-tier tooling-limitation monitor.

--- a/cli/src/commands/__tests__/insights.test.ts
+++ b/cli/src/commands/__tests__/insights.test.ts
@@ -54,6 +54,14 @@ vi.mock('../../analysis/provider-runner.js', () => ({
   },
 }));
 
+const mockReleaseLlmLock = vi.fn();
+const mockAcquireLlmLock = vi.fn((): { release(): void } | null => ({
+  release: mockReleaseLlmLock,
+}));
+vi.mock('../../analysis/llm-lock.js', () => ({
+  acquireLlmLock: mockAcquireLlmLock,
+}));
+
 const mockProvider = {
   parse: vi.fn(),
   getProviderName: vi.fn(() => 'claude-code'),
@@ -62,6 +70,12 @@ vi.mock('../../providers/registry.js', () => ({
   getProvider: vi.fn(() => mockProvider),
   getAllProviders: vi.fn(() => [mockProvider]),
 }));
+
+beforeEach(() => {
+  mockReleaseLlmLock.mockReset();
+  mockAcquireLlmLock.mockReset();
+  mockAcquireLlmLock.mockReturnValue({ release: mockReleaseLlmLock });
+});
 
 // ── Seed helpers ──────────────────────────────────────────────────────────────
 
@@ -144,7 +158,7 @@ describe('V8 migration — session_message_count column', () => {
       .prepare('SELECT version FROM schema_version ORDER BY version')
       .all() as Array<{ version: number }>;
 
-    expect(rows.map(r => r.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(rows.map(r => r.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     db.close();
   });
 
@@ -196,7 +210,7 @@ describe('runInsightsCommand — provider mode (no --native)', () => {
 
     expect(mockFromConfig).toHaveBeenCalledTimes(1);
     expect(mockValidate).not.toHaveBeenCalled();
-  });
+  }, 15_000);
 
   it('saves insights to the database', async () => {
     seedSession(mockDb);
@@ -249,6 +263,51 @@ describe('runInsightsCommand — provider mode (no --native)', () => {
     await expect(
       runInsightsCommand({ sessionId: 'nonexistent', native: false, quiet: true })
     ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe('insightsCommand — shared LLM lock', () => {
+  const originalExitCode = process.exitCode;
+  let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockDb = new Database(':memory:');
+    runMigrations(mockDb);
+    mockProviderRunAnalysis.mockReset();
+    mockFromConfig.mockReset();
+    process.exitCode = undefined;
+    consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    consoleErrSpy.mockRestore();
+    mockDb.close();
+  });
+
+  it('leaves work untouched and returns temporary-failure status when the lock is busy', async () => {
+    seedSession(mockDb, 'busy-session');
+    mockAcquireLlmLock.mockReturnValueOnce(null);
+
+    const { insightsCommand } = await import('../insights.js');
+    await insightsCommand('busy-session', { quiet: false });
+
+    expect(mockProviderRunAnalysis).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(75);
+    expect(consoleErrSpy).toHaveBeenCalledWith(expect.stringMatching(/already running/i));
+  });
+
+  it('releases the lock after a successful direct analysis', async () => {
+    seedSession(mockDb, 'locked-session');
+    mockProviderRunAnalysis
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 100, inputTokens: 0, outputTokens: 0, model: 'test', provider: 'test' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 100, inputTokens: 0, outputTokens: 0, model: 'test', provider: 'test' });
+
+    const { insightsCommand } = await import('../insights.js');
+    await insightsCommand('locked-session', { quiet: true });
+
+    expect(mockAcquireLlmLock).toHaveBeenCalledOnce();
+    expect(mockReleaseLlmLock).toHaveBeenCalledOnce();
   });
 });
 
@@ -464,7 +523,13 @@ describe('insightsCheckCommand — count-based behavior', () => {
       const sid = `chk-sess-${i}`;
       db.exec(`INSERT OR IGNORE INTO sessions (id, project_id, project_name, project_path, started_at, ended_at, message_count) VALUES ('${sid}', 'pc1', 'proj', '/p', datetime('now', '-${i} minutes'), datetime('now', '-${i} minutes'), 10);`);
       if (i < analyzedCount) {
-        db.exec(`INSERT OR IGNORE INTO analysis_usage (session_id, analysis_type, provider, model) VALUES ('${sid}', 'session', 'openai', 'gpt-4');`);
+        db.exec(`
+          INSERT OR IGNORE INTO analysis_usage
+            (session_id, analysis_type, provider, model, session_message_count)
+          VALUES
+            ('${sid}', 'session', 'openai', 'gpt-4', 10),
+            ('${sid}', 'prompt_quality', 'openai', 'gpt-4', 10);
+        `);
       }
     }
   }
@@ -491,6 +556,23 @@ describe('insightsCheckCommand — count-based behavior', () => {
     const { insightsCheckCommand } = await import('../insights.js');
     await insightsCheckCommand({ days: 7, quiet: true });
     expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('counts a session whose saved passes were invalidated after message repair', async () => {
+    seedSessions(mockDb, 1, 0);
+    mockDb.exec(`
+      INSERT INTO analysis_usage
+        (session_id, analysis_type, provider, model, session_message_count)
+      VALUES
+        ('chk-sess-0', 'session', 'openai', 'gpt-4', NULL),
+        ('chk-sess-0', 'prompt_quality', 'openai', 'gpt-4', NULL);
+    `);
+
+    const { insightsCheckCommand } = await import('../insights.js');
+    await insightsCheckCommand({ days: 7, quiet: true });
+
+    const written = (stdoutSpy.mock.calls as Array<[unknown]>).map(c => String(c[0])).join('');
+    expect(written.trim()).toBe('1');
   });
 
   it('prints count and suggest --analyze for 3-10 unanalyzed sessions', async () => {
@@ -527,6 +609,7 @@ describe('insightsCheckCommand — count-based behavior', () => {
 });
 
 describe('insightsCheckCommand — auto-analyze (1-2 sessions)', () => {
+  const originalExitCode = process.exitCode;
   let consoleSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrSpy: ReturnType<typeof vi.spyOn>;
 
@@ -537,11 +620,13 @@ describe('insightsCheckCommand — auto-analyze (1-2 sessions)', () => {
     mockValidate.mockReset();
     mockFromConfig.mockReset();
     mockProviderRunAnalysis.mockReset();
+    process.exitCode = undefined;
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    process.exitCode = originalExitCode;
     consoleSpy.mockRestore();
     consoleErrSpy.mockRestore();
   });
@@ -576,6 +661,17 @@ describe('insightsCheckCommand — auto-analyze (1-2 sessions)', () => {
     expect(mockValidate).not.toHaveBeenCalled();
     expect(mockFromConfig).toHaveBeenCalledTimes(1);
     expect(mockProviderRunAnalysis).toHaveBeenCalledTimes(4);
+  });
+
+  it('retains automatic work for a later run when another analysis holds the lock', async () => {
+    seedOne(mockDb, 'auto-busy');
+    mockAcquireLlmLock.mockReturnValueOnce(null);
+
+    const { insightsCheckCommand } = await import('../insights.js');
+    await insightsCheckCommand({ days: 7, quiet: false });
+
+    expect(mockProviderRunAnalysis).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(75);
   });
 });
 

--- a/cli/src/commands/__tests__/insights.test.ts
+++ b/cli/src/commands/__tests__/insights.test.ts
@@ -326,7 +326,8 @@ describe('runInsightsCommand — resume detection', () => {
 
     mockDb.prepare(`
       INSERT INTO analysis_usage (session_id, analysis_type, provider, model, session_message_count)
-        VALUES ('sess1', 'session', 'openai', 'gpt-4', 10)
+        VALUES ('sess1', 'session', 'openai', 'gpt-4', 10),
+               ('sess1', 'prompt_quality', 'openai', 'gpt-4', 10)
     `).run();
 
     const { runInsightsCommand } = await import('../insights.js');
@@ -337,6 +338,22 @@ describe('runInsightsCommand — resume detection', () => {
     });
 
     expect(mockProviderRunAnalysis).not.toHaveBeenCalled();
+  });
+
+  it('restarts analysis when only the session pass was recorded', async () => {
+    seedSession(mockDb, 'sess1', 10);
+    mockDb.prepare(`
+      INSERT INTO analysis_usage (session_id, analysis_type, provider, model, session_message_count)
+        VALUES ('sess1', 'session', 'openai', 'gpt-4', 10)
+    `).run();
+    mockProviderRunAnalysis
+      .mockResolvedValueOnce({ rawJson: makeAnalysisResponse(), durationMs: 100, inputTokens: 50, outputTokens: 50, model: 'gpt-4', provider: 'openai' })
+      .mockResolvedValueOnce({ rawJson: makePQResponse(), durationMs: 80, inputTokens: 30, outputTokens: 30, model: 'gpt-4', provider: 'openai' });
+
+    const { runInsightsCommand } = await import('../insights.js');
+    await runInsightsCommand({ sessionId: 'sess1', native: false, quiet: true });
+
+    expect(mockProviderRunAnalysis).toHaveBeenCalledTimes(2);
   });
 
   it('proceeds when message_count differs from analysis_usage', async () => {

--- a/cli/src/commands/__tests__/install-hook.test.ts
+++ b/cli/src/commands/__tests__/install-hook.test.ts
@@ -5,6 +5,36 @@ import * as os from 'os';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
+const fsMockState = vi.hoisted(() => ({
+  failRename: false,
+  mutateTargetAfterTempWrite: undefined as string | undefined,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return {
+    ...actual,
+    writeFileSync: vi.fn((...args: any[]) => {
+      const result = (actual.writeFileSync as any)(...args);
+      const writtenPath = String(args[0]);
+      if (
+        fsMockState.mutateTargetAfterTempWrite
+        && writtenPath.includes('.settings.json.')
+        && writtenPath.endsWith('.tmp')
+      ) {
+        const target = fsMockState.mutateTargetAfterTempWrite;
+        fsMockState.mutateTargetAfterTempWrite = undefined;
+        actual.writeFileSync(target, JSON.stringify({ concurrentEdit: true }));
+      }
+      return result;
+    }),
+    renameSync: vi.fn((oldPath: fs.PathLike, newPath: fs.PathLike) => {
+      if (fsMockState.failRename) throw new Error('simulated rename failure');
+      return actual.renameSync(oldPath, newPath);
+    }),
+  };
+});
+
 vi.mock('../../utils/telemetry.js', () => ({
   trackEvent: vi.fn(),
   captureError: vi.fn(),
@@ -32,6 +62,8 @@ beforeEach(() => {
   // Each test gets its own temp dir as home — never touches real ~/.claude/settings.json
   mockHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-hook-test-'));
   _mockOs.homeDir = mockHomeDir;
+  fsMockState.failRename = false;
+  fsMockState.mutateTargetAfterTempWrite = undefined;
   // Reset module cache so CLAUDE_SETTINGS_DIR / HOOKS_FILE pick up the new mockHomeDir
   vi.resetModules();
 });
@@ -55,6 +87,23 @@ function writeSettings(data: unknown): void {
   const dir = path.join(mockHomeDir, '.claude');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(hooksFile(), JSON.stringify(data));
+}
+
+function writeRawSettings(content: string): void {
+  const dir = path.join(mockHomeDir, '.claude');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(hooksFile(), content);
+}
+
+function writeSymlinkedSettings(data: unknown): string {
+  const settingsDir = path.join(mockHomeDir, '.claude');
+  const targetDir = path.join(mockHomeDir, 'shared-claude-settings');
+  const target = path.join(targetDir, 'settings.json');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(target, JSON.stringify(data));
+  fs.symlinkSync(target, hooksFile());
+  return target;
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -86,7 +135,7 @@ describe('installHookCommand', () => {
       expect(sessionEndCmd.type).toBe('command');
       expect(sessionEndCmd.command).toContain('session-end --native -q');
       // Must use node + absolute path (not process.argv[1] which is unstable under npx)
-      expect(sessionEndCmd.command).toMatch(/^node .+index\.js session-end --native -q$/);
+      expect(sessionEndCmd.command).toMatch(/^node '.+index\.js' session-end --native -q$/);
       // 10s timeout — session-end exits immediately after spawning the worker
       expect(sessionEndCmd.timeout).toBe(10000);
     });
@@ -100,6 +149,16 @@ describe('installHookCommand', () => {
       const settings = readSettings();
       expect(settings.theme).toBe('dark');
       expect(settings.someOtherKey).toBe(42);
+    });
+
+    it('fails closed and preserves an unparseable settings.json', async () => {
+      const invalidSettings = '{"hooks":{"SessionEnd":[';
+      writeRawSettings(invalidSettings);
+
+      const { installHookCommand } = await import('../install-hook.js');
+
+      await expect(installHookCommand()).rejects.toThrow(/parse/i);
+      expect(fs.readFileSync(hooksFile(), 'utf-8')).toBe(invalidSettings);
     });
 
     it('preserves existing non-code-insights SessionEnd hooks', async () => {
@@ -129,6 +188,112 @@ describe('installHookCommand', () => {
       const hooks = settings.hooks as Record<string, unknown[]>;
       // Second install must be idempotent — still exactly one code-insights hook
       expect(hooks.SessionEnd).toHaveLength(1);
+    });
+
+    it('pins a custom Code Insights config directory into the hook command', async () => {
+      const previous = process.env.CODE_INSIGHTS_CONFIG_DIR;
+      process.env.CODE_INSIGHTS_CONFIG_DIR = path.join(mockHomeDir, 'custom config');
+      try {
+        const { installHookCommand } = await import('../install-hook.js');
+        await installHookCommand();
+      } finally {
+        if (previous === undefined) delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+        else process.env.CODE_INSIGHTS_CONFIG_DIR = previous;
+      }
+
+      const settings = readSettings();
+      const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      expect(hooks.SessionEnd[0].hooks[0].command).toContain(
+        `CODE_INSIGHTS_CONFIG_DIR='${path.join(mockHomeDir, 'custom config')}'`,
+      );
+    });
+
+    it('atomically replaces settings.json through a same-directory rename', async () => {
+      writeSettings({ theme: 'dark' });
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await installHookCommand();
+
+      const renameSpy = vi.mocked(fs.renameSync);
+      expect(renameSpy).toHaveBeenCalledTimes(1);
+      const [temporaryPath, destinationPath] = renameSpy.mock.calls[0];
+      expect(path.dirname(String(temporaryPath))).toBe(path.dirname(hooksFile()));
+      expect(destinationPath).toBe(hooksFile());
+      expect(fs.existsSync(String(temporaryPath))).toBe(false);
+    });
+
+    it('writes settings.json with mode 0600', async () => {
+      writeSettings({ theme: 'dark' });
+      fs.chmodSync(hooksFile(), 0o644);
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await installHookCommand();
+
+      expect(fs.statSync(hooksFile()).mode & 0o777).toBe(0o600);
+    });
+
+    it('removes the temporary settings file when atomic replacement fails', async () => {
+      writeSettings({ theme: 'dark' });
+      fsMockState.failRename = true;
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await expect(installHookCommand()).rejects.toThrow('simulated rename failure');
+
+      const renameSpy = vi.mocked(fs.renameSync);
+      expect(renameSpy).toHaveBeenCalledTimes(1);
+      const [temporaryPath] = renameSpy.mock.calls[0];
+      expect(fs.existsSync(String(temporaryPath))).toBe(false);
+      expect(readSettings()).toEqual({ theme: 'dark' });
+    });
+
+    it('does not overwrite a concurrent settings edit made before atomic replacement', async () => {
+      writeSettings({ theme: 'dark' });
+      fsMockState.mutateTargetAfterTempWrite = hooksFile();
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await expect(installHookCommand()).rejects.toThrow(/changed/i);
+
+      expect(readSettings()).toEqual({ concurrentEdit: true });
+    });
+
+    it('rejects when settings.json cannot be written', async () => {
+      fs.writeFileSync(path.join(mockHomeDir, '.claude'), 'not a directory');
+
+      const { installHookCommand } = await import('../install-hook.js');
+
+      await expect(installHookCommand()).rejects.toThrow();
+    });
+
+    it('updates a symlink target atomically without replacing the settings.json symlink', async () => {
+      const target = writeSymlinkedSettings({ theme: 'dark' });
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await installHookCommand();
+
+      expect(fs.lstatSync(hooksFile()).isSymbolicLink()).toBe(true);
+      expect(fs.realpathSync(hooksFile())).toBe(fs.realpathSync(target));
+      const settings = JSON.parse(fs.readFileSync(target, 'utf-8')) as Record<string, unknown>;
+      expect(settings.theme).toBe('dark');
+      expect(settings.hooks).toBeDefined();
+
+      const renameSpy = vi.mocked(fs.renameSync);
+      const [temporaryPath, destinationPath] = renameSpy.mock.calls.at(-1)!;
+      expect(path.dirname(String(temporaryPath))).toBe(path.dirname(fs.realpathSync(target)));
+      expect(destinationPath).toBe(fs.realpathSync(target));
+    });
+
+    it('fails closed without replacing a dangling settings.json symlink', async () => {
+      const settingsDir = path.join(mockHomeDir, '.claude');
+      fs.mkdirSync(settingsDir, { recursive: true });
+      const linkTarget = path.join(mockHomeDir, 'missing', 'settings.json');
+      fs.symlinkSync(linkTarget, hooksFile());
+
+      const { installHookCommand } = await import('../install-hook.js');
+      await expect(installHookCommand()).rejects.toThrow(/symbolic link|symlink/i);
+
+      expect(fs.lstatSync(hooksFile()).isSymbolicLink()).toBe(true);
+      expect(fs.readlinkSync(hooksFile())).toBe(linkTarget);
+      expect(fs.existsSync(linkTarget)).toBe(false);
     });
   });
 
@@ -266,5 +431,67 @@ describe('uninstallHookCommand', () => {
 
     const settings = readSettings();
     expect(settings.hooks).toBeUndefined();
+  });
+
+  it('fails closed and preserves an unparseable settings.json', async () => {
+    const invalidSettings = '{"hooks":{"SessionEnd":[';
+    writeRawSettings(invalidSettings);
+
+    const { uninstallHookCommand } = await import('../install-hook.js');
+    await expect(uninstallHookCommand()).rejects.toThrow(/parse/i);
+
+    expect(fs.readFileSync(hooksFile(), 'utf-8')).toBe(invalidSettings);
+  });
+
+  it('atomically writes uninstall changes and propagates replacement failures', async () => {
+    writeSettings({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'node /path/code-insights session-end -q' }] }],
+      },
+    });
+    fsMockState.failRename = true;
+
+    const { uninstallHookCommand } = await import('../install-hook.js');
+    await expect(uninstallHookCommand()).rejects.toThrow('simulated rename failure');
+
+    expect(readSettings()).toEqual({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'node /path/code-insights session-end -q' }] }],
+      },
+    });
+    const renameSpy = vi.mocked(fs.renameSync);
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    const [temporaryPath] = renameSpy.mock.calls[0];
+    expect(fs.existsSync(String(temporaryPath))).toBe(false);
+  });
+
+  it('does not overwrite a concurrent edit while uninstalling hooks', async () => {
+    writeSettings({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'node /path/code-insights session-end -q' }] }],
+      },
+    });
+    fsMockState.mutateTargetAfterTempWrite = hooksFile();
+
+    const { uninstallHookCommand } = await import('../install-hook.js');
+    await expect(uninstallHookCommand()).rejects.toThrow(/changed/i);
+
+    expect(readSettings()).toEqual({ concurrentEdit: true });
+  });
+
+  it('updates a symlink target while preserving the settings.json symlink', async () => {
+    const target = writeSymlinkedSettings({
+      theme: 'dark',
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command: 'node /path/code-insights session-end -q' }] }],
+      },
+    });
+
+    const { uninstallHookCommand } = await import('../install-hook.js');
+    await uninstallHookCommand();
+
+    expect(fs.lstatSync(hooksFile()).isSymbolicLink()).toBe(true);
+    expect(fs.realpathSync(hooksFile())).toBe(fs.realpathSync(target));
+    expect(JSON.parse(fs.readFileSync(target, 'utf-8'))).toEqual({ theme: 'dark' });
   });
 });

--- a/cli/src/commands/__tests__/lock-run.test.ts
+++ b/cli/src/commands/__tests__/lock-run.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  runCommandWithLlmLock,
+  terminateChildProcessTree,
+} from '../lock-run.js';
+
+describe('terminateChildProcessTree', () => {
+  it('uses taskkill without a shell to terminate a Windows process tree', () => {
+    const directSignals: Array<NodeJS.Signals | number | undefined> = [];
+    const calls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+    const child = {
+      pid: 4242,
+      kill(signal?: NodeJS.Signals | number): boolean {
+        directSignals.push(signal);
+        return true;
+      },
+    };
+
+    terminateChildProcessTree(child, 'SIGTERM', {
+      platform: 'win32',
+      runTaskkill(command, args, options) {
+        calls.push({ command, args, options });
+        return { status: 0 };
+      },
+    });
+
+    expect(calls).toEqual([{
+      command: 'taskkill',
+      args: ['/PID', '4242', '/T', '/F'],
+      options: expect.objectContaining({
+        shell: false,
+        stdio: 'ignore',
+        windowsHide: true,
+      }),
+    }]);
+    expect(directSignals).toEqual([]);
+  });
+
+  it('falls back to the direct child when taskkill is unavailable', () => {
+    const directSignals: Array<NodeJS.Signals | number | undefined> = [];
+    const child = {
+      pid: 4242,
+      kill(signal?: NodeJS.Signals | number): boolean {
+        directSignals.push(signal);
+        return true;
+      },
+    };
+
+    terminateChildProcessTree(child, 'SIGTERM', {
+      platform: 'win32',
+      runTaskkill() {
+        throw Object.assign(new Error('spawn taskkill ENOENT'), { code: 'ENOENT' });
+      },
+    });
+
+    expect(directSignals).toEqual(['SIGTERM']);
+  });
+
+  it('falls back to the direct child when taskkill reports failure', () => {
+    const directSignals: Array<NodeJS.Signals | number | undefined> = [];
+    const child = {
+      pid: 4242,
+      kill(signal?: NodeJS.Signals | number): boolean {
+        directSignals.push(signal);
+        return true;
+      },
+    };
+
+    terminateChildProcessTree(child, 'SIGKILL', {
+      platform: 'win32',
+      runTaskkill() {
+        return { status: 1 };
+      },
+    });
+
+    expect(directSignals).toEqual(['SIGKILL']);
+  });
+});
+
+describe('runCommandWithLlmLock', () => {
+  let tempDir: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'code-insights-lock-run-'));
+    lockPath = join(tempDir, 'llm.lock');
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = lockPath;
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+  });
+
+  afterEach(() => {
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    delete process.env.CODE_INSIGHTS_LOCK_HELD;
+    delete process.env.LOCK_RUN_TEST_PID_FILE;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('runs a child with the inherited-lock marker and releases the lock', async () => {
+    const result = await runCommandWithLlmLock([
+      process.execPath,
+      '-e',
+      "process.exit(process.env.CODE_INSIGHTS_LOCK_HELD === '1' && /^[0-9a-f-]{36}$/i.test(process.env.CODE_INSIGHTS_LOCK_TOKEN || '') ? 0 : 9)",
+    ]);
+
+    expect(result).toBe(0);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('returns 75 without spawning work when another live process owns the lock', async () => {
+    const marker = join(tempDir, 'should-not-exist');
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+
+    const result = await runCommandWithLlmLock([
+      process.execPath,
+      '-e',
+      `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`,
+    ]);
+
+    expect(result).toBe(75);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('propagates the child exit status', async () => {
+    const result = await runCommandWithLlmLock([
+      process.execPath,
+      '-e',
+      'process.exit(7)',
+    ]);
+
+    expect(result).toBe(7);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'returns the signal exit code when the child trap exits zero and terminates the complete process group',
+    async () => {
+      const grandchildPidFile = join(tempDir, 'grandchild.pid');
+      process.env.LOCK_RUN_TEST_PID_FILE = grandchildPidFile;
+      const run = runCommandWithLlmLock([
+        '/bin/bash',
+        '-c',
+        // Keep the grandchild alive well beyond this test's timeout. A short
+        // sleep can finish naturally when the full suite heavily loads the
+        // worker, making the wrapper correctly return 0 before TERM is sent.
+        "trap 'exit 0' TERM; sleep 30 & printf '%s\\n' $! > \"$LOCK_RUN_TEST_PID_FILE\"; wait",
+      ]);
+
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(grandchildPidFile) && Date.now() < deadline) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      }
+      expect(existsSync(grandchildPidFile)).toBe(true);
+      const grandchildPid = Number.parseInt(readFileSync(grandchildPidFile, 'utf-8').trim(), 10);
+
+      const signalStartedAt = Date.now();
+      process.emit('SIGTERM', 'SIGTERM');
+      const result = await run;
+
+      expect(result).toBe(143);
+      expect(Date.now() - signalStartedAt).toBeLessThan(1_500);
+      expect(() => process.kill(grandchildPid, 0)).toThrow();
+      delete process.env.LOCK_RUN_TEST_PID_FILE;
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'returns 130 when a child handles SIGINT and exits zero',
+    async () => {
+      const readyFile = join(tempDir, 'sigint-ready');
+      const run = runCommandWithLlmLock([
+        process.execPath,
+        '-e',
+        `process.on('SIGINT', () => process.exit(0)); require('fs').writeFileSync(${JSON.stringify(readyFile)}, 'ready'); setInterval(() => {}, 30_000)`,
+      ]);
+
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(readyFile) && Date.now() < deadline) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      }
+      expect(existsSync(readyFile)).toBe(true);
+
+      process.emit('SIGINT', 'SIGINT');
+
+      await expect(run).resolves.toBe(130);
+      expect(existsSync(lockPath)).toBe(false);
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'waits for the Windows tree termination attempt before releasing the lock',
+    async () => {
+      const taskkillPids: number[] = [];
+      const run = runCommandWithLlmLock([
+        process.execPath,
+        '-e',
+        'setInterval(() => {}, 30_000)',
+      ], {
+        platform: 'win32',
+        runTaskkill(_command, args) {
+          expect(existsSync(lockPath)).toBe(true);
+          const pid = Number.parseInt(args[1], 10);
+          taskkillPids.push(pid);
+          process.kill(pid, 'SIGTERM');
+          return { status: 0 };
+        },
+      });
+
+      process.emit('SIGTERM', 'SIGTERM');
+      const result = await run;
+
+      expect(result).toBe(143);
+      expect(taskkillPids.length).toBeGreaterThanOrEqual(1);
+      expect(new Set(taskkillPids).size).toBe(1);
+      expect(existsSync(lockPath)).toBe(false);
+    },
+    10_000,
+  );
+
+  it('rejects an empty command without creating the lock', async () => {
+    await expect(runCommandWithLlmLock([])).rejects.toThrow(/command is required/i);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/cli/src/commands/__tests__/queue.test.ts
+++ b/cli/src/commands/__tests__/queue.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const processQueue = vi.hoisted(() => vi.fn());
+
+vi.mock('../../analysis/queue-worker.js', () => ({
+  PROCESS_QUEUE_BUSY: -1,
+  PROCESS_QUEUE_FAILED: -2,
+  processQueue,
+}));
+vi.mock('../../db/queue.js', () => ({
+  getQueueStatus: vi.fn(),
+  resetFailed: vi.fn(),
+  pruneCompleted: vi.fn(),
+}));
+
+import { buildQueueCommand, queueProcessCommand } from '../queue.js';
+
+describe('queue process command', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    processQueue.mockResolvedValue(0);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('exposes limit and delay flags and forwards a seconds delay as milliseconds', async () => {
+    const command = buildQueueCommand();
+    const processCommand = command.commands.find((candidate) => candidate.name() === 'process');
+
+    expect(processCommand?.options.map((option) => option.long)).toEqual(
+      expect.arrayContaining(['--limit', '--delay']),
+    );
+
+    await queueProcessCommand({
+      quiet: true,
+      model: 'sonnet',
+      limit: 5,
+      delay: 10,
+    });
+
+    expect(processQueue).toHaveBeenCalledWith({
+      quiet: true,
+      model: 'sonnet',
+      maxItems: 5,
+      delayMs: 10_000,
+    });
+  });
+
+  it('sets a recognizable temporary-failure exit code when the LLM lock is busy', async () => {
+    processQueue.mockResolvedValue(-1);
+
+    await queueProcessCommand({ quiet: true });
+
+    expect(process.exitCode).toBe(75);
+  });
+
+  it('returns failure when a claimed queue item could not be analyzed', async () => {
+    processQueue.mockResolvedValue(-2);
+
+    await queueProcessCommand({ quiet: true });
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/cli/src/commands/__tests__/reflect.test.ts
+++ b/cli/src/commands/__tests__/reflect.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/config.js', () => ({
+  loadConfig: () => ({ dashboard: { port: 7890 } }),
+}));
+
+vi.mock('ora', () => ({
+  default: () => {
+    const spinner = {
+      text: '',
+      start: () => spinner,
+      succeed: vi.fn(),
+      fail: vi.fn(),
+    };
+    return spinner;
+  },
+}));
+
+const mockFetch = vi.fn();
+
+function sseResponse(events: string): Response {
+  return new Response(events, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+async function runReflectWith(stream: Response): Promise<void> {
+  mockFetch
+    .mockResolvedValueOnce(new Response('{}', { status: 200 }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({
+      totalSessions: 8,
+      totalAllSessions: 8,
+    }), { status: 200 }))
+    .mockResolvedValueOnce(stream);
+
+  const { reflectCommand } = await import('../reflect.js');
+  await reflectCommand.parseAsync([
+    'node',
+    'code-insights',
+    '--week',
+    '2026-W29',
+  ]);
+}
+
+describe('reflect command SSE completion', () => {
+  const originalDashboardUrl = process.env.CODE_INSIGHTS_DASHBOARD_URL;
+  const originalLockToken = process.env.CODE_INSIGHTS_LOCK_TOKEN;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    delete process.env.CODE_INSIGHTS_DASHBOARD_URL;
+    delete process.env.CODE_INSIGHTS_LOCK_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalDashboardUrl === undefined) {
+      delete process.env.CODE_INSIGHTS_DASHBOARD_URL;
+    } else {
+      process.env.CODE_INSIGHTS_DASHBOARD_URL = originalDashboardUrl;
+    }
+    if (originalLockToken === undefined) {
+      delete process.env.CODE_INSIGHTS_LOCK_TOKEN;
+    } else {
+      process.env.CODE_INSIGHTS_LOCK_TOKEN = originalLockToken;
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects when the server sends an SSE error event', async () => {
+    const stream = sseResponse(
+      'event: error\n' +
+      'data: {"error":"LLM provider unavailable"}\n\n',
+    );
+
+    await expect(runReflectWith(stream)).rejects.toThrow('LLM provider unavailable');
+  });
+
+  it('rejects when the SSE stream ends without a complete event', async () => {
+    const stream = sseResponse(
+      'event: progress\n' +
+      'data: {"message":"Synthesizing..."}\n\n',
+    );
+
+    await expect(runReflectWith(stream)).rejects.toThrow(/ended without a complete event/i);
+  });
+
+  it('resolves when the server sends a complete event', async () => {
+    const stream = sseResponse(
+      'event: complete\n' +
+      'data: {"results":{"friction-wins":{"narrative":"Done"}}}\n\n',
+    );
+
+    await expect(runReflectWith(stream)).resolves.toBeUndefined();
+  });
+
+  it('uses CODE_INSIGHTS_DASHBOARD_URL before the configured port', async () => {
+    process.env.CODE_INSIGHTS_DASHBOARD_URL = 'http://127.0.0.1:9123/';
+    process.env.CODE_INSIGHTS_LOCK_TOKEN = 'delegated-maintenance-token';
+    const stream = sseResponse(
+      'event: complete\n' +
+      'data: {"results":{"friction-wins":{"narrative":"Done"}}}\n\n',
+    );
+
+    await runReflectWith(stream);
+
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('http://127.0.0.1:9123/api/health');
+    expect(mockFetch.mock.calls[2]?.[0]).toBe('http://127.0.0.1:9123/api/reflect/generate');
+    expect((mockFetch.mock.calls[2]?.[1] as RequestInit).headers).toMatchObject({
+      'x-code-insights-lock-token': 'delegated-maintenance-token',
+    });
+  });
+});
+
+describe('reflect backfill SSE completion', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function runBackfillWith(stream: Response): Promise<void> {
+    mockFetch.mockResolvedValueOnce(stream);
+    const module = await import('../reflect.js') as typeof import('../reflect.js') & {
+      backfillBatchToEndpoint(
+        baseUrl: string,
+        endpoint: string,
+        sessionIds: string[],
+        offset: number,
+        total: number,
+      ): Promise<{ completed: number; failed: number }>;
+    };
+    await module.backfillBatchToEndpoint(
+      'http://localhost:7890',
+      '/api/facets/backfill',
+      ['session-1'],
+      0,
+      1,
+    );
+  }
+
+  it('rejects a busy/error event instead of reporting a zero-work success', async () => {
+    const stream = sseResponse(
+      'event: error\n' +
+      'data: {"error":"Another operation is running","code":"LLM_BUSY"}\n\n',
+    );
+
+    await expect(runBackfillWith(stream)).rejects.toThrow('Another operation is running');
+  });
+
+  it('rejects a truncated backfill stream without a complete event', async () => {
+    const stream = sseResponse(
+      'event: progress\n' +
+      'data: {"completed":0,"failed":0}\n\n',
+    );
+
+    await expect(runBackfillWith(stream)).rejects.toThrow(/without a complete event/i);
+  });
+});

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -249,35 +249,36 @@ async function runInteractiveLLMConfig(): Promise<void> {
   }
 
   // Step 4: Base URL (Ollama, llamacpp, or custom)
-  if (provider === 'ollama') {
+  if (provider === 'ollama' || provider === 'llamacpp') {
+    const defaultUrl = provider === 'ollama' ? 'http://localhost:11434' : 'http://localhost:8080';
     const { baseUrl } = await inquirer.prompt<{ baseUrl: string }>([
       {
         type: 'input',
         name: 'baseUrl',
-        message: 'Ollama URL (leave blank for default http://localhost:11434):',
+        message: `${providerInfo.name} URL (leave blank for default ${defaultUrl}):`,
         default: existing?.baseUrl ?? '',
       },
     ]);
 
-    if (baseUrl && baseUrl !== 'http://localhost:11434') {
-      llmConfig.baseUrl = baseUrl;
-    }
-  }
-
-  if (provider === 'llamacpp') {
-    const { baseUrl } = await inquirer.prompt<{ baseUrl: string }>([
-      {
-        type: 'input',
-        name: 'baseUrl',
-        message: 'llama-server URL (leave blank for default http://localhost:8080):',
-        default: existing?.baseUrl ?? '',
-      },
-    ]);
-
-    if (baseUrl && baseUrl !== 'http://localhost:8080') {
+    if (baseUrl && baseUrl !== defaultUrl) {
       llmConfig.baseUrl = baseUrl;
     }
     // No API key prompt for llamacpp — llama-server runs locally without authentication
+  } else if (provider === 'anthropic' || provider === 'openai' || provider === 'gemini') {
+    // Optional custom base URL for Anthropic-/OpenAI-/Gemini-compatible endpoints
+    // (e.g. Zhipu BigModel's /api/anthropic). Leave blank to use the official API.
+    const { baseUrl } = await inquirer.prompt<{ baseUrl: string }>([
+      {
+        type: 'input',
+        name: 'baseUrl',
+        message: `Custom base URL (leave blank for official ${providerInfo.name} API):`,
+        default: existing?.baseUrl ?? '',
+      },
+    ]);
+
+    if (baseUrl) {
+      llmConfig.baseUrl = baseUrl;
+    }
   }
 
   saveLLMConfig(llmConfig);

--- a/cli/src/commands/doctor/checks/hooks.test.ts
+++ b/cli/src/commands/doctor/checks/hooks.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const mockOs = { homeDir: '' };
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof os>();
+  return {
+    ...actual,
+    homedir: () => mockOs.homeDir,
+  };
+});
+
+let mockHomeDir: string;
+
+beforeEach(() => {
+  mockHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-doctor-hook-test-'));
+  mockOs.homeDir = mockHomeDir;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(mockHomeDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+function writeHook(command: string): void {
+  const settingsDir = path.join(mockHomeDir, '.claude');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(settingsDir, 'settings.json'),
+    JSON.stringify({
+      hooks: {
+        SessionEnd: [{ hooks: [{ type: 'command', command, timeout: 10000 }] }],
+      },
+    }),
+  );
+}
+
+async function runHookCheck(id: string) {
+  const { hooksChecks } = await import('./hooks.js');
+  const check = hooksChecks().find((candidate) => candidate.id === id);
+  if (!check) throw new Error(`Missing hook check: ${id}`);
+  return check.run();
+}
+
+describe('doctor hook binary path parsing', () => {
+  it.each([
+    (binaryPath: string) => `node '${binaryPath}' session-end --native -q`,
+    (binaryPath: string) => `CODE_INSIGHTS_CONFIG_DIR='/tmp/custom config' node "${binaryPath}" session-end --native -q`,
+    (binaryPath: string) => `env CODE_INSIGHTS_CONFIG_DIR='/tmp/custom config' node '${binaryPath}' session-end --native -q`,
+    (binaryPath: string) => `set "CODE_INSIGHTS_CONFIG_DIR=C:\\custom config" && node "${binaryPath}" session-end --native -q`,
+  ])('recognizes a quoted CLI path after optional environment prefixes', async (commandFor) => {
+    const binaryDir = path.join(mockHomeDir, 'code-insights with spaces');
+    const binaryPath = path.join(binaryDir, 'index.js');
+    fs.mkdirSync(binaryDir, { recursive: true });
+    fs.writeFileSync(binaryPath, '#!/usr/bin/env node\n');
+    writeHook(commandFor(binaryPath));
+
+    const result = await runHookCheck('hooks.binary_exists');
+
+    expect(result).toMatchObject({ status: 'pass', detail: binaryPath });
+  });
+
+  it('does not mark the quoted path emitted by install-hook as stale', async () => {
+    const { CLI_ENTRY } = await import('../../../utils/hooks-utils.js');
+    writeHook(`CODE_INSIGHTS_CONFIG_DIR='/tmp/custom config' node '${CLI_ENTRY}' session-end --native -q`);
+
+    const result = await runHookCheck('hooks.binary_current');
+
+    expect(result).toMatchObject({ status: 'pass' });
+  });
+
+  it('preserves Windows path separators inside a double-quoted CLI path', async () => {
+    const binaryPath = path.join(mockHomeDir, 'code-insights\\Program Files\\index.js');
+    fs.writeFileSync(binaryPath, '#!/usr/bin/env node\n');
+    writeHook(`set "CODE_INSIGHTS_CONFIG_DIR=C:\\custom config" && node "${binaryPath}" session-end --native -q`);
+
+    const result = await runHookCheck('hooks.binary_exists');
+
+    expect(result).toMatchObject({ status: 'pass', detail: binaryPath });
+  });
+});

--- a/cli/src/commands/doctor/checks/hooks.ts
+++ b/cli/src/commands/doctor/checks/hooks.ts
@@ -9,10 +9,47 @@ import {
 } from '../../../utils/hooks-utils.js';
 import type { Check, CheckResult } from '../types.js';
 
-/** Extract the binary path from a hook command string like "node /path/to/index.js session-end ..." */
+/** Extract the CLI path after the `node` executable from a shell command. */
 function extractBinaryPath(command: string): string | null {
-  const match = command.match(/node\s+(\S+)/);
-  return match ? match[1] : null;
+  const tokens: string[] = [];
+  let token = '';
+  let quote: "'" | '"' | null = null;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+
+    if (quote) {
+      if (character === quote) {
+        quote = null;
+      } else {
+        token += character;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      if (token) {
+        tokens.push(token);
+        token = '';
+      }
+    } else if (character === '\\' && index + 1 < command.length) {
+      token += command[index + 1];
+      index += 1;
+    } else {
+      token += character;
+    }
+  }
+
+  if (quote) return null;
+  if (token) tokens.push(token);
+
+  const nodeIndex = tokens.findIndex((candidate) => {
+    const executable = candidate.replace(/\\/g, '/').split('/').pop()?.toLowerCase();
+    return executable === 'node' || executable === 'node.exe';
+  });
+  return nodeIndex >= 0 ? tokens[nodeIndex + 1] ?? null : null;
 }
 
 export function hooksChecks(): Check[] {

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -77,12 +77,14 @@ function loadSessionMessages(sessionId: string): SQLiteMessageRow[] {
 function isAlreadyAnalyzed(sessionId: string, currentMessageCount: number): boolean {
   const db = getDb();
   const row = db.prepare(`
-    SELECT session_message_count FROM analysis_usage
-    WHERE session_id = ? AND analysis_type = 'session'
-  `).get(sessionId) as { session_message_count: number | null } | undefined;
+    SELECT COUNT(DISTINCT analysis_type) AS completed_passes
+    FROM analysis_usage
+    WHERE session_id = ?
+      AND analysis_type IN ('session', 'prompt_quality')
+      AND session_message_count = ?
+  `).get(sessionId, currentMessageCount) as { completed_passes: number };
 
-  if (!row) return false;
-  return row.session_message_count === currentMessageCount;
+  return row.completed_passes === 2;
 }
 
 // ── Command options ───────────────────────────────────────────────────────────
@@ -403,4 +405,3 @@ export async function insightsCheckCommand(opts: {
     process.exit(1);
   }
 }
-

--- a/cli/src/commands/insights.ts
+++ b/cli/src/commands/insights.ts
@@ -34,6 +34,7 @@ import {
 import { saveAnalysisUsage } from '../analysis/analysis-usage-db.js';
 import type { AnalysisRunner } from '../analysis/runner-types.js';
 import type { SQLiteMessageRow } from '../analysis/prompt-types.js';
+import { acquireLlmLock } from '../analysis/llm-lock.js';
 
 // ── DB types ──────────────────────────────────────────────────────────────────
 
@@ -262,6 +263,19 @@ export async function runInsightsCommand(options: InsightsCommandOptions): Promi
 
 // ── CLI command entry point ───────────────────────────────────────────────────
 
+function acquireCommandLlmLock(quiet: boolean): ReturnType<typeof acquireLlmLock> {
+  const lock = acquireLlmLock();
+  if (!lock) {
+    if (!quiet) {
+      console.error(chalk.yellow(
+        '[Code Insights] Another LLM analysis process is already running; try again later.'
+      ));
+    }
+    process.exitCode = 75;
+  }
+  return lock;
+}
+
 export async function insightsCommand(
   sessionId: string | undefined,
   opts: {
@@ -274,6 +288,7 @@ export async function insightsCommand(
   }
 ): Promise<void> {
   const quiet = opts.quiet ?? false;
+  let lock: ReturnType<typeof acquireLlmLock> = null;
 
   try {
     if (opts.hook) {
@@ -281,12 +296,16 @@ export async function insightsCommand(
       console.error(chalk.red(
         'The --hook flag has been removed. Run `code-insights install-hook` to install the updated hook.'
       ));
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (!sessionId) {
       throw new Error('Session ID is required');
     }
+
+    lock = acquireCommandLlmLock(quiet);
+    if (!lock) return;
 
     await runInsightsCommand({
       sessionId,
@@ -300,7 +319,9 @@ export async function insightsCommand(
     if (!quiet) {
       console.error(chalk.red(`[Code Insights] ${error instanceof Error ? error.message : 'Analysis failed'}`));
     }
-    process.exit(1);
+    process.exitCode = 1;
+  } finally {
+    lock?.release();
   }
 }
 
@@ -326,10 +347,20 @@ export async function insightsCheckCommand(opts: {
     const rows = db.prepare(`
       SELECT s.id, s.generated_title, s.custom_title, s.started_at, s.message_count
       FROM sessions s
-      LEFT JOIN analysis_usage au ON au.session_id = s.id AND au.analysis_type = 'session'
+      LEFT JOIN analysis_usage session_usage
+        ON session_usage.session_id = s.id
+       AND session_usage.analysis_type = 'session'
+      LEFT JOIN analysis_usage pq_usage
+        ON pq_usage.session_id = s.id
+       AND pq_usage.analysis_type = 'prompt_quality'
       WHERE s.started_at >= ?
         AND s.deleted_at IS NULL
-        AND au.session_id IS NULL
+        AND (
+          session_usage.session_id IS NULL
+          OR session_usage.session_message_count IS NOT s.message_count
+          OR pq_usage.session_id IS NULL
+          OR pq_usage.session_message_count IS NOT s.message_count
+        )
       ORDER BY s.started_at DESC
     `).all(cutoff) as Array<{ id: string; generated_title: string | null; custom_title: string | null; started_at: string; message_count: number }>;
 
@@ -347,39 +378,51 @@ export async function insightsCheckCommand(opts: {
 
     // --analyze: process all found sessions with progress output
     if (analyze) {
-      const runner = ProviderRunner.fromConfig();
-      let successCount = 0;
+      const lock = acquireCommandLlmLock(quiet);
+      if (!lock) return;
+      try {
+        const runner = ProviderRunner.fromConfig();
+        let successCount = 0;
 
-      for (let i = 0; i < rows.length; i++) {
-        const row = rows[i];
-        const label = row.custom_title ?? row.generated_title ?? row.id;
-        const position = `[${i + 1}/${count}]`;
-        process.stdout.write(`${position} ${label} ... `);
-        const start = Date.now();
-        try {
-          await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
-          const elapsed = Math.round((Date.now() - start) / 1000);
-          process.stdout.write(`done (${elapsed}s)\n`);
-          successCount++;
-        } catch (err) {
-          process.stdout.write('failed\n');
-          console.error(chalk.red(`  [Code Insights] ${err instanceof Error ? err.message : 'Analysis failed'}`));
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          const label = row.custom_title ?? row.generated_title ?? row.id;
+          const position = `[${i + 1}/${count}]`;
+          process.stdout.write(`${position} ${label} ... `);
+          const start = Date.now();
+          try {
+            await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
+            const elapsed = Math.round((Date.now() - start) / 1000);
+            process.stdout.write(`done (${elapsed}s)\n`);
+            successCount++;
+          } catch (err) {
+            process.stdout.write('failed\n');
+            console.error(chalk.red(`  [Code Insights] ${err instanceof Error ? err.message : 'Analysis failed'}`));
+          }
         }
-      }
 
-      log(chalk.green(`Analyzed ${successCount} session${successCount !== 1 ? 's' : ''}.`));
+        log(chalk.green(`Analyzed ${successCount} session${successCount !== 1 ? 's' : ''}.`));
+      } finally {
+        lock.release();
+      }
       return;
     }
 
     // Auto-analyze silently when 1-2 unanalyzed sessions
     if (count <= 2) {
-      const runner = ProviderRunner.fromConfig();
-      for (const row of rows) {
-        try {
-          await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
-        } catch {
-          // Silently ignore auto-analyze errors for 1-2 sessions
+      const lock = acquireCommandLlmLock(quiet);
+      if (!lock) return;
+      try {
+        const runner = ProviderRunner.fromConfig();
+        for (const row of rows) {
+          try {
+            await runInsightsCommand({ sessionId: row.id, native: false, quiet: true, _runner: runner });
+          } catch {
+            // Silently ignore auto-analyze errors for 1-2 sessions
+          }
         }
+      } finally {
+        lock.release();
       }
       return;
     }

--- a/cli/src/commands/install-hook.ts
+++ b/cli/src/commands/install-hook.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
+import { randomUUID } from 'crypto';
 import chalk from 'chalk';
 import { trackEvent, captureError, classifyError } from '../utils/telemetry.js';
 import {
@@ -9,10 +9,161 @@ import {
   type ClaudeSettings,
   type HookConfig,
   getHookCommand,
-  hookAlreadyInstalled,
 } from '../utils/hooks-utils.js';
 
-const CLAUDE_SETTINGS_DIR = path.join(os.homedir(), '.claude');
+interface FileFingerprint {
+  device: bigint;
+  inode: bigint;
+  mode: bigint;
+  size: bigint;
+  modifiedAt: bigint;
+  changedAt: bigint;
+}
+
+type SettingsFileTarget =
+  | { kind: 'missing'; path: string }
+  | { kind: 'file'; path: string; fingerprint: FileFingerprint }
+  | { kind: 'symlink'; path: string; linkPath: string; fingerprint: FileFingerprint };
+
+function isMissingFileError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function fingerprintFromStat(entry: fs.BigIntStats): FileFingerprint {
+  return {
+    device: entry.dev,
+    inode: entry.ino,
+    mode: entry.mode,
+    size: entry.size,
+    modifiedAt: entry.mtimeNs,
+    changedAt: entry.ctimeNs,
+  };
+}
+
+function getFileFingerprint(filePath: string): FileFingerprint {
+  return fingerprintFromStat(fs.statSync(filePath, { bigint: true }));
+}
+
+function fingerprintsMatch(left: FileFingerprint, right: FileFingerprint): boolean {
+  return left.device === right.device
+    && left.inode === right.inode
+    && left.mode === right.mode
+    && left.size === right.size
+    && left.modifiedAt === right.modifiedAt
+    && left.changedAt === right.changedAt;
+}
+
+/**
+ * Resolve settings.json without ever replacing a user-managed symlink.
+ * Dangling links and non-regular targets are rejected rather than treated as
+ * an absent settings file.
+ */
+function resolveSettingsFileTarget(): SettingsFileTarget {
+  let entry: fs.Stats;
+  try {
+    entry = fs.lstatSync(HOOKS_FILE);
+  } catch (error) {
+    if (isMissingFileError(error)) return { kind: 'missing', path: HOOKS_FILE };
+    throw error;
+  }
+
+  if (entry.isSymbolicLink()) {
+    let resolvedPath: string;
+    try {
+      resolvedPath = fs.realpathSync(HOOKS_FILE);
+    } catch (error) {
+      throw new Error(
+        'Claude settings.json is a dangling or unsafe symbolic link; refusing to replace it.',
+        { cause: error },
+      );
+    }
+    const resolvedEntry = fs.statSync(resolvedPath, { bigint: true });
+    if (!resolvedEntry.isFile()) {
+      throw new Error(
+        'Claude settings.json symbolic link does not resolve to a regular file; refusing to modify it.',
+      );
+    }
+    return {
+      kind: 'symlink',
+      path: resolvedPath,
+      linkPath: HOOKS_FILE,
+      fingerprint: fingerprintFromStat(resolvedEntry),
+    };
+  }
+
+  if (!entry.isFile()) {
+    throw new Error('Claude settings.json is not a regular file; refusing to modify it.');
+  }
+  return { kind: 'file', path: HOOKS_FILE, fingerprint: getFileFingerprint(HOOKS_FILE) };
+}
+
+function assertSettingsTargetUnchanged(target: SettingsFileTarget): void {
+  if (target.kind === 'symlink') {
+    const entry = fs.lstatSync(target.linkPath);
+    if (!entry.isSymbolicLink() || fs.realpathSync(target.linkPath) !== target.path) {
+      throw new Error('Claude settings.json symbolic link changed while it was being updated.');
+    }
+    if (!fingerprintsMatch(target.fingerprint, getFileFingerprint(target.path))) {
+      throw new Error('Claude settings.json changed while it was being updated.');
+    }
+    return;
+  }
+
+  try {
+    const entry = fs.lstatSync(HOOKS_FILE);
+    if (target.kind === 'missing' || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error('Claude settings.json changed while it was being updated.');
+    }
+    if (!fingerprintsMatch(target.fingerprint, getFileFingerprint(target.path))) {
+      throw new Error('Claude settings.json changed while it was being updated.');
+    }
+  } catch (error) {
+    if (target.kind === 'missing' && isMissingFileError(error)) return;
+    throw error;
+  }
+}
+
+function writeSettingsAtomically(settings: ClaudeSettings, target: SettingsFileTarget): void {
+  const destinationDirectory = path.dirname(target.path);
+  fs.mkdirSync(destinationDirectory, { recursive: true });
+  const temporaryFile = path.join(
+    destinationDirectory,
+    `.settings.json.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    fs.writeFileSync(temporaryFile, JSON.stringify(settings, null, 2), {
+      encoding: 'utf-8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    fs.chmodSync(temporaryFile, 0o600);
+    assertSettingsTargetUnchanged(target);
+    fs.renameSync(temporaryFile, target.path);
+  } finally {
+    fs.rmSync(temporaryFile, { force: true });
+  }
+}
+
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\"'\"'") + "'";
+}
+
+function sessionEndHookCommand(): string {
+  const configDir = process.env.CODE_INSIGHTS_CONFIG_DIR;
+  if (process.platform === 'win32') {
+    const cliEntry = `"${CLI_ENTRY.replace(/"/g, '""')}"`;
+    const prefix = configDir
+      ? `set "CODE_INSIGHTS_CONFIG_DIR=${configDir.replace(/"/g, '""')}" && `
+      : '';
+    return `${prefix}node ${cliEntry} session-end --native -q`;
+  }
+
+  const prefix = configDir
+    ? `CODE_INSIGHTS_CONFIG_DIR=${shellQuote(configDir)} `
+    : '';
+  return `${prefix}node ${shellQuote(CLI_ENTRY)} session-end --native -q`;
+}
 
 /**
  * Remove any existing Code Insights Stop hooks (v4.8.x migration).
@@ -43,21 +194,25 @@ function removeStopHooks(settings: ClaudeSettings): boolean {
 export async function installHookCommand(): Promise<void> {
   console.log(chalk.cyan('\nInstall Code Insights Hook\n'));
 
-  const sessionEndCommand = `node ${CLI_ENTRY} session-end --native -q`;
+  const sessionEndCommand = sessionEndHookCommand();
 
   console.log(chalk.gray('This will add one Claude Code SessionEnd hook:\n'));
   console.log(chalk.white('  SessionEnd hook — Syncs and analyzes sessions when they end'));
   console.log(chalk.gray('                    Uses your Claude subscription. No API key needed.\n'));
 
   try {
+    const settingsTarget = resolveSettingsFileTarget();
     // Load existing settings
     let settings: ClaudeSettings = {};
-    if (fs.existsSync(HOOKS_FILE)) {
+    if (settingsTarget.kind !== 'missing') {
       try {
-        const content = fs.readFileSync(HOOKS_FILE, 'utf-8');
+        const content = fs.readFileSync(settingsTarget.path, 'utf-8');
         settings = JSON.parse(content);
-      } catch {
-        console.log(chalk.yellow('Could not parse existing settings.json, creating new one.'));
+      } catch (error) {
+        throw new Error(
+          'Could not read or parse existing Claude settings.json; refusing to overwrite it.',
+          { cause: error },
+        );
       }
     }
 
@@ -71,22 +226,22 @@ export async function installHookCommand(): Promise<void> {
       console.log(chalk.dim('  Removed legacy Stop hook from v4.8.x'));
     }
 
-    // Install the new unified SessionEnd hook (skip if already installed)
+    // Replace any older Code Insights SessionEnd entry so upgrades refresh the
+    // absolute CLI path and any pinned configuration directory.
     if (!settings.hooks.SessionEnd) {
       settings.hooks.SessionEnd = [];
     }
-
-    if (!hookAlreadyInstalled(settings.hooks.SessionEnd)) {
-      const newHook: HookConfig = {
-        // timeout: 10s is enough — session-end exits immediately after spawn
-        hooks: [{ type: 'command', command: sessionEndCommand, timeout: 10000 }],
-      };
-      settings.hooks.SessionEnd.push(newHook);
-    }
+    settings.hooks.SessionEnd = settings.hooks.SessionEnd.filter(
+      (entry) => !entry.hooks.some((hook) => getHookCommand(hook).includes('code-insights')),
+    );
+    const newHook: HookConfig = {
+      // timeout: 10s is enough — session-end exits immediately after spawn
+      hooks: [{ type: 'command', command: sessionEndCommand, timeout: 10000 }],
+    };
+    settings.hooks.SessionEnd.push(newHook);
 
     // Write settings
-    fs.mkdirSync(CLAUDE_SETTINGS_DIR, { recursive: true });
-    fs.writeFileSync(HOOKS_FILE, JSON.stringify(settings, null, 2));
+    writeSettingsAtomically(settings, settingsTarget);
 
     console.log(chalk.green('Hook installed successfully!'));
     console.log(chalk.gray(`\nConfiguration saved to: ${HOOKS_FILE}`));
@@ -106,6 +261,7 @@ export async function installHookCommand(): Promise<void> {
     const { error_type, error_message } = classifyError(error);
     trackEvent('cli_install_hook', { success: false, error_type, error_message });
     captureError(error, { command: 'install_hook', error_type });
+    throw error;
   }
 }
 
@@ -116,14 +272,23 @@ export async function installHookCommand(): Promise<void> {
 export async function uninstallHookCommand(): Promise<void> {
   console.log(chalk.cyan('\nUninstall Code Insights Hooks\n'));
 
-  if (!fs.existsSync(HOOKS_FILE)) {
-    console.log(chalk.yellow('No hooks file found. Nothing to uninstall.'));
-    return;
-  }
-
   try {
-    const content = fs.readFileSync(HOOKS_FILE, 'utf-8');
-    const settings: ClaudeSettings = JSON.parse(content);
+    const settingsTarget = resolveSettingsFileTarget();
+    if (settingsTarget.kind === 'missing') {
+      console.log(chalk.yellow('No hooks file found. Nothing to uninstall.'));
+      return;
+    }
+
+    let settings: ClaudeSettings;
+    try {
+      const content = fs.readFileSync(settingsTarget.path, 'utf-8');
+      settings = JSON.parse(content);
+    } catch (error) {
+      throw new Error(
+        'Could not read or parse existing Claude settings.json; refusing to overwrite it.',
+        { cause: error },
+      );
+    }
 
     if (!settings.hooks?.Stop && !settings.hooks?.SessionEnd) {
       console.log(chalk.yellow('No Code Insights hooks found. Nothing to uninstall.'));
@@ -154,11 +319,12 @@ export async function uninstallHookCommand(): Promise<void> {
       delete settings.hooks;
     }
 
-    fs.writeFileSync(HOOKS_FILE, JSON.stringify(settings, null, 2));
+    writeSettingsAtomically(settings, settingsTarget);
 
     console.log(chalk.green('Hooks uninstalled successfully!'));
   } catch (error) {
     console.log(chalk.red('Failed to uninstall hooks:'));
     console.error(error instanceof Error ? error.message : 'Unknown error');
+    throw error;
   }
 }

--- a/cli/src/commands/lock-run.ts
+++ b/cli/src/commands/lock-run.ts
@@ -1,0 +1,165 @@
+import { spawn, spawnSync } from 'child_process';
+import { acquireLlmLock } from '../analysis/llm-lock.js';
+
+const SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+interface ProcessTreeChild {
+  readonly pid?: number;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+
+interface TaskkillResult {
+  readonly status: number | null;
+  readonly error?: Error;
+}
+
+interface TaskkillOptions {
+  readonly shell: false;
+  readonly stdio: 'ignore';
+  readonly timeout: number;
+  readonly windowsHide: true;
+}
+
+type TaskkillRunner = (
+  command: string,
+  args: string[],
+  options: TaskkillOptions,
+) => TaskkillResult;
+
+interface ProcessTreeTerminationOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly runTaskkill?: TaskkillRunner;
+}
+
+const defaultTaskkillRunner: TaskkillRunner = (command, args, options) => {
+  const result = spawnSync(command, args, options);
+  return { status: result.status, error: result.error };
+};
+
+/** Terminate a child and, where supported, all of its descendants. */
+export function terminateChildProcessTree(
+  child: ProcessTreeChild,
+  signal: NodeJS.Signals,
+  options: ProcessTreeTerminationOptions = {},
+): void {
+  const platform = options.platform ?? process.platform;
+
+  if (platform === 'win32' && child.pid) {
+    try {
+      const result = (options.runTaskkill ?? defaultTaskkillRunner)(
+        'taskkill',
+        ['/PID', String(child.pid), '/T', '/F'],
+        {
+          shell: false,
+          stdio: 'ignore',
+          timeout: 5_000,
+          windowsHide: true,
+        },
+      );
+      if (!result.error && result.status === 0) return;
+    } catch {
+      // Fall through when taskkill is missing or cannot be started.
+    }
+  } else if (platform !== 'win32' && child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The group may have already exited; fall back to the direct child.
+    }
+  }
+
+  try {
+    child.kill(signal);
+  } catch {
+    // The child has already exited.
+  }
+}
+
+/**
+ * Run one command while holding the shared LLM lock.
+ *
+ * The child receives CODE_INSIGHTS_LOCK_HELD=1 so nested Code Insights
+ * commands reuse the parent's lock instead of attempting a second acquisition.
+ */
+export async function runCommandWithLlmLock(
+  command: string[],
+  terminationOptions: ProcessTreeTerminationOptions = {},
+): Promise<number> {
+  if (command.length === 0 || !command[0]) {
+    throw new Error('A command is required after lock-run.');
+  }
+
+  const lock = acquireLlmLock();
+  if (!lock) return 75;
+
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      const childEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        CODE_INSIGHTS_LOCK_HELD: '1',
+      };
+      if (lock.token) childEnv.CODE_INSIGHTS_LOCK_TOKEN = lock.token;
+      const child = spawn(command[0], command.slice(1), {
+        stdio: 'inherit',
+        env: childEnv,
+        // A separate POSIX process group lets launchd/terminal signals reach
+        // the shell command and every LLM grandchild it is waiting for.
+        detached: (terminationOptions.platform ?? process.platform) !== 'win32',
+      });
+
+      let settled = false;
+      let forwardedSignal: NodeJS.Signals | undefined;
+      let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+      const signalHandlers = new Map<NodeJS.Signals, () => void>();
+      const cleanupListeners = (): void => {
+        for (const [signal, handler] of signalHandlers) {
+          process.off(signal, handler);
+        }
+        if (forceKillTimer) clearTimeout(forceKillTimer);
+      };
+      const killChildTree = (signal: NodeJS.Signals): void => {
+        terminateChildProcessTree(child, signal, terminationOptions);
+      };
+      const settle = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        cleanupListeners();
+        callback();
+      };
+
+      for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+        const handler = (): void => {
+          forwardedSignal ??= signal;
+          killChildTree(signal);
+          if (!forceKillTimer) {
+            forceKillTimer = setTimeout(() => killChildTree('SIGKILL'), 5_000);
+          }
+        };
+        signalHandlers.set(signal, handler);
+        process.on(signal, handler);
+      }
+
+      child.once('error', (error) => settle(() => reject(error)));
+      child.once('exit', (code, signal) => settle(() => {
+        // The shell may exit from its trap before an ignoring grandchild does.
+        // Tear down any remaining members before releasing the global lock.
+        if (forwardedSignal) killChildTree('SIGKILL');
+        if (forwardedSignal) {
+          resolve(SIGNAL_EXIT_CODES[forwardedSignal] ?? 1);
+          return;
+        }
+        if (code !== null) {
+          resolve(code);
+          return;
+        }
+        resolve(signal ? (SIGNAL_EXIT_CODES[signal] ?? 1) : 1);
+      }));
+    });
+  } finally {
+    lock.release();
+  }
+}

--- a/cli/src/commands/queue.ts
+++ b/cli/src/commands/queue.ts
@@ -13,7 +13,11 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { getQueueStatus, resetFailed, pruneCompleted } from '../db/queue.js';
-import { processQueue } from '../analysis/queue-worker.js';
+import {
+  PROCESS_QUEUE_BUSY,
+  PROCESS_QUEUE_FAILED,
+  processQueue,
+} from '../analysis/queue-worker.js';
 
 // ── queue status ──────────────────────────────────────────────────────────────
 
@@ -59,12 +63,36 @@ export async function queueStatusCommand(opts: { quiet?: boolean } = {}): Promis
 
 // ── queue process ─────────────────────────────────────────────────────────────
 
-export async function queueProcessCommand(opts: { quiet?: boolean; model?: string } = {}): Promise<void> {
+export interface QueueProcessCommandOptions {
+  quiet?: boolean;
+  model?: string;
+  /** Maximum number of items to attempt. */
+  limit?: number;
+  /** Delay between items, in seconds. */
+  delay?: number;
+}
+
+export async function queueProcessCommand(opts: QueueProcessCommandOptions = {}): Promise<void> {
   const { quiet = false } = opts;
   const log = quiet ? () => {} : console.log.bind(console);
 
   try {
-    const count = await processQueue({ quiet, model: opts.model });
+    const count = await processQueue({
+      quiet,
+      model: opts.model,
+      maxItems: opts.limit,
+      delayMs: opts.delay === undefined ? undefined : opts.delay * 1_000,
+    });
+    if (count === PROCESS_QUEUE_BUSY) {
+      log(chalk.yellow('[Code Insights] Queue worker is busy; pending items were retained'));
+      process.exitCode = 75;
+      return;
+    }
+    if (count === PROCESS_QUEUE_FAILED) {
+      log(chalk.red('[Code Insights] Queue processing stopped after an analysis failure'));
+      process.exitCode = 1;
+      return;
+    }
     if (count === 0) {
       log(chalk.dim('[Code Insights] No pending items in queue'));
     } else {
@@ -129,10 +157,17 @@ export function buildQueueCommand(): Command {
 
   queueCmd
     .command('process')
-    .description('Process pending queue items (foreground)')
+    .description('Process a bounded number of pending queue items (foreground)')
     .option('-q, --quiet', 'Suppress output')
     .option('--model <model>', 'Model for native analysis (default: sonnet)')
-    .action((opts) => queueProcessCommand({ quiet: opts.quiet, model: opts.model }));
+    .option('--limit <n>', 'Maximum items to attempt', '1')
+    .option('--delay <seconds>', 'Delay between items in seconds', '0')
+    .action((opts) => queueProcessCommand({
+      quiet: opts.quiet,
+      model: opts.model,
+      limit: parseInt(opts.limit, 10),
+      delay: parseInt(opts.delay, 10),
+    }));
 
   queueCmd
     .command('retry [session_id]')

--- a/cli/src/commands/reflect.ts
+++ b/cli/src/commands/reflect.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 import chalk from 'chalk';
 import { loadConfig } from '../utils/config.js';
 import { getCurrentIsoWeek } from '../utils/date-utils.js';
+import { LLM_LOCK_TOKEN_HEADER } from '../analysis/llm-lock.js';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -20,9 +21,19 @@ function confirmPrompt(message: string): Promise<boolean> {
 }
 
 function getBaseUrl(): string {
+  const dashboardUrl = process.env.CODE_INSIGHTS_DASHBOARD_URL?.trim();
+  if (dashboardUrl) return dashboardUrl.replace(/\/+$/, '');
+
   const config = loadConfig();
   const port = config?.dashboard?.port || 7890;
   return `http://localhost:${port}`;
+}
+
+function getLlmRequestHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const lockToken = process.env.CODE_INSIGHTS_LOCK_TOKEN;
+  if (lockToken) headers[LLM_LOCK_TOKEN_HEADER] = lockToken;
+  return headers;
 }
 
 async function checkServer(baseUrl: string): Promise<void> {
@@ -60,7 +71,7 @@ async function checkLlmConfigured(baseUrl: string): Promise<void> {
 async function fetchWithSSE(url: string, body: Record<string, unknown>, signal?: AbortSignal): Promise<Record<string, unknown>> {
   const res = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: getLlmRequestHeaders(),
     body: JSON.stringify(body),
     signal,
   });
@@ -77,6 +88,8 @@ async function fetchWithSSE(url: string, body: Record<string, unknown>, signal?:
   let currentEvent = '';
   let currentData = '';
   let result: Record<string, unknown> = {};
+  let completed = false;
+  let streamError: Error | undefined;
 
   const spinner = ora({ text: 'Starting...', indent: 2 }).start();
 
@@ -103,8 +116,13 @@ async function fetchWithSSE(url: string, body: Record<string, unknown>, signal?:
             } else if (currentEvent === 'complete') {
               spinner.succeed('Analysis complete');
               result = data;
+              completed = true;
             } else if (currentEvent === 'error') {
-              spinner.fail((data.error as string) || 'Generation failed');
+              const message = typeof data.error === 'string' && data.error.trim()
+                ? data.error
+                : 'Generation failed';
+              spinner.fail(message);
+              streamError = new Error(message);
             }
           } catch {
             // Skip malformed SSE events (e.g., truncated JSON from network issues)
@@ -112,11 +130,19 @@ async function fetchWithSSE(url: string, body: Record<string, unknown>, signal?:
 
           currentEvent = '';
           currentData = '';
+
+          if (streamError) throw streamError;
         }
       }
     }
   } finally {
     reader.releaseLock();
+  }
+
+  if (!completed) {
+    const message = 'SSE stream ended without a complete event';
+    spinner.fail(message);
+    throw new Error(message);
   }
 
   return result;
@@ -142,7 +168,7 @@ async function backfillPqBatch(
   return backfillBatchToEndpoint(baseUrl, '/api/facets/backfill-pq', sessionIds, offset, total, signal);
 }
 
-async function backfillBatchToEndpoint(
+export async function backfillBatchToEndpoint(
   baseUrl: string,
   endpoint: string,
   sessionIds: string[],
@@ -152,7 +178,7 @@ async function backfillBatchToEndpoint(
 ): Promise<{ completed: number; failed: number }> {
   const res = await fetch(`${baseUrl}${endpoint}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: getLlmRequestHeaders(),
     // force=true so outdated sessions (which already have facets) are re-processed.
     // Missing sessions are unaffected — the guard only fires when a row exists.
     body: JSON.stringify({ sessionIds, force: true }),
@@ -170,6 +196,8 @@ async function backfillBatchToEndpoint(
   let currentEvent = '';
   let currentData = '';
   let result = { completed: 0, failed: 0 };
+  let completed = false;
+  let streamError: Error | undefined;
 
   const spinner = ora({ text: `  Backfilling ${offset + 1}-${offset + sessionIds.length} of ${total}...`, indent: 2 }).start();
 
@@ -194,15 +222,28 @@ async function backfillBatchToEndpoint(
             } else if (currentEvent === 'complete') {
               result = { completed: data.completed as number, failed: data.failed as number };
               spinner.succeed(`  Batch complete: ${result.completed} extracted, ${result.failed} failed`);
+              completed = true;
+            } else if (currentEvent === 'error') {
+              const message = typeof data.error === 'string' && data.error.trim()
+                ? data.error
+                : 'Backfill failed';
+              spinner.fail(message);
+              streamError = new Error(message);
             }
           } catch { /* skip malformed */ }
           currentEvent = '';
           currentData = '';
+          if (streamError) throw streamError;
         }
       }
     }
   } finally {
     reader.releaseLock();
+  }
+  if (!completed) {
+    const message = 'Backfill SSE stream ended without a complete event';
+    spinner.fail(message);
+    throw new Error(message);
   }
   return result;
 }

--- a/cli/src/commands/sync-dry-run.test.ts
+++ b/cli/src/commands/sync-dry-run.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+describe.sequential('sync --dry-run filesystem safety', () => {
+  let tempDir: string;
+  let configDir: string;
+  let codexHome: string;
+  let previousConfigDir: string | undefined;
+  let previousCodexHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-dry-run-'));
+    configDir = path.join(tempDir, 'config-that-does-not-exist');
+    codexHome = path.join(tempDir, 'codex');
+    fs.mkdirSync(path.join(codexHome, 'sessions'), { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, 'sessions', 'rollout-dry-run.jsonl'),
+      JSON.stringify({
+        type: 'session_meta',
+        payload: { id: 'dry-run', timestamp: '2026-01-01T00:00:00Z', cwd: tempDir },
+      }),
+    );
+
+    previousConfigDir = process.env.CODE_INSIGHTS_CONFIG_DIR;
+    previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODE_INSIGHTS_CONFIG_DIR = configDir;
+    process.env.CODEX_HOME = codexHome;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (previousConfigDir === undefined) delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+    else process.env.CODE_INSIGHTS_CONFIG_DIR = previousConfigDir;
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    vi.resetModules();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('discovers sessions without creating a config directory or SQLite database', async () => {
+    const { runSync } = await import('./sync.js');
+
+    await expect(runSync({ dryRun: true, quiet: true, source: 'codex-cli' }))
+      .resolves.toMatchObject({ syncedCount: 0, errorCount: 0 });
+
+    expect(fs.existsSync(configDir)).toBe(false);
+    expect(fs.existsSync(path.join(configDir, 'data.db'))).toBe(false);
+    expect(fs.existsSync(path.join(configDir, 'sync-state.json'))).toBe(false);
+    expect(fs.existsSync(path.join(configDir, 'config.json'))).toBe(false);
+  });
+});

--- a/cli/src/commands/sync.test.ts
+++ b/cli/src/commands/sync.test.ts
@@ -4,7 +4,20 @@ import * as os from 'os';
 import * as path from 'path';
 import { makeParsedMessage, makeParsedSession } from '../__fixtures__/db/seed.js';
 
-let syncState = { lastSync: '', files: {} as Record<string, any> };
+let syncState: {
+  lastSync: string;
+  files: Record<string, any>;
+  migrations?: { codexScopedMessageIds?: boolean };
+  databaseIdentity?: string;
+} = { lastSync: '', files: {} };
+let currentDbIdentity = '/mock/data.db#database-a';
+let currentDbPath = '/mock/data.db';
+const advanceDbSyncIdentity = vi.fn(() => currentDbIdentity);
+const getDb = vi.fn(() => ({
+  prepare: vi.fn(() => ({ run: vi.fn() })),
+}));
+const getDbIdentity = vi.fn(() => currentDbIdentity);
+const getMigrationResult = vi.fn(() => ({ v6Applied: false }));
 const saveSyncState = vi.fn((state: typeof syncState) => {
   syncState = state;
 });
@@ -17,8 +30,16 @@ vi.mock('../utils/config.js', () => ({
 }));
 
 vi.mock('../db/client.js', () => ({
-  getDb: () => ({}),
-  getMigrationResult: () => ({ v6Applied: false }),
+  getDb,
+  getDbIdentity,
+  getDbPath: () => currentDbPath,
+  advanceDbSyncIdentity,
+  getMigrationResult,
+}));
+
+const autoDetectOllama = vi.fn();
+vi.mock('../utils/ollama-detect.js', () => ({
+  autoDetectOllama,
 }));
 
 const insertSessionWithProjectAndReturnIsNew = vi.fn();
@@ -28,6 +49,11 @@ vi.mock('../db/write.js', () => ({
   insertSessionWithProjectAndReturnIsNew,
   insertMessages,
   recalculateUsageStats,
+}));
+
+const invalidateAnalysisUsage = vi.fn();
+vi.mock('../analysis/analysis-usage-db.js', () => ({
+  invalidateAnalysisUsage,
 }));
 
 const getAllProviders = vi.fn();
@@ -40,23 +66,39 @@ vi.mock('../providers/context.js', () => ({
   setProviderVerbose: () => {},
 }));
 
+const identifyUser = vi.fn();
+const trackEvent = vi.fn();
 vi.mock('../utils/telemetry.js', () => ({
-  trackEvent: () => {},
+  trackEvent,
+  identifyUser,
+  captureError: vi.fn(),
+  classifyError: vi.fn(() => ({ error_type: 'test', error_message: 'test' })),
 }));
 
-const { runSync } = await import('./sync.js');
+const { runSync, syncCommand } = await import('./sync.js');
 
 describe('runSync', () => {
   let tempDir: string;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-sync-'));
-    syncState = { lastSync: '', files: {} };
+    currentDbIdentity = '/mock/data.db#database-a';
+    currentDbPath = path.join(tempDir, 'data.db');
+    getDb.mockClear();
+    getDbIdentity.mockClear();
+    getMigrationResult.mockClear();
+    advanceDbSyncIdentity.mockReset();
+    advanceDbSyncIdentity.mockImplementation(() => currentDbIdentity);
+    syncState = { lastSync: '', files: {}, databaseIdentity: currentDbIdentity };
     saveSyncState.mockClear();
     insertSessionWithProjectAndReturnIsNew.mockReset();
     insertMessages.mockReset();
     recalculateUsageStats.mockClear();
+    invalidateAnalysisUsage.mockReset();
     getAllProviders.mockReset();
+    autoDetectOllama.mockReset();
+    identifyUser.mockReset();
+    trackEvent.mockReset();
   });
 
   afterEach(() => {
@@ -243,5 +285,421 @@ describe('runSync', () => {
     expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledTimes(1);
     expect(insertMessages).toHaveBeenCalledTimes(1);
     expect(result.syncedCount).toBe(1);
+  });
+
+  it('force-resyncs unchanged Codex files once when scoped message IDs have not been migrated', async () => {
+    const filePath = path.join(tempDir, 'rollout.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    const stat = fs.statSync(filePath);
+    syncState.files[filePath] = {
+      lastModified: stat.mtime.toISOString(),
+      lastSyncedLine: 0,
+      sessionId: 'codex:legacy-session',
+    };
+
+    const session = makeParsedSession({
+      id: 'codex:legacy-session',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      userMessageCount: 2,
+      assistantMessageCount: 1,
+      messages: [
+        makeParsedMessage({ id: 'codex:legacy-session:user:0', sessionId: 'codex:legacy-session' }),
+        makeParsedMessage({ id: 'codex:legacy-session:assistant:1', sessionId: 'codex:legacy-session', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:legacy-session:user:2', sessionId: 'codex:legacy-session' }),
+      ],
+    });
+
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => session,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
+
+    const result = await runSync({ quiet: true });
+
+    expect(result.syncedCount).toBe(1);
+    expect(insertMessages).toHaveBeenCalledWith(session, true);
+    expect(invalidateAnalysisUsage).toHaveBeenCalledWith('codex:legacy-session');
+    expect(syncState.migrations?.codexScopedMessageIds).toBe(true);
+  });
+
+  it('does not complete the global Codex migration from a project-filtered sync', async () => {
+    const filePath = path.join(tempDir, 'project-rollout.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    const session = makeParsedSession({
+      id: 'codex:project-session',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      userMessageCount: 2,
+      assistantMessageCount: 1,
+      messages: [
+        makeParsedMessage({ id: 'codex:project-session:user:0', sessionId: 'codex:project-session' }),
+        makeParsedMessage({ id: 'codex:project-session:assistant:1', sessionId: 'codex:project-session', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:project-session:user:2', sessionId: 'codex:project-session' }),
+      ],
+    });
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => session,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
+
+    await runSync({ quiet: true, project: 'only-this-project' });
+    expect(syncState.files[filePath]).toMatchObject({
+      lastModified: fs.statSync(filePath).mtime.toISOString(),
+      fileSize: fs.statSync(filePath).size,
+    });
+    await runSync({ quiet: true, project: 'only-this-project' });
+
+    expect(invalidateAnalysisUsage).not.toHaveBeenCalled();
+    expect(insertMessages).toHaveBeenCalledTimes(1);
+    expect(syncState.migrations?.codexScopedMessageIds).not.toBe(true);
+  });
+
+  it('replaces the full message snapshot for later incremental Codex updates', async () => {
+    const filePath = path.join(tempDir, 'rollout-updated.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    syncState.migrations = { codexScopedMessageIds: true };
+    syncState.files[filePath] = {
+      lastModified: new Date(0).toISOString(),
+      lastSyncedLine: 0,
+      sessionId: 'codex:updated-session',
+    };
+    const session = makeParsedSession({
+      id: 'codex:updated-session',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      userMessageCount: 2,
+      assistantMessageCount: 1,
+      messages: [
+        makeParsedMessage({ id: 'codex:updated-session:user:0', sessionId: 'codex:updated-session' }),
+        makeParsedMessage({ id: 'codex:updated-session:assistant:1', sessionId: 'codex:updated-session', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:updated-session:user:2', sessionId: 'codex:updated-session' }),
+      ],
+    });
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => session,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
+
+    await runSync({ quiet: true });
+
+    expect(insertMessages).toHaveBeenCalledWith(session, true);
+    expect(invalidateAnalysisUsage).toHaveBeenCalledWith('codex:updated-session');
+  });
+
+  it('does not invalidate analysis for an unchanged Codex file forced through a no-op resync', async () => {
+    const filePath = path.join(tempDir, 'rollout-unchanged.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    const stat = fs.statSync(filePath);
+    syncState.migrations = { codexScopedMessageIds: true };
+    syncState.files[filePath] = {
+      lastModified: stat.mtime.toISOString(),
+      fileSize: stat.size,
+      lastSyncedLine: 0,
+      sessionId: 'codex:unchanged-session',
+    };
+    const session = makeParsedSession({
+      id: 'codex:unchanged-session',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      messages: [
+        makeParsedMessage({ id: 'codex:unchanged-session:user:0', sessionId: 'codex:unchanged-session' }),
+        makeParsedMessage({ id: 'codex:unchanged-session:assistant:1', sessionId: 'codex:unchanged-session', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:unchanged-session:user:2', sessionId: 'codex:unchanged-session' }),
+      ],
+    });
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => session,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(false);
+
+    await runSync({ quiet: true, force: true });
+
+    expect(insertMessages).toHaveBeenCalledWith(session, true);
+    expect(invalidateAnalysisUsage).not.toHaveBeenCalled();
+  });
+
+  it('discards file checkpoints and migration flags when the SQLite identity changes', async () => {
+    const filePath = path.join(tempDir, 'rollout-restored-db.jsonl');
+    fs.writeFileSync(filePath, 'unchanged transcript');
+    const stat = fs.statSync(filePath);
+    syncState = {
+      lastSync: '2026-01-01T00:00:00.000Z',
+      databaseIdentity: '/mock/data.db#database-before-restore',
+      files: {
+        [filePath]: {
+          lastModified: stat.mtime.toISOString(),
+          fileSize: stat.size,
+          lastSyncedLine: 0,
+          sessionId: 'codex:restored-db',
+        },
+      },
+      migrations: { codexScopedMessageIds: true },
+    };
+    currentDbIdentity = '/mock/data.db#database-after-restore';
+    const session = makeParsedSession({
+      id: 'codex:restored-db',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      messages: [
+        makeParsedMessage({ id: 'codex:restored-db:user:0', sessionId: 'codex:restored-db' }),
+        makeParsedMessage({ id: 'codex:restored-db:assistant:1', sessionId: 'codex:restored-db', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:restored-db:user:2', sessionId: 'codex:restored-db' }),
+      ],
+    });
+    const parse = vi.fn(async () => session);
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(true);
+
+    const result = await runSync({ quiet: true });
+
+    expect(parse).toHaveBeenCalledOnce();
+    expect(result.syncedCount).toBe(1);
+    expect(syncState.databaseIdentity).toBe(currentDbIdentity);
+    expect(syncState.migrations?.codexScopedMessageIds).toBe(true);
+  });
+
+  it('checkpoints the SQLite sync generation after a completed run', async () => {
+    const nextIdentity = '/mock/data.db#database-a#generation-next';
+    advanceDbSyncIdentity.mockReturnValueOnce(nextIdentity);
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [],
+      parse: async () => null,
+    }]);
+
+    await runSync({ quiet: true });
+
+    expect(advanceDbSyncIdentity).toHaveBeenCalledOnce();
+    expect(syncState.databaseIdentity).toBe(nextIdentity);
+  });
+
+  it('does not mutate or persist sync state during a forced dry run', async () => {
+    const filePath = path.join(tempDir, 'rollout-dry-run.jsonl');
+    fs.writeFileSync(filePath, 'unchanged');
+    syncState = {
+      lastSync: '2026-01-01T00:00:00.000Z',
+      databaseIdentity: '/mock/data.db#database-before-switch',
+      files: {
+        [filePath]: {
+          lastModified: fs.statSync(filePath).mtime.toISOString(),
+          fileSize: fs.statSync(filePath).size,
+          lastSyncedLine: 0,
+          sessionId: 'codex:dry-run',
+        },
+      },
+      migrations: { codexScopedMessageIds: true },
+    };
+    const originalState = structuredClone(syncState);
+    currentDbIdentity = '/mock/data.db#database-after-switch';
+    const parse = vi.fn();
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse,
+    }]);
+
+    await runSync({ quiet: true, dryRun: true, force: true });
+
+    expect(parse).not.toHaveBeenCalled();
+    expect(getDb).not.toHaveBeenCalled();
+    expect(getDbIdentity).not.toHaveBeenCalled();
+    expect(getMigrationResult).not.toHaveBeenCalled();
+    expect(autoDetectOllama).not.toHaveBeenCalled();
+    expect(insertSessionWithProjectAndReturnIsNew).not.toHaveBeenCalled();
+    expect(insertMessages).not.toHaveBeenCalled();
+    expect(recalculateUsageStats).not.toHaveBeenCalled();
+    expect(advanceDbSyncIdentity).not.toHaveBeenCalled();
+    expect(saveSyncState).not.toHaveBeenCalled();
+    expect(syncState).toEqual(originalState);
+  });
+
+  it('plans a dry run without creating a missing database or auto-configuring Ollama', async () => {
+    const filePath = path.join(tempDir, 'dry-run-without-db.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    currentDbPath = path.join(tempDir, 'missing', 'data.db');
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'mock',
+      discover: async () => [filePath],
+      parse: vi.fn(),
+    }]);
+
+    await syncCommand({ dryRun: true });
+
+    expect(fs.existsSync(currentDbPath)).toBe(false);
+    expect(getDb).not.toHaveBeenCalled();
+    expect(getDbIdentity).not.toHaveBeenCalled();
+    expect(getMigrationResult).not.toHaveBeenCalled();
+    expect(autoDetectOllama).not.toHaveBeenCalled();
+    expect(identifyUser).not.toHaveBeenCalled();
+    expect(saveSyncState).not.toHaveBeenCalled();
+    expect(advanceDbSyncIdentity).not.toHaveBeenCalled();
+  });
+
+  it('retries a Codex transcript that changes while it is being parsed', async () => {
+    const filePath = path.join(tempDir, 'rollout-growing.jsonl');
+    fs.writeFileSync(filePath, 'initial');
+    syncState.migrations = { codexScopedMessageIds: true };
+
+    const firstSnapshot = makeParsedSession({
+      id: 'codex:growing-session',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      messages: [
+        makeParsedMessage({ id: 'codex:growing-session:user:0', sessionId: 'codex:growing-session' }),
+        makeParsedMessage({ id: 'codex:growing-session:assistant:1', sessionId: 'codex:growing-session', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:growing-session:user:2', sessionId: 'codex:growing-session' }),
+      ],
+    });
+    const stableSnapshot = makeParsedSession({
+      ...firstSnapshot,
+      messageCount: 4,
+      messages: [
+        ...firstSnapshot.messages,
+        makeParsedMessage({ id: 'codex:growing-session:assistant:3', sessionId: 'codex:growing-session', type: 'assistant' }),
+      ],
+    });
+    let parseAttempts = 0;
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => {
+        parseAttempts++;
+        if (parseAttempts === 1) {
+          fs.appendFileSync(filePath, '-grew-during-parse');
+          return firstSnapshot;
+        }
+        return stableSnapshot;
+      },
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockReturnValue(true);
+
+    const result = await runSync({ quiet: true });
+
+    expect(parseAttempts).toBe(2);
+    expect(result.errorCount).toBe(0);
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledOnce();
+    expect(insertSessionWithProjectAndReturnIsNew).toHaveBeenCalledWith(stableSnapshot, false);
+    expect(syncState.files[filePath].lastModified).toBe(fs.statSync(filePath).mtime.toISOString());
+  });
+
+  it('does not write or checkpoint a Codex transcript that keeps changing', async () => {
+    const filePath = path.join(tempDir, 'rollout-still-growing.jsonl');
+    fs.writeFileSync(filePath, 'initial');
+    const session = makeParsedSession({
+      id: 'codex:still-growing',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      messages: [
+        makeParsedMessage({ id: 'codex:still-growing:user:0', sessionId: 'codex:still-growing' }),
+        makeParsedMessage({ id: 'codex:still-growing:assistant:1', sessionId: 'codex:still-growing', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:still-growing:user:2', sessionId: 'codex:still-growing' }),
+      ],
+    });
+    let parseAttempts = 0;
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => {
+        parseAttempts++;
+        fs.appendFileSync(filePath, `-${parseAttempts}`);
+        return session;
+      },
+    }]);
+
+    const result = await runSync({ quiet: true });
+
+    expect(parseAttempts).toBe(2);
+    expect(result.errorCount).toBe(1);
+    expect(insertSessionWithProjectAndReturnIsNew).not.toHaveBeenCalled();
+    expect(insertMessages).not.toHaveBeenCalled();
+    expect(syncState.files[filePath]).toBeUndefined();
+    expect(syncState.migrations?.codexScopedMessageIds).not.toBe(true);
+  });
+
+  it('checkpoints the parsed Codex snapshot rather than a later file mtime', async () => {
+    const filePath = path.join(tempDir, 'rollout-after-parse.jsonl');
+    fs.writeFileSync(filePath, 'stable-snapshot');
+    const snapshotTime = new Date('2026-01-01T00:00:00.000Z');
+    fs.utimesSync(filePath, snapshotTime, snapshotTime);
+    syncState.migrations = { codexScopedMessageIds: true };
+    const parsedMtime = fs.statSync(filePath).mtime.toISOString();
+    const session = makeParsedSession({
+      id: 'codex:after-parse',
+      sourceTool: 'codex-cli',
+      messageCount: 3,
+      messages: [
+        makeParsedMessage({ id: 'codex:after-parse:user:0', sessionId: 'codex:after-parse' }),
+        makeParsedMessage({ id: 'codex:after-parse:assistant:1', sessionId: 'codex:after-parse', type: 'assistant' }),
+        makeParsedMessage({ id: 'codex:after-parse:user:2', sessionId: 'codex:after-parse' }),
+      ],
+    });
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => session,
+    }]);
+    insertSessionWithProjectAndReturnIsNew.mockImplementation(() => {
+      fs.appendFileSync(filePath, '-new-tail-after-parse');
+      const laterTime = new Date('2026-01-01T00:00:01.000Z');
+      fs.utimesSync(filePath, laterTime, laterTime);
+      return true;
+    });
+
+    await runSync({ quiet: true });
+
+    expect(fs.statSync(filePath).mtime.toISOString()).not.toBe(parsedMtime);
+    expect(syncState.files[filePath].lastModified).toBe(parsedMtime);
+  });
+
+  it('does not mark the Codex ID migration complete when a transcript fails to parse', async () => {
+    const filePath = path.join(tempDir, 'broken-rollout.jsonl');
+    fs.writeFileSync(filePath, '{}');
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => { throw new Error('broken transcript'); },
+    }]);
+
+    const result = await runSync({ quiet: true });
+
+    expect(result.errorCount).toBe(1);
+    expect(syncState.migrations?.codexScopedMessageIds).not.toBe(true);
+  });
+
+  it('returns a failing process status when a sync completes with file errors', async () => {
+    const filePath = path.join(tempDir, 'broken-for-cli.jsonl');
+    fs.writeFileSync(filePath, '{broken}');
+    getAllProviders.mockReturnValue([{
+      getProviderName: () => 'codex-cli',
+      discover: async () => [filePath],
+      parse: async () => { throw new Error('broken transcript'); },
+    }]);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await syncCommand({ quiet: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(trackEvent).toHaveBeenCalledWith(
+        'cli_sync',
+        expect.objectContaining({ errors: 1, success: false }),
+      );
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 });

--- a/cli/src/commands/sync.ts
+++ b/cli/src/commands/sync.ts
@@ -6,9 +6,10 @@ import { loadSyncState, saveSyncState } from '../utils/config.js';
 import { autoDetectOllama } from '../utils/ollama-detect.js';
 import { trackEvent, identifyUser, captureError, classifyError } from '../utils/telemetry.js';
 import { insertSessionWithProjectAndReturnIsNew, insertMessages, recalculateUsageStats } from '../db/write.js';
-import { getDb, getMigrationResult } from '../db/client.js';
+import { advanceDbSyncIdentity, getDb, getDbIdentity, getDbPath, getMigrationResult } from '../db/client.js';
 import { getAllProviders, getProvider } from '../providers/registry.js';
 import { setProviderVerbose } from '../providers/context.js';
+import { invalidateAnalysisUsage } from '../analysis/analysis-usage-db.js';
 import type { SessionProvider } from '../providers/types.js';
 import type { SyncState } from '../types.js';
 import { splitVirtualPath } from '../utils/paths.js';
@@ -30,6 +31,19 @@ export interface SyncResult {
   updatedExistingCount: number;
   sessionsByProvider: Record<string, number>;
 }
+
+interface FileSnapshot {
+  lastModified: string;
+  mtimeMs: number;
+  size: number;
+}
+
+interface StableParseResult {
+  session: Awaited<ReturnType<SessionProvider['parse']>>;
+  snapshot: FileSnapshot;
+}
+
+const CODEX_PARSE_ATTEMPTS = 2;
 
 /**
  * Core sync logic — reusable from stats commands and other callers.
@@ -54,24 +68,33 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
 
   log(chalk.cyan('\n  Code Insights Sync\n'));
 
-  // Initialize database (runs migrations if needed)
-  const spinner = createSpinner('Initializing database...').start();
-  try {
-    getDb();
-    spinner.succeed('Database ready');
-  } catch (error) {
-    spinner.fail('Failed to initialize database');
-    throw new Error(`Database error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
+  const spinner = createSpinner('Initializing database...');
+  let databaseIdentity: string | undefined;
+  let v6JustApplied = false;
 
-  // Auto-detect Ollama if no LLM is configured (silent if not running)
-  if (!options.quiet) {
-    await autoDetectOllama();
-  }
+  // A dry run is a read-only filesystem plan. In particular, do not open
+  // SQLite: getDb() would create the file and run migrations as a side effect.
+  if (!options.dryRun) {
+    spinner.start();
+    try {
+      getDb();
+      databaseIdentity = getDbIdentity();
+      spinner.succeed('Database ready');
+    } catch (error) {
+      spinner.fail('Failed to initialize database');
+      throw new Error(`Database error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
 
-  // Check if V6 migration was just applied — triggers auto force-sync for interactive sessions
-  const migrationResult = getMigrationResult();
-  const v6JustApplied = migrationResult?.v6Applied === true;
+    // Auto-detect Ollama if no LLM is configured (silent if not running).
+    // This may persist config, so it is intentionally excluded from dry runs.
+    if (!options.quiet) {
+      await autoDetectOllama();
+    }
+
+    // Check if V6 migration was just applied — triggers auto force-sync for interactive sessions
+    const migrationResult = getMigrationResult();
+    v6JustApplied = migrationResult?.v6Applied === true;
+  }
 
   if (v6JustApplied && options.quiet) {
     // Hook-triggered sync: defer re-parse to avoid adding 30-60s to a sub-second operation
@@ -109,7 +132,26 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
   // Load sync state
   // When --force is used with --source, only clear the targeted provider's entries
   // instead of nuking the entire sync state.
-  const syncState = loadSyncState();
+  const loadedSyncState = loadSyncState();
+  const previousSyncState = structuredClone(loadedSyncState);
+  // Force/identity reconciliation intentionally mutates state in memory. A dry
+  // run operates on a clone so its "no changes" contract includes checkpoints
+  // and one-time migration flags.
+  const syncState = options.dryRun
+    ? structuredClone(loadedSyncState)
+    : loadedSyncState;
+  const databaseChanged = options.dryRun
+    ? !fs.existsSync(getDbPath()) || !syncState.databaseIdentity
+    : syncState.databaseIdentity !== databaseIdentity;
+  if (databaseChanged) {
+    // File mtimes and one-time migrations describe one exact SQLite database.
+    // Conservatively re-sync once when upgrading legacy state or when the DB
+    // path/file changes, so an empty/restored database cannot inherit skips.
+    syncState.lastSync = '';
+    syncState.files = {};
+    syncState.migrations = {};
+    syncState.databaseIdentity = databaseIdentity;
+  }
   if (options.force) {
     if (options.source) {
       // Targeted force: remove only entries belonging to the specified provider's files
@@ -139,6 +181,12 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
   const sessionsByProvider: Record<string, number> = {};
   for (const provider of providers) {
     const providerName = provider.getProviderName();
+    const isCodexProvider = providerName === 'codex-cli';
+    const needsCodexIdMigration = isCodexProvider &&
+      syncState.migrations?.codexScopedMessageIds !== true;
+    // A project-filtered discovery is not authoritative for all Codex files.
+    // Leave the one-time global migration for the next unfiltered sync.
+    const runCodexIdMigration = needsCodexIdMigration && !options.project;
     try {
       if (providers.length > 1) {
         log(chalk.cyan(`\n  Syncing ${providerName}...`));
@@ -151,8 +199,13 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
 
       if (sessionFiles.length === 0) continue;
 
-      // Filter to only new/modified files
-      const filesToSync = filterFilesToSync(sessionFiles, syncState, options.force);
+      // The scoped Codex message-ID migration must reparse unchanged historical
+      // transcripts once so legacy global IDs cannot coexist with the new IDs.
+      const filesToSync = filterFilesToSync(
+        sessionFiles,
+        syncState,
+        !!options.force || runCodexIdMigration,
+      );
 
       if (filesToSync.length === 0) {
         log(chalk.gray(`  ✔ Up to date (${sessionFiles.length} sessions)`));
@@ -170,6 +223,7 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
       let providerSyncedCount = 0;
       let providerUpdatedCount = 0;
       let providerMessageCount = 0;
+      let providerErrorCount = 0;
 
       for (const filePath of filesToSync) {
         const fileName = path.basename(filePath);
@@ -177,28 +231,42 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
 
         try {
           // Parse session
-          const session = await provider.parse(filePath);
+          const parsed = isCodexProvider
+            ? await parseStableFile(provider, filePath)
+            : { session: await provider.parse(filePath), snapshot: undefined };
+          const { session } = parsed;
           if (!session) {
             // Track null-parse files so they aren't re-discovered on every sync run
-            updateSyncState(syncState, filePath, '__empty__');
+            updateSyncState(syncState, filePath, '__empty__', parsed.snapshot);
             saveSyncState(syncState);
             continue;
           }
 
           // Skip trivial sessions (≤2 messages) — likely abandoned prompts with no content
           if (session.messageCount <= 2) {
-            updateSyncState(syncState, filePath, session.id);
+            updateSyncState(syncState, filePath, session.id, parsed.snapshot);
             saveSyncState(syncState);
             continue;
           }
 
           // Write session and messages to SQLite
           const isNew = insertSessionWithProjectAndReturnIsNew(session, !!options.force);
-          insertMessages(session, !!options.force);
+          // Codex providers parse complete transcript snapshots. Always replace
+          // their message set so index-based IDs cannot leave stale rows after
+          // an insertion or after upgrading from the legacy global ID scheme.
+          insertMessages(session, !!options.force || isCodexProvider);
+          const codexTranscriptChanged = isCodexProvider && parsed.snapshot !== undefined &&
+            fileSnapshotChangedSinceSync(previousSyncState, filePath, parsed.snapshot);
+          if (!isNew && (runCodexIdMigration || codexTranscriptChanged)) {
+            // Legacy message-ID repair and later transcript edits can both
+            // change analysis inputs without changing message_count. Preserve
+            // visible insights, but force both analysis passes to recompute.
+            invalidateAnalysisUsage(session.id);
+          }
 
           // Update and persist sync state after each file
           // so progress survives crashes
-          updateSyncState(syncState, filePath, session.id);
+          updateSyncState(syncState, filePath, session.id, parsed.snapshot);
           saveSyncState(syncState);
 
           if (!isNew && !options.force) {
@@ -212,11 +280,21 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
           totalMessageCount += session.messages.length;
         } catch (error) {
           totalErrorCount++;
+          providerErrorCount++;
           spinner.fail(`Failed to sync ${fileName}`);
           if (!options.quiet) {
             console.error(chalk.red(`  ${error instanceof Error ? error.message : 'Unknown error'}`));
           }
         }
+      }
+
+      if (runCodexIdMigration && providerErrorCount === 0) {
+        syncState.migrations = {
+          ...syncState.migrations,
+          codexScopedMessageIds: true,
+        };
+        saveSyncState(syncState);
+        log(chalk.gray('  ✔ Migrated Codex messages to session-scoped IDs'));
       }
 
       sessionsByProvider[providerName] = providerSyncedCount;
@@ -242,7 +320,7 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
   }
 
   // Resurrect soft-deleted sessions on --force so users get a clean slate
-  if (options.force) {
+  if (options.force && !options.dryRun) {
     const db = getDb();
     db.prepare('UPDATE sessions SET deleted_at = NULL WHERE deleted_at IS NOT NULL').run();
   }
@@ -252,7 +330,7 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
     ? (totalSyncedCount > 0 || totalErrorCount > 0)
     : totalUpdatedExisting > 0;
 
-  if (shouldRecalculateUsageStats) {
+  if (!options.dryRun && shouldRecalculateUsageStats) {
     spinner.start('Recalculating usage stats...');
     try {
       recalculateUsageStats();
@@ -278,8 +356,11 @@ export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
   }
 
   // Save sync state
-  syncState.lastSync = new Date().toISOString();
-  saveSyncState(syncState);
+  if (!options.dryRun) {
+    syncState.databaseIdentity = advanceDbSyncIdentity();
+    syncState.lastSync = new Date().toISOString();
+    saveSyncState(syncState);
+  }
 
   return {
     syncedCount: totalSyncedCount,
@@ -301,20 +382,25 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     const result = await runSync(options);
     const duration_ms = Date.now() - startTime;
 
-    // Identify user now that DB is open (updates total_sessions person property)
-    void identifyUser();
+    // Identify user only after a writable sync has opened the DB. A dry run
+    // must remain safe even when the database does not exist yet.
+    if (!options.dryRun) {
+      void identifyUser();
+    }
 
     // Summary (only if not quiet)
     if (result.syncedCount === 0 && result.errorCount === 0) {
       log(chalk.green('\n  Already up to date!'));
-      trackEvent('cli_sync', {
-        duration_ms,
-        sessions_synced: 0,
-        sessions_by_provider: result.sessionsByProvider,
-        errors: 0,
-        source_filter: options.source ?? null,
-        success: true,
-      });
+      if (!options.dryRun) {
+        trackEvent('cli_sync', {
+          duration_ms,
+          sessions_synced: 0,
+          sessions_by_provider: result.sessionsByProvider,
+          errors: 0,
+          source_filter: options.source ?? null,
+          success: true,
+        });
+      }
       return;
     }
     log(chalk.cyan('\n  Sync Summary'));
@@ -327,29 +413,41 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     if (result.errorCount > 0) {
       log(chalk.red(`  Errors: ${result.errorCount}`));
     }
-    log(chalk.green('\n  Sync complete!'));
-    trackEvent('cli_sync', {
-      duration_ms,
-      sessions_synced: result.syncedCount,
-      sessions_by_provider: result.sessionsByProvider,
-      errors: result.errorCount,
-      source_filter: options.source ?? null,
-      success: true,
-    });
+    const succeeded = result.errorCount === 0;
+    log(succeeded
+      ? chalk.green('\n  Sync complete!')
+      : chalk.yellow('\n  Sync completed with errors.'));
+    if (!options.dryRun) {
+      trackEvent('cli_sync', {
+        duration_ms,
+        sessions_synced: result.syncedCount,
+        sessions_by_provider: result.sessionsByProvider,
+        errors: result.errorCount,
+        source_filter: options.source ?? null,
+        success: succeeded,
+      });
+    }
+    if (!succeeded) {
+      // Successfully imported files stay checkpointed, but callers must be
+      // able to detect that at least one transcript was not synchronized.
+      process.exitCode = 1;
+    }
   } catch (error) {
     const duration_ms = Date.now() - startTime;
     const { error_type, error_message } = classifyError(error);
-    trackEvent('cli_sync', {
-      duration_ms,
-      sessions_synced: 0,
-      sessions_by_provider: {},
-      errors: 1,
-      source_filter: options.source ?? null,
-      success: false,
-      error_type,
-      error_message,
-    });
-    captureError(error, { command: 'sync', error_type, source_filter: options.source ?? null });
+    if (!options.dryRun) {
+      trackEvent('cli_sync', {
+        duration_ms,
+        sessions_synced: 0,
+        sessions_by_provider: {},
+        errors: 1,
+        source_filter: options.source ?? null,
+        success: false,
+        error_type,
+        error_message,
+      });
+      captureError(error, { command: 'sync', error_type, source_filter: options.source ?? null });
+    }
     if (!options.quiet) {
       console.error(chalk.red(error instanceof Error ? error.message : 'Sync failed'));
     }
@@ -406,7 +504,8 @@ function filterFilesToSync(files: string[], syncState: SyncState, force?: boolea
     if (sessionFragment) {
       // Virtual path (multi-session DB).
       // If the DB file changed, re-sync all sessions from it.
-      if (fileState.lastModified !== lastModified) return true;
+      if (fileState.lastModified !== lastModified ||
+          (fileState.fileSize !== undefined && fileState.fileSize !== stat.size)) return true;
 
       // Otherwise only sync sessions we haven't seen yet.
       if (fileState.syncedSessionIds) {
@@ -418,16 +517,72 @@ function filterFilesToSync(files: string[], syncState: SyncState, force?: boolea
     }
 
     // For regular files, check if modified since last sync
-    return fileState.lastModified !== lastModified;
+    return fileState.lastModified !== lastModified ||
+      (fileState.fileSize !== undefined && fileState.fileSize !== stat.size);
   });
+}
+
+function getFileSnapshot(filePath: string): FileSnapshot {
+  const { realPath } = splitVirtualPath(filePath);
+  const stat = fs.statSync(realPath);
+  return {
+    lastModified: stat.mtime.toISOString(),
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  };
+}
+
+function snapshotsMatch(left: FileSnapshot, right: FileSnapshot): boolean {
+  return left.mtimeMs === right.mtimeMs && left.size === right.size;
+}
+
+function fileSnapshotChangedSinceSync(
+  state: SyncState,
+  filePath: string,
+  snapshot: FileSnapshot,
+): boolean {
+  const { realPath } = splitVirtualPath(filePath);
+  const previous = state.files[realPath];
+  if (!previous) return false;
+
+  return previous.lastModified !== snapshot.lastModified ||
+    (previous.fileSize !== undefined && previous.fileSize !== snapshot.size);
+}
+
+/**
+ * Parse an append-only Codex rollout from one stable filesystem snapshot.
+ * A growing active transcript is retried once. If it changes again, callers
+ * leave both SQLite and sync-state untouched so the next sync can try again.
+ */
+async function parseStableFile(
+  provider: SessionProvider,
+  filePath: string,
+): Promise<StableParseResult> {
+  for (let attempt = 1; attempt <= CODEX_PARSE_ATTEMPTS; attempt++) {
+    const before = getFileSnapshot(filePath);
+    const session = await provider.parse(filePath);
+    const after = getFileSnapshot(filePath);
+
+    if (snapshotsMatch(before, after)) {
+      return { session, snapshot: after };
+    }
+  }
+
+  throw new Error(`Codex transcript changed while parsing: ${filePath}`);
 }
 
 /**
  * Update sync state for a file
  */
-function updateSyncState(state: SyncState, filePath: string, sessionId: string): void {
+function updateSyncState(
+  state: SyncState,
+  filePath: string,
+  sessionId: string,
+  parsedSnapshot?: FileSnapshot,
+): void {
   const { realPath, sessionFragment } = splitVirtualPath(filePath);
-  const stat = fs.statSync(realPath);
+  const currentSnapshot = parsedSnapshot ?? getFileSnapshot(filePath);
+  const { lastModified, size: fileSize } = currentSnapshot;
 
   if (sessionFragment) {
     // Virtual path: track the session fragment in syncedSessionIds
@@ -437,7 +592,8 @@ function updateSyncState(state: SyncState, filePath: string, sessionId: string):
       syncedIds.push(sessionFragment);
     }
     state.files[realPath] = {
-      lastModified: stat.mtime.toISOString(),
+      lastModified,
+      fileSize,
       lastSyncedLine: 0,
       sessionId,
       syncedSessionIds: syncedIds,
@@ -445,7 +601,8 @@ function updateSyncState(state: SyncState, filePath: string, sessionId: string):
   } else {
     // Regular file path
     state.files[realPath] = {
-      lastModified: stat.mtime.toISOString(),
+      lastModified,
+      fileSize,
       lastSyncedLine: 0,
       sessionId,
     };

--- a/cli/src/db/__tests__/migrate.test.ts
+++ b/cli/src/db/__tests__/migrate.test.ts
@@ -34,8 +34,44 @@ describe('runMigrations — idempotency', () => {
       .all() as Array<{ version: number }>;
 
     // One row per version, no duplicates
-    expect(rows.map(r => r.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(rows.map(r => r.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     db.close();
+  });
+});
+
+describe('runMigrations — persistent database identity', () => {
+  it('creates one stable unique identity per SQLite database', () => {
+    const firstDb = freshDb();
+    const secondDb = freshDb();
+
+    runMigrations(firstDb);
+    const firstIdentity = firstDb
+      .prepare("SELECT value FROM code_insights_metadata WHERE key = 'database_id'")
+      .pluck()
+      .get() as string;
+    runMigrations(firstDb);
+    const identityAfterSecondMigration = firstDb
+      .prepare("SELECT value FROM code_insights_metadata WHERE key = 'database_id'")
+      .pluck()
+      .get() as string;
+
+    runMigrations(secondDb);
+    const secondIdentity = secondDb
+      .prepare("SELECT value FROM code_insights_metadata WHERE key = 'database_id'")
+      .pluck()
+      .get() as string;
+    const firstSyncGeneration = firstDb
+      .prepare("SELECT value FROM code_insights_metadata WHERE key = 'sync_generation'")
+      .pluck()
+      .get() as string;
+
+    expect(firstIdentity).toMatch(/^[0-9a-f]{32}$/);
+    expect(firstSyncGeneration).toMatch(/^[0-9a-f]{32}$/);
+    expect(identityAfterSecondMigration).toBe(firstIdentity);
+    expect(secondIdentity).not.toBe(firstIdentity);
+
+    firstDb.close();
+    secondDb.close();
   });
 });
 

--- a/cli/src/db/client-identity.test.ts
+++ b/cli/src/db/client-identity.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const originalDbPath = process.env.CODE_INSIGHTS_DB;
+const tempDirs: string[] = [];
+
+async function loadClient(dbPath: string) {
+  process.env.CODE_INSIGHTS_DB = dbPath;
+  vi.resetModules();
+  return import('./client.js');
+}
+
+afterEach(() => {
+  if (originalDbPath === undefined) {
+    delete process.env.CODE_INSIGHTS_DB;
+  } else {
+    process.env.CODE_INSIGHTS_DB = originalDbPath;
+  }
+  vi.resetModules();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('getDbIdentity', () => {
+  it('combines the absolute path with a stable identity stored inside SQLite', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-db-id-'));
+    tempDirs.push(tempDir);
+    const relativeDbPath = path.relative(process.cwd(), path.join(tempDir, 'data.db'));
+
+    const firstClient = await loadClient(relativeDbPath);
+    firstClient.getDb();
+    const firstIdentity = firstClient.getDbIdentity();
+    firstClient.closeDb();
+
+    const reopenedClient = await loadClient(relativeDbPath);
+    reopenedClient.getDb();
+    const reopenedIdentity = reopenedClient.getDbIdentity();
+    reopenedClient.closeDb();
+
+    expect(firstIdentity).toBe(reopenedIdentity);
+    expect(firstIdentity.startsWith(`${path.resolve(relativeDbPath)}#`)).toBe(true);
+  });
+
+  it('changes when a different SQLite database replaces the file at the same path', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-db-replace-'));
+    tempDirs.push(tempDir);
+    const dbPath = path.join(tempDir, 'data.db');
+
+    const firstClient = await loadClient(dbPath);
+    firstClient.getDb();
+    const firstIdentity = firstClient.getDbIdentity();
+    firstClient.closeDb();
+
+    fs.rmSync(dbPath);
+
+    const replacementClient = await loadClient(dbPath);
+    replacementClient.getDb();
+    const replacementIdentity = replacementClient.getDbIdentity();
+    replacementClient.closeDb();
+
+    expect(replacementIdentity).not.toBe(firstIdentity);
+    expect(replacementIdentity.split('#')[0]).toBe(firstIdentity.split('#')[0]);
+  });
+
+  it('detects restoration of an older backup from the same database lineage', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-insights-db-restore-'));
+    tempDirs.push(tempDir);
+    const dbPath = path.join(tempDir, 'data.db');
+    const backupPath = path.join(tempDir, 'backup.db');
+
+    const firstClient = await loadClient(dbPath);
+    firstClient.getDb();
+    firstClient.advanceDbSyncIdentity();
+    const backedUpIdentity = firstClient.getDbIdentity();
+    firstClient.closeDb();
+    fs.copyFileSync(dbPath, backupPath);
+
+    const laterClient = await loadClient(dbPath);
+    laterClient.getDb();
+    const currentIdentity = laterClient.advanceDbSyncIdentity();
+    laterClient.closeDb();
+    expect(currentIdentity).not.toBe(backedUpIdentity);
+
+    fs.copyFileSync(backupPath, dbPath);
+
+    const restoredClient = await loadClient(dbPath);
+    restoredClient.getDb();
+    const restoredIdentity = restoredClient.getDbIdentity();
+    restoredClient.closeDb();
+
+    expect(restoredIdentity).toBe(backedUpIdentity);
+    expect(restoredIdentity).not.toBe(currentIdentity);
+  });
+});

--- a/cli/src/db/client.ts
+++ b/cli/src/db/client.ts
@@ -1,11 +1,13 @@
 import Database from 'better-sqlite3';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { mkdirSync, existsSync } from 'fs';
 import { runMigrations, type MigrationResult } from './migrate.js';
 
-const DB_DIR = join(homedir(), '.code-insights');
-const DB_PATH = join(DB_DIR, 'data.db');
+const CONFIG_DIR = process.env.CODE_INSIGHTS_CONFIG_DIR
+  || join(homedir(), '.code-insights');
+const DB_PATH = process.env.CODE_INSIGHTS_DB || join(CONFIG_DIR, 'data.db');
+const DB_DIR = dirname(DB_PATH);
 
 let _db: Database.Database | null = null;
 let _migrationResult: MigrationResult | null = null;
@@ -71,4 +73,47 @@ export function closeDb(): void {
  */
 export function getDbPath(): string {
   return DB_PATH;
+}
+
+/**
+ * Stable identity for the exact SQLite database backing this process.
+ *
+ * The absolute path distinguishes intentional alternate databases, while the
+ * ID stored inside SQLite distinguishes replacement/restored files at the same
+ * path. Backups retain their original identity by design.
+ */
+export function getDbIdentity(): string {
+  const rows = getDb().prepare(`
+    SELECT key, value
+    FROM code_insights_metadata
+    WHERE key IN ('database_id', 'sync_generation')
+  `).all() as Array<{ key: string; value: string }>;
+  const metadata = new Map(rows.map(row => [row.key, row.value]));
+  const databaseId = metadata.get('database_id');
+  const syncGeneration = metadata.get('sync_generation');
+
+  if (!databaseId || !syncGeneration) {
+    throw new Error('SQLite database identity is missing');
+  }
+
+  return `${resolve(DB_PATH)}#${databaseId}#${syncGeneration}`;
+}
+
+/**
+ * Advance the generation only after a full sync reaches its checkpoint.
+ * Restoring an older copy of the same database then produces an identity
+ * mismatch even though the persistent database_id is preserved by backups.
+ */
+export function advanceDbSyncIdentity(): string {
+  const result = getDb().prepare(`
+    UPDATE code_insights_metadata
+    SET value = lower(hex(randomblob(16)))
+    WHERE key = 'sync_generation'
+  `).run();
+
+  if (result.changes !== 1) {
+    throw new Error('Could not advance SQLite sync identity');
+  }
+
+  return getDbIdentity();
 }

--- a/cli/src/db/migrate.ts
+++ b/cli/src/db/migrate.ts
@@ -6,6 +6,7 @@ export interface MigrationResult {
   v7Applied: boolean;
   v8Applied: boolean;
   v9Applied: boolean;
+  v10Applied: boolean;
 }
 
 /**
@@ -21,6 +22,7 @@ export interface MigrationResult {
  * Version 7: Add analysis_usage table for tracking LLM analysis costs per session
  * Version 8: Add session_message_count to analysis_usage for resume detection
  * Version 9: Add analysis_queue table for async hook-triggered analysis
+ * Version 10: Add persistent per-database identity metadata
  */
 export function runMigrations(db: Database.Database): MigrationResult {
   // Create schema_version table first if it doesn't exist.
@@ -78,7 +80,13 @@ export function runMigrations(db: Database.Database): MigrationResult {
     v9Applied = true;
   }
 
-  return { v6Applied, v7Applied, v8Applied, v9Applied };
+  let v10Applied = false;
+  if (currentVersion < 10) {
+    applyV10(db);
+    v10Applied = true;
+  }
+
+  return { v6Applied, v7Applied, v8Applied, v9Applied, v10Applied };
 }
 
 function getCurrentVersion(db: Database.Database): number {
@@ -202,4 +210,22 @@ function applyV9(db: Database.Database): void {
     `CREATE INDEX IF NOT EXISTS idx_analysis_queue_enqueued_at ON analysis_queue(enqueued_at ASC)`
   );
   db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(9);
+}
+
+function applyV10(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS code_insights_metadata (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `);
+  db.prepare(`
+    INSERT OR IGNORE INTO code_insights_metadata (key, value)
+    VALUES ('database_id', lower(hex(randomblob(16))))
+  `).run();
+  db.prepare(`
+    INSERT OR IGNORE INTO code_insights_metadata (key, value)
+    VALUES ('sync_generation', lower(hex(randomblob(16))))
+  `).run();
+  db.prepare('INSERT OR IGNORE INTO schema_version (version) VALUES (?)').run(10);
 }

--- a/cli/src/db/queue.test.ts
+++ b/cli/src/db/queue.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { createTestDb } from '../__fixtures__/db/seed.js';
+
+let testDb: Database.Database;
+
+vi.mock('./client.js', () => ({
+  getDb: () => testDb,
+}));
+
+const { claimNext, enqueue, markCompleted, markFailed } = await import('./queue.js');
+
+describe('analysis queue claiming', () => {
+  beforeEach(() => {
+    testDb = createTestDb();
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it('claims the most recently enqueued pending session first', () => {
+    testDb.prepare(
+      `INSERT INTO projects (id, name, path, last_activity)
+       VALUES ('project-1', 'project', '/project', '2026-07-14 10:00:00')`,
+    ).run();
+    const insertSession = testDb.prepare(
+      `INSERT INTO sessions
+         (id, project_id, project_name, project_path, started_at, ended_at)
+       VALUES
+         (?, 'project-1', 'project', '/project', ?, ?)`,
+    );
+    insertSession.run('older-session', '2026-07-14 09:00:00', '2026-07-14 09:30:00');
+    insertSession.run('newer-session', '2026-07-14 10:00:00', '2026-07-14 10:30:00');
+
+    testDb.prepare(
+      `INSERT INTO analysis_queue (session_id, enqueued_at)
+       VALUES (?, ?)`,
+    ).run('older-session', '2026-07-14 09:00:00');
+    testDb.prepare(
+      `INSERT INTO analysis_queue (session_id, enqueued_at)
+       VALUES (?, ?)`,
+    ).run('newer-session', '2026-07-14 10:00:00');
+
+    const claimed = claimNext();
+
+    expect(claimed?.session_id).toBe('newer-session');
+  });
+
+  it('uses insertion order as the newest-first tie-break within the same second', () => {
+    testDb.prepare(
+      `INSERT INTO projects (id, name, path, last_activity)
+       VALUES ('project-1', 'project', '/project', '2026-07-14 10:00:00')`,
+    ).run();
+    const insertSession = testDb.prepare(
+      `INSERT INTO sessions
+         (id, project_id, project_name, project_path, started_at, ended_at)
+       VALUES
+         (?, 'project-1', 'project', '/project', ?, ?)`,
+    );
+    insertSession.run('first-session', '2026-07-14 10:00:00', '2026-07-14 10:10:00');
+    insertSession.run('second-session', '2026-07-14 10:00:00', '2026-07-14 10:10:00');
+
+    const enqueueAt = '2026-07-14 10:30:00';
+    testDb.prepare(
+      `INSERT INTO analysis_queue (session_id, enqueued_at)
+       VALUES (?, ?)`,
+    ).run('first-session', enqueueAt);
+    testDb.prepare(
+      `INSERT INTO analysis_queue (session_id, enqueued_at)
+       VALUES (?, ?)`,
+    ).run('second-session', enqueueAt);
+
+    const claimed = claimNext();
+
+    expect(claimed?.session_id).toBe('second-session');
+  });
+
+  it('does not let an old worker complete a newer enqueue of the same session', () => {
+    testDb.exec(`
+      INSERT INTO projects (id, name, path, last_activity)
+      VALUES ('project-race', 'project', '/project', '2026-07-14 10:00:00');
+      INSERT INTO sessions
+        (id, project_id, project_name, project_path, started_at, ended_at)
+      VALUES
+        ('session-race', 'project-race', 'project', '/project', '2026-07-14 10:00:00', '2026-07-14 10:30:00');
+    `);
+    enqueue('session-race');
+    expect(claimNext()?.status).toBe('processing');
+
+    enqueue('session-race');
+    markCompleted('session-race');
+
+    const row = testDb.prepare(
+      'SELECT status, attempt_count, error_message FROM analysis_queue WHERE session_id = ?',
+    ).get('session-race') as { status: string; attempt_count: number; error_message: string | null };
+    expect(row).toEqual({ status: 'pending', attempt_count: 0, error_message: null });
+  });
+
+  it('does not let an old worker fail a newer enqueue of the same session', () => {
+    testDb.exec(`
+      INSERT INTO projects (id, name, path, last_activity)
+      VALUES ('project-fail-race', 'project', '/project', '2026-07-14 10:00:00');
+      INSERT INTO sessions
+        (id, project_id, project_name, project_path, started_at, ended_at)
+      VALUES
+        ('session-fail-race', 'project-fail-race', 'project', '/project', '2026-07-14 10:00:00', '2026-07-14 10:30:00');
+    `);
+    enqueue('session-fail-race');
+    expect(claimNext()?.status).toBe('processing');
+
+    enqueue('session-fail-race');
+    markFailed('session-fail-race', 'stale worker error');
+
+    const row = testDb.prepare(
+      'SELECT status, attempt_count, error_message FROM analysis_queue WHERE session_id = ?',
+    ).get('session-fail-race') as { status: string; attempt_count: number; error_message: string | null };
+    expect(row).toEqual({ status: 'pending', attempt_count: 0, error_message: null });
+  });
+});

--- a/cli/src/db/queue.ts
+++ b/cli/src/db/queue.ts
@@ -67,7 +67,7 @@ export function claimNext(): QueueItem | null {
      WHERE session_id = (
        SELECT session_id FROM analysis_queue
        WHERE status = 'pending'
-       ORDER BY enqueued_at ASC
+       ORDER BY enqueued_at DESC, rowid DESC
        LIMIT 1
      )
      RETURNING *`
@@ -82,7 +82,7 @@ export function markCompleted(sessionId: string): void {
   db.prepare(
     `UPDATE analysis_queue
      SET status = 'completed', completed_at = datetime('now'), error_message = NULL
-     WHERE session_id = ?`
+     WHERE session_id = ? AND status = 'processing'`
   ).run(sessionId);
 }
 
@@ -103,7 +103,7 @@ export function markFailed(sessionId: string, errorMessage: string): void {
            ELSE 'pending'
          END,
          started_at = NULL
-     WHERE session_id = ?`
+     WHERE session_id = ? AND status = 'processing'`
   ).run(errorMessage, sessionId);
 }
 

--- a/cli/src/db/read-write.test.ts
+++ b/cli/src/db/read-write.test.ts
@@ -349,6 +349,46 @@ describe('Database read/write operations', () => {
       expect(rows.cnt).toBe(1);
     });
 
+    it('replaces the complete message set during a force sync', () => {
+      const original = makeParsedSession({
+        id: 'sess-force',
+        messages: [
+          makeParsedMessage({ id: 'old-1', sessionId: 'sess-force' }),
+          makeParsedMessage({ id: 'old-2', sessionId: 'sess-force' }),
+        ],
+      });
+      const reparsed = makeParsedSession({
+        id: 'sess-force',
+        messages: [makeParsedMessage({ id: 'new-1', sessionId: 'sess-force' })],
+      });
+
+      insertSessionWithProject(original);
+      insertMessages(original);
+      insertMessages(reparsed, true);
+
+      const rows = testDb
+        .prepare('SELECT id FROM messages WHERE session_id = ? ORDER BY id')
+        .all('sess-force') as Array<{ id: string }>;
+      expect(rows).toEqual([{ id: 'new-1' }]);
+    });
+
+    it('clears stale messages when a force-sync snapshot is empty', () => {
+      const original = makeParsedSession({
+        id: 'sess-force-empty',
+        messages: [makeParsedMessage({ id: 'old-message', sessionId: 'sess-force-empty' })],
+      });
+      const empty = makeParsedSession({ id: 'sess-force-empty', messages: [] });
+
+      insertSessionWithProject(original);
+      insertMessages(original);
+      insertMessages(empty, true);
+
+      const row = testDb
+        .prepare('SELECT COUNT(*) AS count FROM messages WHERE session_id = ?')
+        .get('sess-force-empty') as { count: number };
+      expect(row.count).toBe(0);
+    });
+
     it('stores tool_calls as JSON when present', () => {
       const msg = makeParsedMessage({
         id: 'msg-tools',

--- a/cli/src/db/schema.test.ts
+++ b/cli/src/db/schema.test.ts
@@ -298,12 +298,12 @@ describe('runMigrations', () => {
     db.close();
   });
 
-  it('V9 schema version is 9 after migration', () => {
+  it('V10 schema version is 10 after migration', () => {
     const db = new Database(':memory:');
     runMigrations(db);
 
     const row = db.prepare('SELECT MAX(version) AS v FROM schema_version').get() as { v: number };
-    expect(row.v).toBe(9);
+    expect(row.v).toBe(10);
 
     db.close();
   });

--- a/cli/src/db/schema.ts
+++ b/cli/src/db/schema.ts
@@ -128,6 +128,6 @@ CREATE TABLE IF NOT EXISTS usage_stats (
 );
 `;
 
-export const CURRENT_SCHEMA_VERSION = 9;
+export const CURRENT_SCHEMA_VERSION = 10;
 
 export { runMigrations } from './migrate.js';

--- a/cli/src/db/write.ts
+++ b/cli/src/db/write.ts
@@ -303,16 +303,19 @@ function upsertSession(
 
 /**
  * Insert messages for a session.
- * isForce: when true (--force sync), uses INSERT OR REPLACE so existing message
- * content is overwritten with the freshly-parsed result (e.g. after a parsing fix).
+ * isForce: when true (--force sync), replaces the session's complete message set
+ * with the freshly parsed snapshot, including clearing stale rows for an empty set.
  */
 export function insertMessages(session: ParsedSession, isForce = false): void {
-  if (session.messages.length === 0) return;
+  if (session.messages.length === 0 && !isForce) return;
 
   const db = getDb();
   const stmts = getStmts();
 
   const tx = db.transaction((messages: ParsedMessage[]) => {
+    if (isForce) {
+      db.prepare('DELETE FROM messages WHERE session_id = ?').run(session.id);
+    }
     const stmt = isForce ? stmts.replaceMessage : stmts.insertMessage;
     for (const msg of messages) {
       stmt.run(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,6 +16,7 @@ import { reflectCommand } from './commands/reflect.js';
 import { insightsCommand, insightsCheckCommand } from './commands/insights.js';
 import { sessionEndCommand } from './commands/session-end.js';
 import { buildQueueCommand } from './commands/queue.js';
+import { runCommandWithLlmLock } from './commands/lock-run.js';
 import { doctorCommand } from './commands/doctor/index.js';
 import { showTelemetryNoticeIfNeeded } from './utils/telemetry.js';
 
@@ -146,6 +147,20 @@ program
 // queue command suite — manage the analysis_queue
 program.addCommand(buildQueueCommand());
 
+// Internal wrapper used by automation scripts to serialize arbitrary LLM work.
+program
+  .command('lock-run <command...>', { hidden: true })
+  .description('Run a command while holding the shared Code Insights LLM lock')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .action(async (command: string[]) => {
+    const exitCode = await runCommandWithLlmLock(command);
+    if (exitCode === 75) {
+      console.error('[Code Insights] Another LLM analysis process is already running.');
+    }
+    process.exitCode = exitCode;
+  });
+
 // insights command — analyze a session using native claude -p or configured LLM
 const insightsCmd = program
   .command('insights [session_id]')
@@ -180,11 +195,19 @@ program.action(async () => {
   await dashboardCommand({ port: '7890', open: true, sync: true });
 });
 
-// Show one-time telemetry disclosure before any command runs
-// Skip for --version/-V and --help/-h since those commands don't need it
+// Show one-time telemetry disclosure before any command runs.
+// A dry run must not create the config directory just to persist this marker.
 const isVersionOrHelp = process.argv.some(arg => ['--version', '-V', '--help', '-h'].includes(arg));
-if (!isVersionOrHelp) {
+const cliArgs = process.argv.slice(2);
+const isSyncDryRun = cliArgs[0] === 'sync' && cliArgs.includes('--dry-run');
+if (!isVersionOrHelp && !isSyncDryRun) {
   showTelemetryNoticeIfNeeded();
 }
 
-program.parse();
+try {
+  await program.parseAsync();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`[Code Insights] ${message}`);
+  process.exitCode = 1;
+}

--- a/cli/src/providers/codex.test.ts
+++ b/cli/src/providers/codex.test.ts
@@ -77,6 +77,79 @@ describe('CodexProvider — Format A system context filtering', () => {
     expect(session!.assistantMessageCount).toBe(1);
   });
 
+  it('rejects when a discovered rollout file cannot be read', async () => {
+    const provider = new CodexProvider();
+    const missingPath = path.join(tempDir, 'rollout-missing.jsonl');
+
+    await expect(provider.parse(missingPath)).rejects.toThrow(/rollout-missing\.jsonl/);
+  });
+
+  it('rejects malformed legacy JSON instead of reporting an empty session', async () => {
+    const filePath = path.join(tempDir, 'rollout-broken.json');
+    fs.writeFileSync(filePath, '{"session":');
+
+    const provider = new CodexProvider();
+
+    await expect(provider.parse(filePath)).rejects.toThrow(/invalid Codex JSON/i);
+  });
+
+  it('rejects a malformed complete JSONL line instead of silently dropping it', async () => {
+    const filePath = path.join(tempDir, 'rollout-corrupt.jsonl');
+    fs.writeFileSync(filePath, buildJSONL([
+      sessionMeta(),
+      userMessageLine('First complete prompt'),
+      '{not valid json}',
+      assistantLine('This complete line proves the malformed line was not a trailing write.'),
+    ]));
+
+    const provider = new CodexProvider();
+
+    await expect(provider.parse(filePath)).rejects.toThrow(/line 3/i);
+  });
+
+  it('tolerates only an unfinished final JSONL line from an active rollout', async () => {
+    const filePath = path.join(tempDir, 'rollout-active.jsonl');
+    fs.writeFileSync(filePath, buildJSONL([
+      sessionMeta(),
+      userMessageLine('Keep the complete snapshot'),
+      assistantLine('Complete response'),
+      '{"type":"response_item","payload":',
+    ]));
+
+    const provider = new CodexProvider();
+    const session = await provider.parse(filePath);
+
+    expect(session).not.toBeNull();
+    expect(session!.userMessageCount).toBe(1);
+    expect(session!.assistantMessageCount).toBe(1);
+  });
+
+  it('rejects a complete but malformed final JSONL line', async () => {
+    const filePath = path.join(tempDir, 'rollout-corrupt-tail.jsonl');
+    fs.writeFileSync(filePath, buildJSONL([
+      sessionMeta(),
+      userMessageLine('Complete prompt before corrupt tail'),
+      '{not valid json}',
+    ]));
+
+    const provider = new CodexProvider();
+
+    await expect(provider.parse(filePath)).rejects.toThrow(/line 3/i);
+  });
+
+  it('rejects a closed final JSON object with a trailing comma', async () => {
+    const filePath = path.join(tempDir, 'rollout-corrupt-trailing-comma.jsonl');
+    fs.writeFileSync(filePath, buildJSONL([
+      sessionMeta(),
+      userMessageLine('Complete prompt before malformed tail'),
+      '{"a":1,}',
+    ]));
+
+    const provider = new CodexProvider();
+
+    await expect(provider.parse(filePath)).rejects.toThrow(/line 3/i);
+  });
+
   it('keeps message IDs unique across different Codex sessions', async () => {
     const firstPath = path.join(tempDir, 'rollout-first.jsonl');
     const secondPath = path.join(tempDir, 'rollout-second.jsonl');

--- a/cli/src/providers/codex.test.ts
+++ b/cli/src/providers/codex.test.ts
@@ -77,6 +77,33 @@ describe('CodexProvider — Format A system context filtering', () => {
     expect(session!.assistantMessageCount).toBe(1);
   });
 
+  it('keeps message IDs unique across different Codex sessions', async () => {
+    const firstPath = path.join(tempDir, 'rollout-first.jsonl');
+    const secondPath = path.join(tempDir, 'rollout-second.jsonl');
+    fs.writeFileSync(firstPath, buildJSONL([
+      sessionMeta('session-one'),
+      userMessageLine('First question'),
+      assistantLine('First answer'),
+      taskCompleteLine(),
+    ]));
+    fs.writeFileSync(secondPath, buildJSONL([
+      sessionMeta('session-two'),
+      userMessageLine('Second question'),
+      assistantLine('Second answer'),
+      taskCompleteLine(),
+    ]));
+
+    const provider = new CodexProvider();
+    const first = await provider.parse(firstPath);
+    const second = await provider.parse(secondPath);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    const firstIds = new Set(first!.messages.map(message => message.id));
+    const secondIds = second!.messages.map(message => message.id);
+    expect(secondIds.every(id => !firstIds.has(id))).toBe(true);
+  });
+
   it('filters out <permissions> system context messages', async () => {
     const content = buildJSONL([
       sessionMeta(),

--- a/cli/src/providers/codex.ts
+++ b/cli/src/providers/codex.ts
@@ -173,20 +173,16 @@ interface FormatBItem {
 // ---------------------------------------------------------------------------
 
 function parseCodexSession(filePath: string): ParsedSession | null {
-  try {
-    const content = fs.readFileSync(filePath, 'utf-8').trim();
-    if (!content) return null;
+  const content = fs.readFileSync(filePath, 'utf-8').trim();
+  if (!content) return null;
 
-    // Detect format by file extension — content-sniffing is unreliable because
-    // JSONL files also start with '{' on line 1 (the session_meta object).
-    if (filePath.endsWith('.json')) {
-      return parseFormatB(content);
-    }
-
-    return parseFormatA(content);
-  } catch {
-    return null;
+  // Detect format by file extension — content-sniffing is unreliable because
+  // JSONL files also start with '{' on line 1 (the session_meta object).
+  if (filePath.endsWith('.json')) {
+    return parseFormatB(content);
   }
+
+  return parseFormatA(content);
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +195,9 @@ function parseFormatA(content: string): ParsedSession | null {
 
   // Parse first line — session metadata
   const meta = parseSessionMeta(lines[0]);
-  if (!meta) return null;
+  if (!meta?.id || !meta.timestamp) {
+    throw new Error('Invalid Codex JSONL session metadata on line 1');
+  }
 
   const sessionId = `codex:${meta.id}`;
 
@@ -255,8 +253,12 @@ function parseFormatA(content: string): ParsedSession | null {
     let event: CodexRolloutLine;
     try {
       event = JSON.parse(line) as CodexRolloutLine;
-    } catch {
-      continue;
+    } catch (error) {
+      // Codex appends to active JSONL transcripts. A truncated final line is
+      // expected while the process is writing and will be picked up after the
+      // file mtime changes. Corruption in any completed line must not be hidden.
+      if (i === lines.length - 1 && isLikelyTruncatedJson(line, error)) continue;
+      throw new Error(`Invalid Codex JSONL event on line ${i + 1}`);
     }
 
     // Unwrap RolloutLine envelope if present
@@ -458,6 +460,23 @@ function parseFormatA(content: string): ParsedSession | null {
   return buildSession(sessionId, meta.cwd || 'codex://unknown', meta.cli_version || null, meta.timestamp, messages, usageEntries, model);
 }
 
+function isLikelyTruncatedJson(line: string, error: unknown): boolean {
+  if (!(error instanceof SyntaxError)) return false;
+
+  const trimmed = line.trimEnd();
+  // A closed JSON object/array is not an in-progress append. Syntax errors at
+  // its final character (for example {"a":1,}) are complete corruption.
+  if (trimmed.endsWith('}') || trimmed.endsWith(']')) return false;
+
+  const message = error.message;
+  if (/unexpected end|unterminated string/i.test(message)) return true;
+
+  const position = /position (\d+)/i.exec(message);
+  if (position && Number(position[1]) >= line.length) return true;
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Format B parser (pre-2025 single JSON object: { session, items })
 // ---------------------------------------------------------------------------
@@ -467,10 +486,12 @@ function parseFormatB(content: string): ParsedSession | null {
   try {
     parsed = JSON.parse(content) as FormatBSession;
   } catch {
-    return null;
+    throw new Error('Invalid Codex JSON document');
   }
 
-  if (!parsed.session?.id || !Array.isArray(parsed.items)) return null;
+  if (!parsed.session?.id || !Array.isArray(parsed.items)) {
+    throw new Error('Invalid Codex JSON document structure');
+  }
 
   const meta = parsed.session;
   const sessionId = `codex:${meta.id}`;

--- a/cli/src/providers/codex.ts
+++ b/cli/src/providers/codex.ts
@@ -230,7 +230,7 @@ function parseFormatA(content: string): ParsedSession | null {
     } : null;
 
     messages.push({
-      id: `codex-assistant-${messages.length}`,
+      id: `${sessionId}:assistant:${messages.length}`,
       sessionId: sessionId,
       type: 'assistant',
       content: text.slice(0, 10000),
@@ -298,7 +298,7 @@ function parseFormatA(content: string): ParsedSession | null {
         const msgText = (payload.message as string) || '';
         if (msgText && !isSystemContextMessage(msgText)) {
           messages.push({
-            id: (payload.id as string) || `codex-user-${messages.length}`,
+            id: `${sessionId}:user:${(payload.id as string) || messages.length}`,
             sessionId: sessionId,
             type: 'user',
             content: msgText.slice(0, 10000),
@@ -493,7 +493,7 @@ function parseFormatB(content: string): ParsedSession | null {
     if (currentToolCalls.length === 0 && !currentThinking) return;
 
     messages.push({
-      id: `codex-assistant-${messages.length}`,
+      id: `${sessionId}:assistant:${messages.length}`,
       sessionId: sessionId,
       type: 'assistant',
       content: '',
@@ -519,7 +519,7 @@ function parseFormatB(content: string): ParsedSession | null {
       const userContent = extractFormatBContent(item.content);
       if (userContent && !isSystemContextMessage(userContent)) {
         messages.push({
-          id: `codex-user-${messages.length}`,
+          id: `${sessionId}:user:${messages.length}`,
           sessionId: sessionId,
           type: 'user',
           content: userContent.slice(0, 10000),

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -370,10 +370,18 @@ export type ExportTemplate = 'knowledge-base' | 'agent-rules';
 export interface SyncState {
   lastSync: string;
   files: Record<string, FileSyncState>;
+  /** Absolute DB path plus the persistent identity stored inside SQLite. */
+  databaseIdentity?: string;
+  migrations?: {
+    /** All Codex transcripts were re-synced after message IDs became session-scoped. */
+    codexScopedMessageIds?: boolean;
+  };
 }
 
 export interface FileSyncState {
   lastModified: string;
+  /** Byte size of the parsed snapshot; catches same-timestamp appends. */
+  fileSize?: number;
   lastSyncedLine: number;
   sessionId: string;
   syncedSessionIds?: string[];  // For providers where 1 file = N sessions (e.g., Cursor SQLite)
@@ -439,4 +447,3 @@ export interface DispatchImagePromptResponse {
   model: string;
   tokensUsed: { input: number; output: number };
 }
-

--- a/cli/src/utils/config-paths.test.ts
+++ b/cli/src/utils/config-paths.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'path';
+
+describe('Code Insights data path overrides', () => {
+  const originalConfigDir = process.env.CODE_INSIGHTS_CONFIG_DIR;
+  const originalDb = process.env.CODE_INSIGHTS_DB;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+    delete process.env.CODE_INSIGHTS_DB;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.CODE_INSIGHTS_CONFIG_DIR;
+    else process.env.CODE_INSIGHTS_CONFIG_DIR = originalConfigDir;
+    if (originalDb === undefined) delete process.env.CODE_INSIGHTS_DB;
+    else process.env.CODE_INSIGHTS_DB = originalDb;
+  });
+
+  it('uses CODE_INSIGHTS_CONFIG_DIR for config, sync state, and the default database', async () => {
+    process.env.CODE_INSIGHTS_CONFIG_DIR = '/tmp/code-insights-custom';
+
+    const config = await import('./config.js');
+    const db = await import('../db/client.js');
+
+    expect(config.getConfigDir()).toBe('/tmp/code-insights-custom');
+    expect(config.getSyncStatePath()).toBe('/tmp/code-insights-custom/sync-state.json');
+    expect(db.getDbPath()).toBe('/tmp/code-insights-custom/data.db');
+  });
+
+  it('prefers CODE_INSIGHTS_DB over the configured directory', async () => {
+    process.env.CODE_INSIGHTS_CONFIG_DIR = '/tmp/code-insights-custom';
+    process.env.CODE_INSIGHTS_DB = join('/tmp', 'code-insights-explicit', 'state.sqlite');
+
+    const db = await import('../db/client.js');
+
+    expect(db.getDbPath()).toBe('/tmp/code-insights-explicit/state.sqlite');
+  });
+});

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as os from 'os';
 import type { ClaudeInsightConfig, SyncState } from '../types.js';
 
-const CONFIG_DIR = path.join(os.homedir(), '.code-insights');
+const CONFIG_DIR = process.env.CODE_INSIGHTS_CONFIG_DIR
+  || path.join(os.homedir(), '.code-insights');
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 const SYNC_STATE_FILE = path.join(CONFIG_DIR, 'sync-state.json');
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "pnpm --filter @code-insights/cli build && pnpm --filter @code-insights/server build && pnpm --filter @code-insights/dashboard build",
     "dev": "pnpm --filter @code-insights/cli dev",
-    "test": "pnpm -r test",
+    "test": "pnpm run test:automation && pnpm -r test",
+    "test:automation": "bash automation/tests/maintenance.test.sh && bash automation/tests/throttled-lock.test.sh && bash automation/tests/install-launchd.test.sh",
     "test:watch": "vitest",
     "test:coverage": "pnpm --filter @code-insights/cli test:coverage && pnpm --filter @code-insights/server test:coverage"
   },

--- a/server/src/llm/analysis.test.ts
+++ b/server/src/llm/analysis.test.ts
@@ -506,6 +506,34 @@ describe('extractFacetsOnly', () => {
     expect(facetRow!.iteration_count).toBe(3);
   });
 
+  it('filters invalid friction categories before facet-only persistence', async () => {
+    mockChat.mockResolvedValue({
+      content: JSON.stringify({
+        ...validFacetResponse,
+        friction_points: [
+          'reasoning-only primitive',
+          { _reasoning: 'No friction occurred.' },
+          { category: null, description: 'N/A' },
+          { category: 42, description: 'N/A' },
+          { category: { nested: true }, description: 'N/A' },
+          { category: ['wrong-approach'], description: 'N/A' },
+          { category: '   ', description: 'N/A' },
+          { category: 'wrong-approach', description: 'Valid friction', severity: 'medium', resolution: 'resolved' },
+        ],
+      }),
+      usage: null,
+    });
+
+    const result = await extractFacetsOnly(makeSession(), [makeMessage()]);
+
+    expect(result.success).toBe(true);
+    const facetRow = testDb.prepare('SELECT friction_points FROM session_facets WHERE session_id = ?')
+      .get('sess-test') as { friction_points: string } | undefined;
+    expect(JSON.parse(facetRow!.friction_points)).toEqual([
+      expect.objectContaining({ category: 'wrong-approach', description: 'Valid friction' }),
+    ]);
+  });
+
   it('pattern normalization — task-decomposition saved as structured-planning', async () => {
     const response = {
       ...validFacetResponse,

--- a/server/src/llm/client.ts
+++ b/server/src/llm/client.ts
@@ -50,7 +50,7 @@ export function createClientFromConfig(config: LLMProviderConfig): LLMClient {
     case 'openai':
       return createOpenAIClient(config.apiKey ?? '', config.model);
     case 'anthropic':
-      return createAnthropicClient(config.apiKey ?? '', config.model);
+      return createAnthropicClient(config.apiKey ?? '', config.model, config.baseUrl);
     case 'gemini':
       return createGeminiClient(config.apiKey ?? '', config.model);
     case 'ollama':

--- a/server/src/llm/llm-lock-token.test.ts
+++ b/server/src/llm/llm-lock-token.test.ts
@@ -1,0 +1,57 @@
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  acquireGlobal: vi.fn(),
+  isTokenOwner: vi.fn(),
+}));
+
+vi.mock('@code-insights/cli/analysis/llm-lock', () => ({
+  LLM_LOCK_TOKEN_HEADER: 'x-code-insights-lock-token',
+  acquireLlmLock: (...args: unknown[]) => mocks.acquireGlobal(...args),
+  isLlmLockTokenOwner: (...args: unknown[]) => mocks.isTokenOwner(...args),
+}));
+
+const { acquireServerLlmLock } = await import('./llm-lock.js');
+
+function requestContext(token?: string): Context {
+  return {
+    req: {
+      header: (name: string) => name.toLowerCase() === 'x-code-insights-lock-token' ? token : undefined,
+    },
+  } as unknown as Context;
+}
+
+describe('server LLM lock capability', () => {
+  beforeEach(() => {
+    mocks.acquireGlobal.mockReset();
+    mocks.acquireGlobal.mockReturnValue(null);
+    mocks.isTokenOwner.mockReset();
+    mocks.isTokenOwner.mockImplementation((token: string) => token === 'valid-owner-token');
+  });
+
+  it('allows the owning request token while preserving the in-process gate', () => {
+    const context = requestContext('valid-owner-token');
+
+    const first = acquireServerLlmLock(context);
+    expect(first).not.toBeNull();
+    expect(mocks.isTokenOwner).toHaveBeenCalledWith('valid-owner-token');
+    expect(mocks.acquireGlobal).not.toHaveBeenCalled();
+
+    try {
+      expect(acquireServerLlmLock(context)).toBeNull();
+    } finally {
+      first?.release();
+    }
+
+    const afterRelease = acquireServerLlmLock(context);
+    expect(afterRelease).not.toBeNull();
+    afterRelease?.release();
+  });
+
+  it('does not bypass a busy global lock without the owning token', () => {
+    expect(acquireServerLlmLock(requestContext())).toBeNull();
+    expect(acquireServerLlmLock(requestContext('wrong-token'))).toBeNull();
+    expect(mocks.acquireGlobal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/llm/llm-lock.test.ts
+++ b/server/src/llm/llm-lock.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { acquireServerLlmLock } from './llm-lock.js';
+import { acquireLlmLock } from '@code-insights/cli/analysis/llm-lock';
+
+let lockTestDir: string | undefined;
+
+afterEach(() => {
+  delete process.env.CODE_INSIGHTS_LOCK_HELD;
+  delete process.env.CODE_INSIGHTS_LOCK_TOKEN;
+  delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+  if (lockTestDir) rmSync(lockTestDir, { recursive: true, force: true });
+  lockTestDir = undefined;
+});
+
+describe('server LLM lock', () => {
+  it('serializes requests inside a server that inherited its parent lock', () => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-inherited-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
+    const parentLock = acquireLlmLock();
+    expect(parentLock).not.toBeNull();
+    process.env.CODE_INSIGHTS_LOCK_HELD = '1';
+    process.env.CODE_INSIGHTS_LOCK_TOKEN = parentLock?.token;
+
+    const first = acquireServerLlmLock();
+    expect(first).not.toBeNull();
+
+    try {
+      expect(acquireServerLlmLock()).toBeNull();
+    } finally {
+      first?.release();
+    }
+
+    const afterRelease = acquireServerLlmLock();
+    expect(afterRelease).not.toBeNull();
+    afterRelease?.release();
+    parentLock?.release();
+  });
+
+  it('releases the underlying cross-process lock', () => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
+
+    const first = acquireServerLlmLock();
+    expect(first).not.toBeNull();
+    expect(acquireServerLlmLock()).toBeNull();
+    first?.release();
+
+    const afterRelease = acquireServerLlmLock();
+    expect(afterRelease).not.toBeNull();
+    afterRelease?.release();
+  });
+});

--- a/server/src/llm/llm-lock.ts
+++ b/server/src/llm/llm-lock.ts
@@ -1,0 +1,61 @@
+import {
+  acquireLlmLock,
+  isLlmLockTokenOwner,
+  LLM_LOCK_TOKEN_HEADER,
+  type LlmLockHandle,
+} from '@code-insights/cli/analysis/llm-lock';
+import type { Context } from 'hono';
+
+export const LLM_BUSY_CODE = 'LLM_BUSY' as const;
+export const LLM_BUSY_MESSAGE = 'Another Code Insights LLM operation is already running. Try again when it finishes.';
+
+export interface LlmBusyPayload {
+  error: string;
+  code: typeof LLM_BUSY_CODE;
+}
+
+export type LockedResult<T> =
+  | { acquired: true; value: T }
+  | { acquired: false };
+
+let activeInProcess = false;
+
+export function llmBusyPayload(): LlmBusyPayload {
+  return { error: LLM_BUSY_MESSAGE, code: LLM_BUSY_CODE };
+}
+
+export function acquireServerLlmLock(c?: Context): LlmLockHandle | null {
+  if (activeInProcess) return null;
+
+  const requestToken = c?.req.header(LLM_LOCK_TOKEN_HEADER);
+  const ownsGlobalLock = !!requestToken && isLlmLockTokenOwner(requestToken);
+  const globalLock = ownsGlobalLock
+    ? { release: () => {} }
+    : acquireLlmLock();
+  if (!globalLock) return null;
+
+  activeInProcess = true;
+  let released = false;
+  return {
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        globalLock.release();
+      } finally {
+        activeInProcess = false;
+      }
+    },
+  };
+}
+
+export async function runWithLlmLock<T>(c: Context, operation: () => Promise<T>): Promise<LockedResult<T>> {
+  const lock = acquireServerLlmLock(c);
+  if (!lock) return { acquired: false };
+
+  try {
+    return { acquired: true, value: await operation() };
+  } finally {
+    lock.release();
+  }
+}

--- a/server/src/llm/providers/anthropic.ts
+++ b/server/src/llm/providers/anthropic.ts
@@ -4,7 +4,10 @@
 
 import type { LLMClient, LLMMessage, LLMResponse, ChatOptions } from '../types.js';
 
-export function createAnthropicClient(apiKey: string, model: string): LLMClient {
+export function createAnthropicClient(apiKey: string, model: string, baseUrl?: string): LLMClient {
+  // baseUrl allows Anthropic-compatible endpoints (e.g. Zhipu BigModel's /api/anthropic).
+  // Defaults to the official Anthropic API when unset.
+  const base = (baseUrl || 'https://api.anthropic.com').trim().replace(/\/$/, '');
   return {
     provider: 'anthropic',
     model,
@@ -14,7 +17,7 @@ export function createAnthropicClient(apiKey: string, model: string): LLMClient 
       const systemMessage = messages.find(m => m.role === 'system');
       const chatMessages = messages.filter(m => m.role !== 'system');
 
-      const response = await fetch('https://api.anthropic.com/v1/messages', {
+      const response = await fetch(`${base}/v1/messages`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/server/src/routes/analysis.test.ts
+++ b/server/src/routes/analysis.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 
@@ -7,6 +10,13 @@ import { runMigrations } from '@code-insights/cli/db/schema';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -71,6 +81,8 @@ function seedInsight(sessionId: string, projectId: string, type: string, title: 
 
 describe('Analysis routes', () => {
   beforeEach(() => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(false);
     mockAnalyzeSession.mockReset();
@@ -83,6 +95,8 @@ describe('Analysis routes', () => {
 
   afterEach(() => {
     testDb.close();
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    rmSync(lockTestDir, { recursive: true, force: true });
   });
 
   describe('POST /api/analysis/session', () => {
@@ -181,6 +195,24 @@ describe('Analysis routes', () => {
       expect(body.success).toBe(false);
       expect(mockCaptureError).not.toHaveBeenCalled();
     });
+
+    it('returns a recognizable busy response without calling the LLM', async () => {
+      seedProject('proj-1', 'myproject');
+      seedSession('sess-1', 'proj-1');
+      mockIsLLMConfigured.mockReturnValue(true);
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/analysis/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: 'sess-1' }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ code: 'LLM_BUSY' });
+      expect(mockAnalyzeSession).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/analysis/session/stream', () => {
@@ -200,6 +232,22 @@ describe('Analysis routes', () => {
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body.error).toMatch(/sessionId/);
+    });
+
+    it('sends a recognizable busy SSE error without calling the LLM', async () => {
+      seedProject('proj-1', 'myproject');
+      seedSession('sess-1', 'proj-1');
+      mockIsLLMConfigured.mockReturnValue(true);
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/analysis/session/stream?sessionId=sess-1');
+      const body = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(body).toContain('event: error');
+      expect(body).toContain('LLM_BUSY');
+      expect(mockAnalyzeSession).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -7,6 +7,7 @@ import { loadLLMConfig } from '../llm/client.js';
 import { analyzeSession, analyzePromptQuality, findRecurringInsights } from '../llm/analysis.js';
 import { getSessionAnalysisUsage } from '../llm/analysis-usage-db.js';
 import { calculateAnalysisCost } from '../llm/analysis-pricing.js';
+import { llmBusyPayload, runWithLlmLock } from '../llm/llm-lock.js';
 import {
   loadSessionForAnalysis,
   loadSessionMessages,
@@ -81,7 +82,9 @@ app.post('/session', requireLLM(), async (c) => {
   const messages = loadSessionMessages(db, body.sessionId);
 
   const startTime = Date.now();
-  const result = await analyzeSession(session, messages);
+  const locked = await runWithLlmLock(c, () => analyzeSession(session, messages));
+  if (!locked.acquired) return c.json(llmBusyPayload(), 409);
+  const result = locked.value;
   trackAnalysisResult('session', result, startTime, {
     onSuccess: () => {
       trackEvent('insight_generated', { type: 'session', count: result.insights.length });
@@ -145,7 +148,9 @@ app.post('/prompt-quality', requireLLM(), async (c) => {
   const messages = loadSessionMessages(db, body.sessionId);
 
   const startTime = Date.now();
-  const result = await analyzePromptQuality(session, messages);
+  const locked = await runWithLlmLock(c, () => analyzePromptQuality(session, messages));
+  if (!locked.acquired) return c.json(llmBusyPayload(), 409);
+  const result = locked.value;
   trackAnalysisResult('prompt-quality', result, startTime, {
     onSuccess: () => {
       trackEvent('insight_generated', { type: 'prompt_quality', count: result.insights.length });
@@ -219,7 +224,9 @@ app.post('/recurring', requireLLM(), async (c) => {
   }>;
 
   const startTime = Date.now();
-  const result = await findRecurringInsights(insights);
+  const locked = await runWithLlmLock(c, () => findRecurringInsights(insights));
+  if (!locked.acquired) return c.json(llmBusyPayload(), 409);
+  const result = locked.value;
   // recurring errors don't carry error_type/response_preview — pass them as undefined;
   // trackAnalysisResult handles undefined gracefully (omits from event properties).
   trackAnalysisResult('recurring', {

--- a/server/src/routes/config.test.ts
+++ b/server/src/routes/config.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 import { saveConfig } from '@code-insights/cli/utils/config';
@@ -8,6 +11,13 @@ import { saveConfig } from '@code-insights/cli/utils/config';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -23,10 +33,12 @@ vi.mock('@code-insights/cli/utils/config', () => ({
   saveConfig: vi.fn(),
 }));
 
+const mockTestLLMConfig = vi.fn().mockResolvedValue({ success: true });
+
 vi.mock('../llm/client.js', () => ({
   loadLLMConfig: () => null,
   isLLMConfigured: () => false,
-  testLLMConfig: vi.fn().mockResolvedValue({ success: true }),
+  testLLMConfig: (...args: unknown[]) => mockTestLLMConfig(...args),
 }));
 
 vi.mock('../llm/providers/ollama.js', () => ({
@@ -51,11 +63,16 @@ function initTestDb(): Database.Database {
 
 describe('Config routes', () => {
   beforeEach(() => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
     testDb = initTestDb();
+    mockTestLLMConfig.mockClear();
   });
 
   afterEach(() => {
     testDb.close();
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    rmSync(lockTestDir, { recursive: true, force: true });
   });
 
   describe('GET /api/config/llm', () => {
@@ -193,6 +210,21 @@ describe('Config routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.success).toBe(true);
+    });
+
+    it('returns a recognizable busy response without testing the provider', async () => {
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/config/llm/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'ollama', model: 'llama3' }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ code: 'LLM_BUSY' });
+      expect(mockTestLLMConfig).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { loadConfig, saveConfig } from '@code-insights/cli/utils/config';
 import type { ClaudeInsightConfig, LLMProviderConfig } from '@code-insights/cli/types';
 import { loadLLMConfig, testLLMConfig } from '../llm/client.js';
+import { llmBusyPayload, runWithLlmLock } from '../llm/llm-lock.js';
 import { discoverOllamaModels } from '../llm/providers/ollama.js';
 import { discoverLlamaCppModels } from '../llm/providers/llamacpp.js';
 
@@ -123,7 +124,9 @@ app.post('/llm/test', async (c) => {
     }, 400);
   }
 
-  const result = await testLLMConfig(testConfig);
+  const locked = await runWithLlmLock(c, () => testLLMConfig(testConfig));
+  if (!locked.acquired) return c.json(llmBusyPayload(), 409);
+  const result = locked.value;
   return c.json(result, result.success ? 200 : 422);
 });
 

--- a/server/src/routes/dispatch.test.ts
+++ b/server/src/routes/dispatch.test.ts
@@ -1,5 +1,8 @@
 import Database from 'better-sqlite3';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 
 // ──────────────────────────────────────────────────────
@@ -7,6 +10,23 @@ import { runMigrations } from '@code-insights/cli/db/schema';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function setupLlmLockTest(): void {
+  lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+  process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
+}
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
+
+function cleanupLlmLockTest(): void {
+  delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+  rmSync(lockTestDir, { recursive: true, force: true });
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -135,9 +155,15 @@ const BASE_BODY = {
 
 describe('POST /api/dispatch/generate', () => {
   beforeEach(() => {
+    setupLlmLockTest();
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(true);
     mockCreateLLMClient.mockReset();
+  });
+
+  afterEach(() => {
+    testDb.close();
+    cleanupLlmLockTest();
   });
 
   it('returns 400 when LLM is not configured', async () => {
@@ -287,6 +313,26 @@ describe('POST /api/dispatch/generate', () => {
     // Verify system prompt is included in messages
     const callArgs = mockClient.chat.mock.calls[0][0] as Array<{ role: string }>;
     expect(callArgs[0].role).toBe('system');
+  });
+
+  it('returns a recognizable busy response without calling the LLM', async () => {
+    seedPrerequisites();
+    seedInsight('ins-1', 'learning', 'Summary one', 'Content one');
+    seedInsight('ins-2', 'decision', 'Summary two', 'Content two');
+    seedInsight('ins-3', 'technique', 'Summary three', 'Content three');
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient(VALID_MARKDOWN));
+    occupyLlmLock();
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(BASE_BODY),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: 'LLM_BUSY' });
+    expect(mockCreateLLMClient).not.toHaveBeenCalled();
   });
 
   it('handles null bullets without crashing', async () => {
@@ -640,9 +686,15 @@ const IMAGE_PROMPT_BODY = {
 
 describe('POST /api/dispatch/image-prompt', () => {
   beforeEach(() => {
+    setupLlmLockTest();
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(true);
     mockCreateLLMClient.mockReset();
+  });
+
+  afterEach(() => {
+    testDb.close();
+    cleanupLlmLockTest();
   });
 
   it('returns 400 when LLM is not configured', async () => {
@@ -714,6 +766,22 @@ describe('POST /api/dispatch/image-prompt', () => {
     expect(json.model).toBe('gpt-4o');
     expect(json.tokensUsed.input).toBe(500);
     expect(json.tokensUsed.output).toBe(800);
+  });
+
+  it('returns a recognizable busy response without calling the LLM', async () => {
+    mockCreateLLMClient.mockReturnValue(makeMockLLMClient('A prompt.'));
+    occupyLlmLock();
+
+    const app = createApp();
+    const res = await app.request('/api/dispatch/image-prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(IMAGE_PROMPT_BODY),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: 'LLM_BUSY' });
+    expect(mockCreateLLMClient).not.toHaveBeenCalled();
   });
 
   it('passes responseFormat text to prevent JSON mode', async () => {

--- a/server/src/routes/dispatch.ts
+++ b/server/src/routes/dispatch.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { getDb } from '@code-insights/cli/db/client';
 import { createLLMClient } from '../llm/client.js';
+import { acquireServerLlmLock, llmBusyPayload } from '../llm/llm-lock.js';
 import { requireLLM } from './route-helpers.js';
 import {
   buildDispatchSystemPrompt,
@@ -161,48 +162,54 @@ app.post('/generate', requireLLM(), async (c) => {
 
   const systemPrompt = buildDispatchSystemPrompt(tone, format);
   const userMessage = buildDispatchContext({ userContext: contextText, insights: orderedInsights, sessionBackgrounds });
+  const lock = acquireServerLlmLock(c);
+  if (!lock) return c.json(llmBusyPayload(), 409);
 
-  const client = createLLMClient();
-  const messages = [
-    { role: 'system' as const, content: systemPrompt },
-    { role: 'user' as const, content: userMessage },
-  ];
+  try {
+    const client = createLLMClient();
+    const messages = [
+      { role: 'system' as const, content: systemPrompt },
+      { role: 'user' as const, content: userMessage },
+    ];
 
-  const chatOptions = { temperature: TEMPERATURES[format], responseFormat: 'text' as const };
-  let response = await client.chat(messages, chatOptions);
+    const chatOptions = { temperature: TEMPERATURES[format], responseFormat: 'text' as const };
+    let response = await client.chat(messages, chatOptions);
 
-  let parsed = parseDispatchOutput(response.content, format);
+    let parsed = parseDispatchOutput(response.content, format);
 
-  // Single retry on parse failure
-  if (!parsed.ok) {
-    response = await client.chat(messages, chatOptions);
-    parsed = parseDispatchOutput(response.content, format);
-
+    // Single retry on parse failure
     if (!parsed.ok) {
-      // Degrade gracefully — return the raw content with extracted title
-      parsed = buildDegradedResponse(response.content);
+      response = await client.chat(messages, chatOptions);
+      parsed = parseDispatchOutput(response.content, format);
+
+      if (!parsed.ok) {
+        // Degrade gracefully — return the raw content with extracted title
+        parsed = buildDegradedResponse(response.content);
+      }
     }
+
+    const markdown = parsed.markdown ?? response.content;
+    const bodyText = parsed.body ?? markdown;
+    const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
+    const characterCount = bodyText.length;
+
+    return c.json({
+      markdown,
+      body: bodyText,
+      format,
+      frontmatter: parsed.frontmatter ?? { title: 'Untitled', tags: [], tldr: '' },
+      wordCount,
+      characterCount,
+      degraded: parsed.degraded ?? false,
+      model: client.model,
+      tokensUsed: {
+        input: response.usage?.inputTokens ?? 0,
+        output: response.usage?.outputTokens ?? 0,
+      },
+    });
+  } finally {
+    lock.release();
   }
-
-  const markdown = parsed.markdown ?? response.content;
-  const bodyText = parsed.body ?? markdown;
-  const wordCount = bodyText.trim().split(/\s+/).filter(Boolean).length;
-  const characterCount = bodyText.length;
-
-  return c.json({
-    markdown,
-    body: bodyText,
-    format,
-    frontmatter: parsed.frontmatter ?? { title: 'Untitled', tags: [], tldr: '' },
-    wordCount,
-    characterCount,
-    degraded: parsed.degraded ?? false,
-    model: client.model,
-    tokensUsed: {
-      input: response.usage?.inputTokens ?? 0,
-      output: response.usage?.outputTokens ?? 0,
-    },
-  });
 });
 
 // POST /api/dispatch/image-prompt
@@ -234,28 +241,34 @@ app.post('/image-prompt', requireLLM(), async (c) => {
     tags,
     format: body.format as string,
   });
+  const lock = acquireServerLlmLock(c);
+  if (!lock) return c.json(llmBusyPayload(), 409);
 
-  const client = createLLMClient();
-  const messages = [
-    { role: 'system' as const, content: systemPrompt },
-    { role: 'user' as const, content: userMessage },
-  ];
+  try {
+    const client = createLLMClient();
+    const messages = [
+      { role: 'system' as const, content: systemPrompt },
+      { role: 'user' as const, content: userMessage },
+    ];
 
-  const response = await client.chat(messages, { temperature: 0.85, responseFormat: 'text' as const });
-  const parsed = parseImagePromptOutput(response.content);
+    const response = await client.chat(messages, { temperature: 0.85, responseFormat: 'text' as const });
+    const parsed = parseImagePromptOutput(response.content);
 
-  if (!parsed.ok) {
-    return c.json({ error: 'Failed to generate image prompt', detail: parsed.error }, 500);
+    if (!parsed.ok) {
+      return c.json({ error: 'Failed to generate image prompt', detail: parsed.error }, 500);
+    }
+
+    return c.json({
+      prompt: parsed.prompt,
+      model: client.model,
+      tokensUsed: {
+        input: response.usage?.inputTokens ?? 0,
+        output: response.usage?.outputTokens ?? 0,
+      },
+    });
+  } finally {
+    lock.release();
   }
-
-  return c.json({
-    prompt: parsed.prompt,
-    model: client.model,
-    tokensUsed: {
-      input: response.usage?.inputTokens ?? 0,
-      output: response.usage?.outputTokens ?? 0,
-    },
-  });
 });
 
 export default app;

--- a/server/src/routes/export.test.ts
+++ b/server/src/routes/export.test.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'crypto';
 import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 
@@ -8,6 +11,13 @@ import { runMigrations } from '@code-insights/cli/db/schema';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -94,6 +104,8 @@ function parseSSEEvents(text: string): Array<{ event: string; data: string }> {
 
 describe('Export routes', () => {
   beforeEach(() => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(false);
     mockChat.mockReset();
@@ -103,6 +115,8 @@ describe('Export routes', () => {
 
   afterEach(() => {
     testDb.close();
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    rmSync(lockTestDir, { recursive: true, force: true });
   });
 
   describe('POST /api/export/markdown', () => {
@@ -426,6 +440,23 @@ describe('Export routes', () => {
       const body = await res.json();
       expect(body.content).toBe('');
     });
+
+    it('returns a recognizable busy response without calling the LLM', async () => {
+      mockIsLLMConfigured.mockReturnValue(true);
+      mockChat.mockResolvedValue({ content: '# should not run' });
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/export/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: 'all', format: 'knowledge-brief' }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toMatchObject({ code: 'LLM_BUSY' });
+      expect(mockChat).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/export/generate/stream', () => {
@@ -509,6 +540,22 @@ describe('Export routes', () => {
       expect(completeData.content).toBe('# Streamed Export');
       expect(completeData.metadata).toBeDefined();
       expect(completeData.metadata.scope).toBe('all');
+    });
+
+    it('emits a recognizable busy SSE error without calling the LLM', async () => {
+      seedProjectAndSession('proj-1', 'sess-1');
+      seedInsight('sess-1', 'proj-1', 'decision', 'Use SQLite', 'SQLite is local-first.');
+      mockIsLLMConfigured.mockReturnValue(true);
+      mockChat.mockResolvedValue({ content: '# should not run' });
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/export/generate/stream?scope=all&format=knowledge-brief');
+      const text = await res.text();
+
+      expect(text).toContain('event: error');
+      expect(text).toContain('LLM_BUSY');
+      expect(mockChat).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -7,6 +7,7 @@ import { formatKnowledgeBase } from '../export/knowledge-base.js';
 import { formatAgentRules } from '../export/agent-rules.js';
 import type { SessionRow, InsightRow } from '../export/knowledge-base.js';
 import { createLLMClient, loadLLMConfig } from '../llm/client.js';
+import { acquireServerLlmLock, llmBusyPayload } from '../llm/llm-lock.js';
 import { requireLLM } from './route-helpers.js';
 import {
   applyDepthCap,
@@ -218,6 +219,8 @@ app.post('/generate', requireLLM(), async (c) => {
   const db = getDb();
   const llmConfig = loadLLMConfig();
   const startTime = Date.now();
+  const lock = acquireServerLlmLock(c);
+  if (!lock) return c.json(llmBusyPayload(), 409);
 
   try {
     const rawInsights = fetchScopedInsights(db, scope, projectId);
@@ -284,6 +287,8 @@ app.post('/generate', requireLLM(), async (c) => {
       error_message: message,
     });
     return c.json({ error: message }, 422);
+  } finally {
+    lock.release();
   }
 });
 
@@ -316,6 +321,15 @@ app.get('/generate/stream', requireLLM(), async (c) => {
 
   return streamSSE(c, async (stream) => {
     const streamStart = Date.now();
+    const lock = acquireServerLlmLock(c);
+    if (!lock) {
+      await stream.writeSSE({
+        event: 'error',
+        data: JSON.stringify(llmBusyPayload()),
+      });
+      return;
+    }
+
     try {
       const abortSignal = c.req.raw.signal;
 
@@ -410,6 +424,8 @@ app.get('/generate/stream', requireLLM(), async (c) => {
         event: 'error',
         data: JSON.stringify({ error: message }),
       }).catch(() => {});
+    } finally {
+      lock.release();
     }
   });
 });

--- a/server/src/routes/facets.test.ts
+++ b/server/src/routes/facets.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 
@@ -7,6 +10,13 @@ import { runMigrations } from '@code-insights/cli/db/schema';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -161,6 +171,8 @@ function parseSSEEvents(text: string): Array<{ event: string; data: string }> {
 
 describe('Facets routes', () => {
   beforeEach(() => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(false);
     mockExtractFacetsOnly.mockReset();
@@ -169,6 +181,8 @@ describe('Facets routes', () => {
 
   afterEach(() => {
     testDb.close();
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    rmSync(lockTestDir, { recursive: true, force: true });
   });
 
   // ────────────────────────────────────────────────
@@ -565,6 +579,27 @@ describe('Facets routes', () => {
   // POST /api/facets/backfill (SSE streaming)
   // ────────────────────────────────────────────────
   describe('POST /api/facets/backfill (SSE)', () => {
+    it('sends a recognizable busy error without starting a backfill', async () => {
+      seedProject('proj-1', 'alpha');
+      seedSession('sess-1', 'proj-1');
+      seedMessage('sess-1');
+      mockIsLLMConfigured.mockReturnValue(true);
+      mockExtractFacetsOnly.mockResolvedValue({ success: true });
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/facets/backfill', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionIds: ['sess-1'] }),
+      });
+      const text = await res.text();
+
+      expect(text).toContain('event: error');
+      expect(text).toContain('LLM_BUSY');
+      expect(mockExtractFacetsOnly).not.toHaveBeenCalled();
+    });
+
     it('streams progress and complete events for a valid session', async () => {
       seedProject('proj-1', 'alpha');
       seedSession('sess-1', 'proj-1');

--- a/server/src/routes/reflect.test.ts
+++ b/server/src/routes/reflect.test.ts
@@ -30,6 +30,7 @@ vi.mock('../llm/client.js', () => ({
 }));
 
 const { createApp } = await import('../index.js');
+const { formatIsoWeek } = await import('./shared-aggregation.js');
 
 // ──────────────────────────────────────────────────────
 // Helpers
@@ -379,6 +380,28 @@ describe('Reflect routes', () => {
       // The first entry in weeks is the most recent week (current)
       const currentWeekEntry = body.weeks[0];
       expect(currentWeekEntry.sessionCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it('counts a Sunday session in the previous ISO week', async () => {
+      const now = new Date();
+      const nowDay = now.getUTCDay();
+      const daysToMonday = nowDay === 0 ? 6 : nowDay - 1;
+      const thisMondayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+        - daysToMonday * 86400000;
+      const thisMonday = new Date(thisMondayMs);
+      const previousMonday = new Date(thisMondayMs - 7 * 86400000);
+      const previousSundayNoon = new Date(thisMondayMs - 12 * 3600000);
+
+      seedSessionWithFacets('sess-previous-sunday', { startedAt: previousSundayNoon.toISOString() });
+
+      const app = createApp();
+      const res = await app.request('/api/reflect/weeks');
+      const body = await res.json();
+      const currentWeek = body.weeks.find((w: { week: string }) => w.week === formatIsoWeek(thisMonday));
+      const previousWeek = body.weeks.find((w: { week: string }) => w.week === formatIsoWeek(previousMonday));
+
+      expect(previousWeek.sessionCount).toBe(1);
+      expect(currentWeek.sessionCount).toBe(0);
     });
   });
 

--- a/server/src/routes/reflect.test.ts
+++ b/server/src/routes/reflect.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@code-insights/cli/db/schema';
 
@@ -7,6 +10,13 @@ import { runMigrations } from '@code-insights/cli/db/schema';
 // ──────────────────────────────────────────────────────
 
 let testDb: Database.Database;
+let lockTestDir: string;
+
+function occupyLlmLock(): void {
+  const lockPath = process.env.CODE_INSIGHTS_LLM_LOCK_DIR!;
+  mkdirSync(lockPath, { recursive: true });
+  writeFileSync(join(lockPath, 'pid'), `${process.pid}\n`);
+}
 
 vi.mock('@code-insights/cli/db/client', () => ({
   getDb: () => testDb,
@@ -126,6 +136,8 @@ function parseSSEEvents(text: string): Array<{ event: string; data: string }> {
 
 describe('Reflect routes', () => {
   beforeEach(() => {
+    lockTestDir = mkdtempSync(join(tmpdir(), 'code-insights-server-lock-'));
+    process.env.CODE_INSIGHTS_LLM_LOCK_DIR = join(lockTestDir, 'llm.lock');
     testDb = initTestDb();
     mockIsLLMConfigured.mockReturnValue(false);
     mockChat.mockReset();
@@ -133,6 +145,8 @@ describe('Reflect routes', () => {
 
   afterEach(() => {
     testDb.close();
+    delete process.env.CODE_INSIGHTS_LLM_LOCK_DIR;
+    rmSync(lockTestDir, { recursive: true, force: true });
   });
 
   // ──────────────────────────────────────────────────────
@@ -514,6 +528,25 @@ describe('Reflect routes', () => {
       expect(errorData.code).toBe('INSUFFICIENT_FACETS');
       expect(errorData.current).toBe(3);
       expect(errorData.required).toBe(8);
+    });
+
+    it('sends a recognizable busy error without calling the LLM', async () => {
+      mockIsLLMConfigured.mockReturnValue(true);
+      mockChat.mockResolvedValue({ content: '<json>{}</json>' });
+      seedMultipleSessions(8);
+      occupyLlmLock();
+
+      const app = createApp();
+      const res = await app.request('/api/reflect/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ period: 'all', sections: ['friction-wins'] }),
+      });
+      const text = await res.text();
+
+      expect(text).toContain('event: error');
+      expect(text).toContain('LLM_BUSY');
+      expect(mockChat).not.toHaveBeenCalled();
     });
 
     it('streams progress and complete events for friction-wins section', async () => {

--- a/server/src/routes/reflect.ts
+++ b/server/src/routes/reflect.ts
@@ -3,6 +3,7 @@ import { streamSSE } from 'hono/streaming';
 import { getDb } from '@code-insights/cli/db/client';
 import { jsonrepair } from 'jsonrepair';
 import { createLLMClient } from '../llm/client.js';
+import { acquireServerLlmLock, llmBusyPayload } from '../llm/llm-lock.js';
 import { requireLLM } from './route-helpers.js';
 import { extractJsonPayload } from '../llm/response-parsers.js';
 import {
@@ -66,6 +67,14 @@ app.post('/generate', requireLLM(), async (c) => {
 
   return streamSSE(c, async (stream) => {
     const abortSignal = c.req.raw.signal;
+    const lock = acquireServerLlmLock(c);
+    if (!lock) {
+      await stream.writeSSE({
+        event: 'error',
+        data: JSON.stringify(llmBusyPayload()),
+      });
+      return;
+    }
 
     try {
       await stream.writeSSE({
@@ -236,6 +245,8 @@ app.post('/generate', requireLLM(), async (c) => {
         event: 'error',
         data: JSON.stringify({ error: message }),
       }).catch(() => {});
+    } finally {
+      lock.release();
     }
   });
 });

--- a/server/src/routes/reflect.ts
+++ b/server/src/routes/reflect.ts
@@ -311,16 +311,16 @@ app.get('/weeks', (c) => {
   const projectKey = project || '__all__';
 
   // Query 1: session counts per ISO week using GROUP BY.
-  // The Thursday trick: 'weekday 4' advances to the ISO week's Thursday (or stays if already
-  // Thursday), then '-3 days' gives that week's Monday. This handles all 7 days correctly —
-  // unlike 'weekday 1, -7 days' which overshoots by one week for sessions starting on Monday.
+  // Shift back three days before advancing to Thursday so Friday-Sunday stay in their
+  // current ISO week. Advancing directly to Thursday would move them into the next week.
+  // The final '-3 days' converts the selected Thursday to that ISO week's Monday.
   // Returns one row per week that has sessions — O(sessions), not O(weeks).
   const rangeStart = weekEntries[weekEntries.length - 1].start;
   const rangeEnd = weekEntries[0].end;
 
   const sessionCountRaw = db.prepare(`
     SELECT
-      date(s.started_at, 'weekday 4', '-3 days') as week_monday,
+      date(s.started_at, '-3 days', 'weekday 4', '-3 days') as week_monday,
       COUNT(*) as cnt
     FROM sessions s
     WHERE s.deleted_at IS NULL

--- a/server/src/routes/route-helpers.ts
+++ b/server/src/routes/route-helpers.ts
@@ -12,6 +12,7 @@ import { calculateAnalysisCost } from '../llm/analysis-pricing.js';
 import type { AnalysisResult, AnalysisOptions } from '../llm/analysis.js';
 import type { SessionData } from '../llm/analysis-db.js';
 import type { SQLiteMessageRow } from '../llm/prompt-types.js';
+import { acquireServerLlmLock, llmBusyPayload } from '../llm/llm-lock.js';
 
 /**
  * Load a session row for LLM analysis. Returns undefined if the session doesn't exist
@@ -164,6 +165,15 @@ export function streamSessionAnalysis(
 
   return streamSSE(c, async (stream) => {
     const streamStart = Date.now();
+    const lock = acquireServerLlmLock(c);
+    if (!lock) {
+      await stream.writeSSE({
+        event: 'error',
+        data: JSON.stringify(llmBusyPayload()),
+      });
+      return;
+    }
+
     try {
       const abortSignal = c.req.raw.signal;
 
@@ -247,6 +257,8 @@ export function streamSessionAnalysis(
         event: 'error',
         data: JSON.stringify({ error: message }),
       }).catch(() => {});
+    } finally {
+      lock.release();
     }
   });
 }
@@ -294,59 +306,72 @@ export function streamBatchBackfill(
   const db = getDb();
 
   return streamSSE(c, async (stream) => {
+    const lock = acquireServerLlmLock(c);
+    if (!lock) {
+      await stream.writeSSE({
+        event: 'error',
+        data: JSON.stringify(llmBusyPayload()),
+      });
+      return;
+    }
+
     const abortSignal = c.req.raw.signal;
     let completed = 0;
     let failed = 0;
     const total = sessionIds.length;
 
-    for (const sessionId of sessionIds) {
-      if (abortSignal.aborted) break;
+    try {
+      for (const sessionId of sessionIds) {
+        if (abortSignal.aborted) break;
 
-      const session = loadSessionForAnalysis(db, sessionId);
+        const session = loadSessionForAnalysis(db, sessionId);
 
-      if (!session) {
-        failed++;
+        if (!session) {
+          failed++;
+          await stream.writeSSE({
+            event: 'progress',
+            data: JSON.stringify({ completed, failed, total, currentSessionId: sessionId }),
+          });
+          continue;
+        }
+
+        // Skip sessions that already have work done unless force=true.
+        if (!force && opts.shouldSkip(sessionId)) {
+          completed++;
+          await stream.writeSSE({
+            event: 'progress',
+            data: JSON.stringify({ completed, failed, total, currentSessionId: sessionId }),
+          });
+          continue;
+        }
+
+        const messages = loadSessionMessages(db, sessionId);
+        const result = await opts.analysisFn(session, messages, { signal: abortSignal });
+
+        if (result.success) {
+          completed++;
+        } else {
+          failed++;
+        }
+
         await stream.writeSSE({
           event: 'progress',
-          data: JSON.stringify({ completed, failed, total, currentSessionId: sessionId }),
+          data: JSON.stringify({
+            completed,
+            failed,
+            total,
+            currentSessionId: sessionId,
+            ...(result.success ? {} : { error: result.error }),
+          }),
         });
-        continue;
-      }
-
-      // Skip sessions that already have work done unless force=true.
-      if (!force && opts.shouldSkip(sessionId)) {
-        completed++;
-        await stream.writeSSE({
-          event: 'progress',
-          data: JSON.stringify({ completed, failed, total, currentSessionId: sessionId }),
-        });
-        continue;
-      }
-
-      const messages = loadSessionMessages(db, sessionId);
-      const result = await opts.analysisFn(session, messages, { signal: abortSignal });
-
-      if (result.success) {
-        completed++;
-      } else {
-        failed++;
       }
 
       await stream.writeSSE({
-        event: 'progress',
-        data: JSON.stringify({
-          completed,
-          failed,
-          total,
-          currentSessionId: sessionId,
-          ...(result.success ? {} : { error: result.error }),
-        }),
+        event: 'complete',
+        data: JSON.stringify({ completed, failed, total }),
       });
+    } finally {
+      lock.release();
     }
-
-    await stream.writeSSE({
-      event: 'complete',
-      data: JSON.stringify({ completed, failed, total }),
-    });
   });
 }

--- a/server/src/routes/shared-aggregation.test.ts
+++ b/server/src/routes/shared-aggregation.test.ts
@@ -236,6 +236,28 @@ describe('getAggregatedData', () => {
     expect(knowledgeGap!.examples).toHaveLength(2);
   });
 
+  it('skips malformed friction points without a string category', () => {
+    seedSessionWithFacets(testDb, 'sess-1', {
+      frictionPoints: [
+        'reasoning-only primitive',
+        { _reasoning: 'No friction occurred, so this entry should have been omitted.' },
+        { category: null, description: 'N/A', severity: null, resolution: null },
+        { category: 42, description: 'N/A' },
+        { category: { nested: true }, description: 'N/A' },
+        { category: ['wrong-approach'], description: 'N/A' },
+        { category: '   ', description: 'N/A' },
+        { category: 'wrong-approach', description: 'Valid friction', severity: 'medium', resolution: 'resolved' },
+      ],
+    });
+
+    const result = getAggregatedData(testDb, '', []);
+
+    expect(result.frictionTotal).toBe(1);
+    expect(result.frictionCategories).toEqual([
+      expect.objectContaining({ category: 'wrong-approach', count: 1 }),
+    ]);
+  });
+
   it('aggregates effective patterns with frequency', () => {
     seedSessionWithFacets(testDb, 'sess-1', {
       effectivePatterns: [

--- a/server/src/routes/shared-aggregation.ts
+++ b/server/src/routes/shared-aggregation.ts
@@ -184,14 +184,26 @@ export function getAggregatedData(
 
   const frictionCategories = db.prepare(`
     SELECT
-      json_extract(je.value, '$.category') as category,
+      CASE
+        WHEN json_type(
+          sf.friction_points,
+          '$[' || CAST(je.key AS INTEGER) || '].category'
+        ) = 'text'
+        THEN json_extract(
+          sf.friction_points,
+          '$[' || CAST(je.key AS INTEGER) || '].category'
+        )
+        ELSE NULL
+      END as category,
       COUNT(*) as count,
       AVG(CASE
-        WHEN json_extract(je.value, '$.severity') = 'high' THEN 3
-        WHEN json_extract(je.value, '$.severity') = 'medium' THEN 2
+        WHEN json_extract(sf.friction_points, '$[' || CAST(je.key AS INTEGER) || '].severity') = 'high' THEN 3
+        WHEN json_extract(sf.friction_points, '$[' || CAST(je.key AS INTEGER) || '].severity') = 'medium' THEN 2
         ELSE 1
       END) as avg_severity,
-      json_group_array(json_extract(je.value, '$.description')) as examples,
+      json_group_array(
+        json_extract(sf.friction_points, '$[' || CAST(je.key AS INTEGER) || '].description')
+      ) as examples,
       json_group_array(sf.session_id) as session_ids
     FROM session_facets sf
     JOIN sessions s ON sf.session_id = s.id
@@ -199,7 +211,7 @@ export function getAggregatedData(
     ${where}
     GROUP BY category
     ORDER BY count DESC, avg_severity DESC
-  `).all(...params) as Array<{ category: string; count: number; avg_severity: number; examples: string; session_ids: string }>;
+  `).all(...params) as Array<{ category: string | null; count: number; avg_severity: number; examples: string; session_ids: string }>;
 
   // Fetch effective patterns with confidence >= 50.
   // Category-based grouping happens in code (post-query) after normalizePatternCategory()
@@ -259,6 +271,10 @@ export function getAggregatedData(
 
   const normalizedFriction = new Map<string, { count: number; total_severity: number; examples: string[]; session_ids: string[] }>();
   for (const fc of parsedFriction) {
+    // Older or non-schema-enforcing providers can persist reasoning-only entries
+    // or explicit null categories. They are not friction observations and must not
+    // reach the string normalizer.
+    if (typeof fc.category !== 'string' || fc.category.trim() === '') continue;
     const normalized = normalizeFrictionCategory(fc.category);
     const existing = normalizedFriction.get(normalized);
     if (existing) {

--- a/throttled-analyze.sh
+++ b/throttled-analyze.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# throttled-analyze.sh — 逐个分析会话,带节流和限流自动重试
+# 用途:绕过智谱 BigModel 的并发/RPM 限制(code-insights 官方无节流机制)
+#
+# 策略:
+#   1. 从 SQLite 取所有未分析会话 id
+#   2. 逐个调用 code-insights insights <id>(串行,不并发)
+#   3. 每个会话之间固定 sleep(默认 8 秒,给智谱喘息)
+#   4. 输出含"1302"(账户限流)时,指数退避重试该会话(最多 4 次)
+#   5. 输出含"1305"(平台过载)时,同样退避重试
+#   6. 其他错误(如编码 500)跳过,记录到失败列表
+#
+# 用法: ./throttled-analyze.sh [间隔秒数] [lookback天数]
+#   默认: 间隔 8 秒,lookback 14 天
+
+set -o pipefail
+
+INTERVAL="${1:-8}"
+LOOKBACK="${2:-14}"
+DB="$HOME/.code-insights/data.db"
+LOG="$HOME/.code-insights/throttled-analyze.log"
+
+echo "=== 节流批量分析 | 间隔 ${INTERVAL}s | lookback ${LOOKBACK}d ==="
+echo "日志: $LOG"
+
+# 取未分析会话 id(近 LOOKBACK 天,排除已有 insights 的)
+# 用 cutoff 日期避免边界问题
+CUTOFF=$(date -v-${LOOKBACK}d +%Y-%m-%d 2>/dev/null || date -d "-${LOOKBACK} days" +%Y-%m-%d 2>/dev/null)
+IDS_STR=$(sqlite3 "$DB" "
+  SELECT s.id FROM sessions s
+  LEFT JOIN insights i ON i.session_id = s.id
+  WHERE s.started_at >= '${CUTOFF}'
+    AND i.id IS NULL
+  ORDER BY s.started_at DESC;
+" 2>/dev/null)
+
+# bash 3.2 (macOS) 兼容:用 read -a 读换行分隔的列表
+IDS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && IDS+=("$line")
+done <<< "$IDS_STR"
+
+TOTAL=${#IDS[@]}
+echo "待分析: $TOTAL 个会话"
+echo ""
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "✅ 没有未分析会话,全部已完成"
+  exit 0
+fi
+
+OK=0
+FAILED_LIST=()
+
+for i in "${!IDS[@]}"; do
+  SID="${IDS[$i]}"
+  NUM=$((i + 1))
+  SHORT="${SID:0:16}"
+  echo -n "[$NUM/$TOTAL] $SHORT ... "
+
+  ATTEMPT=0
+  MAX_RETRY=4
+  BACKOFF=15
+  SUCCESS=""
+
+  while [ "$ATTEMPT" -lt "$MAX_RETRY" ]; do
+    ATTEMPT=$((ATTEMPT + 1))
+    # 跑分析,合并 stdout+stderr 用于检测限流
+    OUTPUT=$(code-insights insights "$SID" 2>&1)
+    EC=$?
+
+    if echo "$OUTPUT" | grep -q "Session analyzed"; then
+      SUCCESS="ok"
+      break
+    fi
+
+    if echo "$OUTPUT" | grep -qE "1302|1305|速率限制|rate limit"; then
+      # 限流:退避后重试
+      echo -n "限流,${BACKOFF}s后重试(attempt $ATTEMPT/$MAX_RETRY)... "
+      sleep "$BACKOFF"
+      BACKOFF=$((BACKOFF * 2))  # 指数退避: 15→30→60→120
+      continue
+    fi
+
+    # 其他错误(编码 500 等):不重试,跳过
+    SUCCESS="other-error"
+    ERRMSG=$(echo "$OUTPUT" | grep -oE "\[[0-9]+\]\[[^]]*\]" | head -1)
+    break
+  done
+
+  if [ "$SUCCESS" = "ok" ]; then
+    echo "✓"
+    OK=$((OK + 1))
+    echo "[$NUM/$TOTAL] $SID OK" >> "$LOG"
+  else
+    echo "✗ ${ERRMSG:-失败}"
+    FAILED_LIST+=("$SHORT:${ERRMSG:-unknown}")
+    echo "[$NUM/$TOTAL] $SID FAIL ${ERRMSG:-}" >> "$LOG"
+  fi
+
+  # 会话间固定间隔(最后一个不用等)
+  if [ "$NUM" -lt "$TOTAL" ]; then
+    sleep "$INTERVAL"
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+echo "完成: $OK/$TOTAL 成功"
+if [ "${#FAILED_LIST[@]}" -gt 0 ]; then
+  echo "失败:"
+  for f in "${FAILED_LIST[@]}"; do echo "  - $f"; done
+fi
+echo "════════════════════════════════════════"

--- a/throttled-analyze.sh
+++ b/throttled-analyze.sh
@@ -1,114 +1,233 @@
 #!/usr/bin/env bash
-# throttled-analyze.sh — 逐个分析会话,带节流和限流自动重试
-# 用途:绕过智谱 BigModel 的并发/RPM 限制(code-insights 官方无节流机制)
-#
-# 策略:
-#   1. 从 SQLite 取所有未分析会话 id
-#   2. 逐个调用 code-insights insights <id>(串行,不并发)
-#   3. 每个会话之间固定 sleep(默认 8 秒,给智谱喘息)
-#   4. 输出含"1302"(账户限流)时,指数退避重试该会话(最多 4 次)
-#   5. 输出含"1305"(平台过载)时,同样退避重试
-#   6. 其他错误(如编码 500)跳过,记录到失败列表
-#
-# 用法: ./throttled-analyze.sh [间隔秒数] [lookback天数]
-#   默认: 间隔 8 秒,lookback 14 天
+# Bounded, newest-first session analysis with rate-limit protection.
 
-set -o pipefail
+set -uo pipefail
 
-INTERVAL="${1:-8}"
-LOOKBACK="${2:-14}"
-DB="$HOME/.code-insights/data.db"
-LOG="$HOME/.code-insights/throttled-analyze.log"
+DELAY=8
+LOOKBACK=14
+BATCH_SIZE=10
+SOURCE=""
+DRY_RUN=false
+MAX_RETRIES=4
+DB="${CODE_INSIGHTS_DB:-$HOME/.code-insights/data.db}"
+LOG="${CODE_INSIGHTS_LOG:-$HOME/.code-insights/throttled-analyze.log}"
+LOCK_DIR="${TMPDIR:-/tmp}/code-insights-analysis.lock"
+LEGACY_POSITION=0
 
-echo "=== 节流批量分析 | 间隔 ${INTERVAL}s | lookback ${LOOKBACK}d ==="
-echo "日志: $LOG"
+usage() {
+  cat <<'EOF'
+Usage: ./throttled-analyze.sh [options]
 
-# 取未分析会话 id(近 LOOKBACK 天,排除已有 insights 的)
-# 用 cutoff 日期避免边界问题
-CUTOFF=$(date -v-${LOOKBACK}d +%Y-%m-%d 2>/dev/null || date -d "-${LOOKBACK} days" +%Y-%m-%d 2>/dev/null)
-IDS_STR=$(sqlite3 "$DB" "
-  SELECT s.id FROM sessions s
-  LEFT JOIN insights i ON i.session_id = s.id
-  WHERE s.started_at >= '${CUTOFF}'
-    AND i.id IS NULL
-  ORDER BY s.started_at DESC;
-" 2>/dev/null)
+Options:
+  --days N          Only consider sessions from the last N days (default: 14)
+  --batch-size N    Analyze at most N sessions in this run (default: 10)
+  --delay N         Seconds between sessions (default: 8)
+  --source NAME     Limit to claude-code, codex-cli, cursor, copilot-cli, or copilot
+  --dry-run         List the selected sessions without calling the LLM
+  -h, --help        Show this help
 
-# bash 3.2 (macOS) 兼容:用 read -a 读换行分隔的列表
+Legacy positional form is still supported: INTERVAL LOOKBACK
+EOF
+}
+
+is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --days|--lookback)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 64; }
+      LOOKBACK="$2"; shift 2 ;;
+    --batch-size)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 64; }
+      BATCH_SIZE="$2"; shift 2 ;;
+    --delay|--interval)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 64; }
+      DELAY="$2"; shift 2 ;;
+    --source)
+      [[ $# -ge 2 ]] || { echo "Missing value for $1" >&2; exit 64; }
+      SOURCE="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=true; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    --*)
+      echo "Unknown option: $1" >&2; usage >&2; exit 64 ;;
+    *)
+      if [[ "$LEGACY_POSITION" -eq 0 ]]; then
+        DELAY="$1"
+      elif [[ "$LEGACY_POSITION" -eq 1 ]]; then
+        LOOKBACK="$1"
+      else
+        echo "Unexpected positional argument: $1" >&2; exit 64
+      fi
+      LEGACY_POSITION=$((LEGACY_POSITION + 1))
+      shift ;;
+  esac
+done
+
+is_uint "$DELAY" || { echo "--delay must be a non-negative integer" >&2; exit 64; }
+is_uint "$LOOKBACK" && [[ "$LOOKBACK" -gt 0 ]] || { echo "--days must be a positive integer" >&2; exit 64; }
+is_uint "$BATCH_SIZE" && [[ "$BATCH_SIZE" -gt 0 ]] || { echo "--batch-size must be a positive integer" >&2; exit 64; }
+[[ -f "$DB" ]] || { echo "Database not found: $DB" >&2; exit 66; }
+command -v sqlite3 >/dev/null || { echo "sqlite3 not found" >&2; exit 69; }
+command -v code-insights >/dev/null || { echo "code-insights not found" >&2; exit 69; }
+
+case "$SOURCE" in
+  "") SOURCE_SQL="" ;;
+  claude-code|codex-cli|cursor|copilot-cli|copilot) SOURCE_SQL="AND s.source_tool = '$SOURCE'" ;;
+  *) echo "Unsupported source: $SOURCE" >&2; exit 64 ;;
+esac
+
+# A session is complete only when both model passes match its current message count.
+# Empty-message sessions are excluded so metadata-only imports cannot consume credits.
+QUERY="
+  SELECT s.id
+  FROM sessions s
+  LEFT JOIN analysis_usage session_usage
+    ON session_usage.session_id = s.id AND session_usage.analysis_type = 'session'
+  LEFT JOIN analysis_usage pq_usage
+    ON pq_usage.session_id = s.id AND pq_usage.analysis_type = 'prompt_quality'
+  WHERE s.deleted_at IS NULL
+    AND s.message_count >= 3
+    AND julianday(s.started_at) >= julianday('now', '-${LOOKBACK} days')
+    AND EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.id)
+    AND (
+      session_usage.session_id IS NULL
+      OR session_usage.session_message_count IS NOT s.message_count
+      OR pq_usage.session_id IS NULL
+      OR pq_usage.session_message_count IS NOT s.message_count
+    )
+    $SOURCE_SQL
+  ORDER BY julianday(s.started_at) DESC
+  LIMIT ${BATCH_SIZE};
+"
+
+if ! IDS_STR=$(sqlite3 "$DB" "$QUERY"); then
+  echo "Failed to query analysis candidates" >&2
+  exit 74
+fi
 IDS=()
 while IFS= read -r line; do
-  [ -n "$line" ] && IDS+=("$line")
+  if [[ -n "$line" ]]; then
+    [[ "$line" =~ ^[A-Za-z0-9:._-]+$ ]] || { echo "Unsafe session ID returned by database" >&2; exit 65; }
+    IDS+=("$line")
+  fi
 done <<< "$IDS_STR"
-
 TOTAL=${#IDS[@]}
-echo "待分析: $TOTAL 个会话"
-echo ""
 
-if [ "$TOTAL" -eq 0 ]; then
-  echo "✅ 没有未分析会话,全部已完成"
+echo "=== Bounded analysis | newest first | days ${LOOKBACK} | batch ${BATCH_SIZE} | delay ${DELAY}s ==="
+[[ -n "$SOURCE" ]] && echo "Source: $SOURCE"
+echo "Selected: $TOTAL session(s)"
+
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "No incomplete sessions match this batch."
   exit 0
 fi
 
+if [[ "$DRY_RUN" == true ]]; then
+  if ! sqlite3 -header -column "$DB" "
+    SELECT s.started_at, s.source_tool, s.message_count, s.id
+    FROM sessions s
+    WHERE s.id IN ($(printf "'%s'," "${IDS[@]}" | sed 's/,$//'))
+    ORDER BY julianday(s.started_at) DESC;
+  "; then
+    echo "Failed to display dry-run candidates" >&2
+    exit 74
+  fi
+  echo "Dry run: no analysis calls made."
+  exit 0
+fi
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  LOCK_PID=""
+  [[ -f "$LOCK_DIR/pid" ]] && read -r LOCK_PID < "$LOCK_DIR/pid"
+  if [[ -n "$LOCK_PID" ]] && ! kill -0 "$LOCK_PID" 2>/dev/null; then
+    rm -f "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "Another analysis batch is already running: $LOCK_DIR" >&2
+    exit 75
+  fi
+fi
+printf '%s\n' "$$" > "$LOCK_DIR/pid"
+cleanup() {
+  OWNER_PID=""
+  [[ -f "$LOCK_DIR/pid" ]] && read -r OWNER_PID < "$LOCK_DIR/pid"
+  if [[ "$OWNER_PID" == "$$" ]]; then
+    rm -f "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
 OK=0
-FAILED_LIST=()
+FAILED=0
+RATE_LIMITED=false
 
 for i in "${!IDS[@]}"; do
   SID="${IDS[$i]}"
   NUM=$((i + 1))
-  SHORT="${SID:0:16}"
-  echo -n "[$NUM/$TOTAL] $SHORT ... "
-
   ATTEMPT=0
-  MAX_RETRY=4
   BACKOFF=15
-  SUCCESS=""
+  SUCCESS=false
+  LAST_OUTPUT=""
 
-  while [ "$ATTEMPT" -lt "$MAX_RETRY" ]; do
+  printf '[%d/%d] %s ... ' "$NUM" "$TOTAL" "${SID:0:28}"
+  while [[ "$ATTEMPT" -lt "$MAX_RETRIES" ]]; do
     ATTEMPT=$((ATTEMPT + 1))
-    # 跑分析,合并 stdout+stderr 用于检测限流
-    OUTPUT=$(code-insights insights "$SID" 2>&1)
-    EC=$?
+    LAST_OUTPUT=$(code-insights insights "$SID" 2>&1)
+    EXIT_CODE=$?
 
-    if echo "$OUTPUT" | grep -q "Session analyzed"; then
-      SUCCESS="ok"
+    if ! COMPLETE=$(sqlite3 "$DB" "
+      SELECT COUNT(DISTINCT analysis_type)
+      FROM analysis_usage
+      WHERE session_id = '$SID'
+        AND analysis_type IN ('session', 'prompt_quality')
+        AND session_message_count = (SELECT message_count FROM sessions WHERE id = '$SID');
+    "); then
+      LAST_OUTPUT="Failed to verify analysis completion in SQLite"
+      break
+    fi
+    if [[ "$EXIT_CODE" -eq 0 && "$COMPLETE" -eq 2 ]]; then
+      SUCCESS=true
       break
     fi
 
-    if echo "$OUTPUT" | grep -qE "1302|1305|速率限制|rate limit"; then
-      # 限流:退避后重试
-      echo -n "限流,${BACKOFF}s后重试(attempt $ATTEMPT/$MAX_RETRY)... "
-      sleep "$BACKOFF"
-      BACKOFF=$((BACKOFF * 2))  # 指数退避: 15→30→60→120
-      continue
+    if grep -qiE '1302|1305|429|rate.?limit|速率限制|访问量过大|overload|too many requests|capacity|throttl' <<< "$LAST_OUTPUT"; then
+      if [[ "$ATTEMPT" -lt "$MAX_RETRIES" ]]; then
+        printf 'rate-limited; retry in %ss ... ' "$BACKOFF"
+        sleep "$BACKOFF"
+        BACKOFF=$((BACKOFF * 2))
+        continue
+      fi
+      RATE_LIMITED=true
     fi
-
-    # 其他错误(编码 500 等):不重试,跳过
-    SUCCESS="other-error"
-    ERRMSG=$(echo "$OUTPUT" | grep -oE "\[[0-9]+\]\[[^]]*\]" | head -1)
     break
   done
 
-  if [ "$SUCCESS" = "ok" ]; then
-    echo "✓"
+  if [[ "$SUCCESS" == true ]]; then
+    echo "ok"
     OK=$((OK + 1))
-    echo "[$NUM/$TOTAL] $SID OK" >> "$LOG"
+    printf '[%s] %s OK\n' "$(date -Iseconds)" "$SID" >> "$LOG"
   else
-    echo "✗ ${ERRMSG:-失败}"
-    FAILED_LIST+=("$SHORT:${ERRMSG:-unknown}")
-    echo "[$NUM/$TOTAL] $SID FAIL ${ERRMSG:-}" >> "$LOG"
+    echo "failed"
+    FAILED=$((FAILED + 1))
+    ERROR_LINE=$(printf '%s\n' "$LAST_OUTPUT" | tail -n 1)
+    printf '[%s] %s FAIL %s\n' "$(date -Iseconds)" "$SID" "$ERROR_LINE" >> "$LOG"
+    [[ -n "$ERROR_LINE" ]] && echo "  $ERROR_LINE"
   fi
 
-  # 会话间固定间隔(最后一个不用等)
-  if [ "$NUM" -lt "$TOTAL" ]; then
-    sleep "$INTERVAL"
+  if [[ "$RATE_LIMITED" == true ]]; then
+    echo "Stopping this batch after repeated rate limiting."
+    break
   fi
+  [[ "$NUM" -lt "$TOTAL" ]] && sleep "$DELAY"
 done
 
-echo ""
-echo "════════════════════════════════════════"
-echo "完成: $OK/$TOTAL 成功"
-if [ "${#FAILED_LIST[@]}" -gt 0 ]; then
-  echo "失败:"
-  for f in "${FAILED_LIST[@]}"; do echo "  - $f"; done
-fi
-echo "════════════════════════════════════════"
+echo "Completed: $OK succeeded, $FAILED failed, $((TOTAL - OK - FAILED)) not attempted."
+[[ "$RATE_LIMITED" == true ]] && exit 2
+[[ "$FAILED" -gt 0 ]] && exit 1
+exit 0

--- a/throttled-analyze.sh
+++ b/throttled-analyze.sh
@@ -8,9 +8,12 @@ LOOKBACK=14
 BATCH_SIZE=10
 SOURCE=""
 DRY_RUN=false
+RETRY_FAILED=false
 MAX_RETRIES=4
+GENERIC_RETRIES=2
 DB="${CODE_INSIGHTS_DB:-$HOME/.code-insights/data.db}"
 LOG="${CODE_INSIGHTS_LOG:-$HOME/.code-insights/throttled-analyze.log}"
+FAIL_LOG="${CODE_INSIGHTS_FAIL_LOG:-$HOME/.code-insights/throttled-analyze.failures}"
 LOCK_DIR="${TMPDIR:-/tmp}/code-insights-analysis.lock"
 LEGACY_POSITION=0
 
@@ -23,6 +26,7 @@ Options:
   --batch-size N    Analyze at most N sessions in this run (default: 10)
   --delay N         Seconds between sessions (default: 8)
   --source NAME     Limit to claude-code, codex-cli, cursor, copilot-cli, or copilot
+  --retry-failed    Only retry sessions quarantined by previous batches
   --dry-run         List the selected sessions without calling the LLM
   -h, --help        Show this help
 
@@ -50,6 +54,8 @@ while [[ $# -gt 0 ]]; do
       SOURCE="$2"; shift 2 ;;
     --dry-run)
       DRY_RUN=true; shift ;;
+    --retry-failed)
+      RETRY_FAILED=true; shift ;;
     -h|--help)
       usage; exit 0 ;;
     --*)
@@ -101,7 +107,7 @@ QUERY="
     )
     $SOURCE_SQL
   ORDER BY julianday(s.started_at) DESC
-  LIMIT ${BATCH_SIZE};
+  ;
 "
 
 if ! IDS_STR=$(sqlite3 "$DB" "$QUERY"); then
@@ -112,13 +118,20 @@ IDS=()
 while IFS= read -r line; do
   if [[ -n "$line" ]]; then
     [[ "$line" =~ ^[A-Za-z0-9:._-]+$ ]] || { echo "Unsafe session ID returned by database" >&2; exit 65; }
+    if [[ "$RETRY_FAILED" == true ]]; then
+      [[ -f "$FAIL_LOG" ]] && grep -Fqx "$line" "$FAIL_LOG" || continue
+    elif [[ -f "$FAIL_LOG" ]] && grep -Fqx "$line" "$FAIL_LOG"; then
+      continue
+    fi
     IDS+=("$line")
+    [[ "${#IDS[@]}" -ge "$BATCH_SIZE" ]] && break
   fi
 done <<< "$IDS_STR"
 TOTAL=${#IDS[@]}
 
 echo "=== Bounded analysis | newest first | days ${LOOKBACK} | batch ${BATCH_SIZE} | delay ${DELAY}s ==="
 [[ -n "$SOURCE" ]] && echo "Source: $SOURCE"
+[[ "$RETRY_FAILED" == true ]] && echo "Mode: retry quarantined failures"
 echo "Selected: $TOTAL session(s)"
 
 if [[ "$TOTAL" -eq 0 ]]; then
@@ -204,6 +217,10 @@ for i in "${!IDS[@]}"; do
         continue
       fi
       RATE_LIMITED=true
+    elif [[ "$ATTEMPT" -lt "$GENERIC_RETRIES" ]]; then
+      printf 'invalid/transient response; retry in 5s ... '
+      sleep 5
+      continue
     fi
     break
   done
@@ -212,11 +229,18 @@ for i in "${!IDS[@]}"; do
     echo "ok"
     OK=$((OK + 1))
     printf '[%s] %s OK\n' "$(date -Iseconds)" "$SID" >> "$LOG"
+    if [[ -f "$FAIL_LOG" ]]; then
+      grep -Fvx "$SID" "$FAIL_LOG" > "$FAIL_LOG.tmp" || true
+      mv "$FAIL_LOG.tmp" "$FAIL_LOG"
+    fi
   else
     echo "failed"
     FAILED=$((FAILED + 1))
     ERROR_LINE=$(printf '%s\n' "$LAST_OUTPUT" | tail -n 1)
     printf '[%s] %s FAIL %s\n' "$(date -Iseconds)" "$SID" "$ERROR_LINE" >> "$LOG"
+    if [[ ! -f "$FAIL_LOG" ]] || ! grep -Fqx "$SID" "$FAIL_LOG"; then
+      printf '%s\n' "$SID" >> "$FAIL_LOG"
+    fi
     [[ -n "$ERROR_LINE" ]] && echo "  $ERROR_LINE"
   fi
 

--- a/throttled-analyze.sh
+++ b/throttled-analyze.sh
@@ -3,6 +3,8 @@
 
 set -uo pipefail
 
+ORIGINAL_ARGS=("$@")
+
 DELAY=8
 LOOKBACK=14
 BATCH_SIZE=10
@@ -11,10 +13,10 @@ DRY_RUN=false
 RETRY_FAILED=false
 MAX_RETRIES=4
 GENERIC_RETRIES=2
-DB="${CODE_INSIGHTS_DB:-$HOME/.code-insights/data.db}"
-LOG="${CODE_INSIGHTS_LOG:-$HOME/.code-insights/throttled-analyze.log}"
-FAIL_LOG="${CODE_INSIGHTS_FAIL_LOG:-$HOME/.code-insights/throttled-analyze.failures}"
-LOCK_DIR="${TMPDIR:-/tmp}/code-insights-analysis.lock"
+CONFIG_DIR="${CODE_INSIGHTS_CONFIG_DIR:-$HOME/.code-insights}"
+DB="${CODE_INSIGHTS_DB:-$CONFIG_DIR/data.db}"
+LOG="${CODE_INSIGHTS_LOG:-$CONFIG_DIR/throttled-analyze.log}"
+FAIL_LOG="${CODE_INSIGHTS_FAIL_LOG:-$CONFIG_DIR/throttled-analyze.failures}"
 LEGACY_POSITION=0
 
 usage() {
@@ -153,28 +155,9 @@ if [[ "$DRY_RUN" == true ]]; then
   exit 0
 fi
 
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  LOCK_PID=""
-  [[ -f "$LOCK_DIR/pid" ]] && read -r LOCK_PID < "$LOCK_DIR/pid"
-  if [[ -n "$LOCK_PID" ]] && ! kill -0 "$LOCK_PID" 2>/dev/null; then
-    rm -f "$LOCK_DIR/pid"
-    rmdir "$LOCK_DIR" 2>/dev/null || true
-  fi
-  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    echo "Another analysis batch is already running: $LOCK_DIR" >&2
-    exit 75
-  fi
+if [[ "${CODE_INSIGHTS_LOCK_HELD:-}" != "1" ]]; then
+  exec code-insights lock-run /bin/bash "$0" "${ORIGINAL_ARGS[@]}"
 fi
-printf '%s\n' "$$" > "$LOCK_DIR/pid"
-cleanup() {
-  OWNER_PID=""
-  [[ -f "$LOCK_DIR/pid" ]] && read -r OWNER_PID < "$LOCK_DIR/pid"
-  if [[ "$OWNER_PID" == "$$" ]]; then
-    rm -f "$LOCK_DIR/pid"
-    rmdir "$LOCK_DIR" 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT
 
 OK=0
 FAILED=0


### PR DESCRIPTION
## Summary

- support Anthropic-compatible custom base URLs and explicit model selection, while hardening native Claude CLI structured-output parsing and error propagation
- make Codex ingestion incremental and content-safe with scoped IDs, migration/invalidation, dry-run purity, and non-zero partial-sync status
- serialize CLI, hook, server, reflect, and scheduled LLM work behind a crash-recoverable process lock with durable newest-first queueing
- add bounded retry/quarantine scripts plus an atomic macOS LaunchAgent and SessionEnd-hook lifecycle
- refresh weekly reflection snapshots only when their analyzed facet set/content changes

## Verification

- `pnpm test` (automation suites; CLI 692/692; server 599/599; dashboard 15/15)
- `pnpm build` (CLI, server, dashboard)
- `git diff --check`, shell syntax checks, plist lint, lock/signal/process-tree smoke tests
- independent Critical/Important review gate: clear

## Platform note

Windows process-tree and process-birth behavior is covered by win32 simulation and static review; no real Windows host was available in this run.